### PR TITLE
feat: wire Better-Auth + persistence + permissions stack end-to-end

### DIFF
--- a/.claude/QUICKSTART.md
+++ b/.claude/QUICKSTART.md
@@ -34,8 +34,12 @@ docker compose up -d postgres   # boot Postgres only (others optional)
 bun run dev                     # auto-spawns Prisma Studio + opens /dev
 ```
 
-Server is at `http://localhost:3000` (or `https://api.nest-base.localhost`
-if you have portless installed). Dev cockpit at `/dev`.
+Server is at the URL the dev runner prints — `https://api.nest-base.localhost`
+if you have [portless](https://github.com/portless/portless) installed,
+otherwise the bare `http://localhost:<port>` it announces (`:3000` when
+free, a dynamic fallback like `:4266` when it isn't). Always trust the
+printed URL over a hard-coded `localhost:3000` — concurrent runs and
+test suites can shift the port. Dev cockpit at `/dev`.
 
 If `bun install` hasn't run: `bun install && bun run prisma:generate`.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ bun run dev
 >
 > **Re-running `bun run setup` after a prior boot?** Delete `.env` first, then re-run setup, then run `docker compose down -v && docker compose up -d` to discard the old Postgres volume — otherwise `bun run prisma:migrate` fails with `P1000` because the volume still holds the previous password.
 
-The Dev Hub opens automatically at **http://localhost:3000/dev** (or `https://api.<project>.localhost/dev` if you use [portless](https://github.com/portless/portless)).
+The Dev Hub opens automatically at the URL the dev runner prints — `https://api.<project>.localhost/dev` if you use [portless](https://github.com/portless/portless), otherwise the bare `http://localhost:<port>/dev`. The runner picks `:3000` when free and falls back to a dynamic port (e.g. `:4266`) when it isn't, so always trust the printed URL over a hard-coded `:3000`.
 
 > **What `bun run dev` does for you**: starts Postgres via `docker compose up -d postgres` if the container isn't running, spawns Prisma Studio on `:5555`, watches `.env` for changes (so feature toggles take effect without a manual restart), and opens the Dev Hub in your browser. Set `NO_OPEN=1` to skip the auto-open, `SKIP_DB_BOOT=1` to skip the Postgres boot.
 >

--- a/prisma/migrations/20260430160000_better_auth_tables/migration.sql
+++ b/prisma/migrations/20260430160000_better_auth_tables/migration.sql
@@ -1,0 +1,167 @@
+-- Better-Auth Prisma persistence (closes finding #1).
+--
+-- Adds the columns Better-Auth's user table requires plus the four
+-- core tables (sessions / accounts / verifications) and the three
+-- plugin tables (jwks / two_factors / passkeys). All tables stay
+-- empty until the matching authMethod / plugin is toggled on, so a
+-- single migration covers every feature-flag combination.
+--
+-- Existing rows: the `users` row provisioned by SystemSetupModule
+-- bootstrap (or any prior seed run) gets `name = ''`,
+-- `email_verified = false`, no `image`. The `tenant_id` column is
+-- relaxed from NOT NULL to nullable so a Better-Auth signup can
+-- create a user before tenant pre-pick happens. Existing
+-- non-null values are preserved.
+
+-- AlterTable: extend `users` with the Better-Auth required columns
+ALTER TABLE "users"
+    ADD COLUMN "name"            TEXT    NOT NULL DEFAULT '',
+    ADD COLUMN "email_verified"  BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN "image"           TEXT,
+    ADD COLUMN "two_factor_enabled" BOOLEAN;
+
+-- Drop the existing FK first so we can relax NOT NULL on the column
+-- without losing the relation when we re-create the constraint with
+-- ON DELETE SET NULL semantics (matching the new Prisma `Tenant?`
+-- relation).
+ALTER TABLE "users" DROP CONSTRAINT "users_tenant_id_fkey";
+ALTER TABLE "users" ALTER COLUMN "tenant_id" DROP NOT NULL;
+ALTER TABLE "users"
+    ADD CONSTRAINT "users_tenant_id_fkey"
+    FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateTable: sessions
+CREATE TABLE "sessions" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+CREATE INDEX "sessions_user_id_idx" ON "sessions"("user_id");
+
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: accounts
+CREATE TABLE "accounts" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "account_id" TEXT NOT NULL,
+    "provider_id" TEXT NOT NULL,
+    "access_token" TEXT,
+    "refresh_token" TEXT,
+    "id_token" TEXT,
+    "access_token_expires_at" TIMESTAMP(3),
+    "refresh_token_expires_at" TIMESTAMP(3),
+    "scope" TEXT,
+    "password" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "accounts_user_id_idx" ON "accounts"("user_id");
+
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: verifications
+CREATE TABLE "verifications" (
+    "id" UUID NOT NULL,
+    "identifier" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "verifications_identifier_idx" ON "verifications"("identifier");
+
+-- CreateTable: jwks (jwt plugin)
+CREATE TABLE "jwks" (
+    "id" UUID NOT NULL,
+    "public_key" TEXT NOT NULL,
+    "private_key" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3),
+
+    CONSTRAINT "jwks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: two_factors (twoFactor plugin)
+CREATE TABLE "two_factors" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "secret" TEXT NOT NULL,
+    "backup_codes" TEXT NOT NULL,
+    "verified" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "two_factors_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "two_factors_secret_idx" ON "two_factors"("secret");
+CREATE INDEX "two_factors_user_id_idx" ON "two_factors"("user_id");
+
+ALTER TABLE "two_factors" ADD CONSTRAINT "two_factors_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: passkeys (passkey plugin)
+CREATE TABLE "passkeys" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "name" TEXT,
+    "public_key" TEXT NOT NULL,
+    "credential_id" TEXT NOT NULL,
+    "counter" INTEGER NOT NULL,
+    "device_type" TEXT NOT NULL,
+    "backed_up" BOOLEAN NOT NULL,
+    "transports" TEXT,
+    "created_at" TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP,
+    "aaguid" TEXT,
+
+    CONSTRAINT "passkeys_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "passkeys_user_id_idx" ON "passkeys"("user_id");
+CREATE INDEX "passkeys_credential_id_idx" ON "passkeys"("credential_id");
+
+ALTER TABLE "passkeys" ADD CONSTRAINT "passkeys_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- RLS · `users` now allows tenant_id-NULL rows.
+--
+-- Better-Auth's anonymous sign-up flow creates a user before any
+-- tenant pre-pick has happened, so the row's `tenant_id` is NULL.
+-- The previous policy compared `tenant_id::text = current_setting(...)`
+-- which evaluates to NULL for null rows, blocking the INSERT entirely.
+-- Relaxing to "either match the request tenant OR be unattached"
+-- keeps tenant-scoped reads safe while letting Better-Auth complete
+-- the signup. Linking the user to a tenant later (via
+-- TenantMember.activate or the system-setup admin bootstrap) is the
+-- canonical path that re-stamps `tenant_id`.
+DROP POLICY IF EXISTS tenant_isolation_users ON users;
+CREATE POLICY tenant_isolation_users ON users
+  USING (
+    tenant_id IS NULL
+    OR tenant_id::text = current_setting('app.tenant_id', true)
+  )
+  WITH CHECK (
+    tenant_id IS NULL
+    OR tenant_id::text = current_setting('app.tenant_id', true)
+  );

--- a/prisma/schema.generated.prisma
+++ b/prisma/schema.generated.prisma
@@ -69,18 +69,144 @@ model TenantMember {
   @@map("tenant_members")
 }
 
+// `User` is owned by Better-Auth (per the project rule "Reuse
+// Better-Auth's user. Don't shadow it"). The Prisma adapter
+// (`better-auth/adapters/prisma`) reads/writes this model directly.
+//
+// Required Better-Auth fields: id, email, name, emailVerified,
+// createdAt, updatedAt (all the model below). Optional: image,
+// twoFactorEnabled.
+//
+// Project-owned extension fields:
+//  - `tenantId` — nullable so a Better-Auth signup can create a user
+//    before the tenant pre-pick happens. The TenantMember join-table
+//    is the canonical source of truth for "which tenants does this
+//    user belong to"; `tenantId` here is the user's *primary* tenant
+//    (set on first membership-activate or by the system-setup admin
+//    bootstrap).
 model User {
+  id               String   @id @default(uuid()) @db.Uuid
+  email            String   @unique
+  name             String   @default("")
+  emailVerified    Boolean  @default(false) @map("email_verified")
+  image            String?
+  twoFactorEnabled Boolean? @map("two_factor_enabled")
+  tenantId         String?  @map("tenant_id") @db.Uuid
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  tenant      Tenant?        @relation(fields: [tenantId], references: [id], onDelete: SetNull)
+  memberships TenantMember[]
+  apiKeys     ApiKey[]
+  sessions    Session[]
+  accounts    Account[]
+  twoFactors  TwoFactor[]
+  passkeys    Passkey[]
+
+  @@map("users")
+}
+
+// ---------- Better-Auth managed tables ----------
+//
+// Mapped 1:1 to Better-Auth's logical schema (camelCase TS field
+// names are what the adapter queries; @map() projects them to
+// snake_case Postgres columns). Plugin tables (Jwks, TwoFactor,
+// Passkey) are always present in the schema regardless of which
+// authMethods are toggled — keeping a single migration tree is
+// cheaper than feature-gated plugin schemas, and the unused tables
+// stay empty.
+
+model Session {
   id        String   @id @default(uuid()) @db.Uuid
-  email     String   @unique
-  tenantId  String   @map("tenant_id") @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  token     String   @unique
+  expiresAt DateTime @map("expires_at")
+  ipAddress String?  @map("ip_address")
+  userAgent String?  @map("user_agent")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  tenant      Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  memberships TenantMember[]
-  apiKeys     ApiKey[]
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("users")
+  @@index([userId])
+  @@map("sessions")
+}
+
+model Account {
+  id                    String    @id @default(uuid()) @db.Uuid
+  userId                String    @map("user_id") @db.Uuid
+  accountId             String    @map("account_id")
+  providerId            String    @map("provider_id")
+  accessToken           String?   @map("access_token")
+  refreshToken          String?   @map("refresh_token")
+  idToken               String?   @map("id_token")
+  accessTokenExpiresAt  DateTime? @map("access_token_expires_at")
+  refreshTokenExpiresAt DateTime? @map("refresh_token_expires_at")
+  scope                 String?
+  password              String?
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("accounts")
+}
+
+model Verification {
+  id         String   @id @default(uuid()) @db.Uuid
+  identifier String
+  value      String
+  expiresAt  DateTime @map("expires_at")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  @@index([identifier])
+  @@map("verifications")
+}
+
+model Jwks {
+  id         String    @id @default(uuid()) @db.Uuid
+  publicKey  String    @map("public_key")
+  privateKey String    @map("private_key")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  expiresAt  DateTime? @map("expires_at")
+
+  @@map("jwks")
+}
+
+model TwoFactor {
+  id          String  @id @default(uuid()) @db.Uuid
+  userId      String  @map("user_id") @db.Uuid
+  secret      String
+  backupCodes String  @map("backup_codes")
+  verified    Boolean @default(true)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([secret])
+  @@index([userId])
+  @@map("two_factors")
+}
+
+model Passkey {
+  id           String    @id @default(uuid()) @db.Uuid
+  userId       String    @map("user_id") @db.Uuid
+  name         String?
+  publicKey    String    @map("public_key")
+  credentialID String    @map("credential_id")
+  counter      Int
+  deviceType   String    @map("device_type")
+  backedUp     Boolean   @map("backed_up")
+  transports   String?
+  createdAt    DateTime? @default(now()) @map("created_at")
+  aaguid       String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([credentialID])
+  @@map("passkeys")
 }
 
 model ApiKey {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,18 +65,144 @@ model TenantMember {
   @@map("tenant_members")
 }
 
+// `User` is owned by Better-Auth (per the project rule "Reuse
+// Better-Auth's user. Don't shadow it"). The Prisma adapter
+// (`better-auth/adapters/prisma`) reads/writes this model directly.
+//
+// Required Better-Auth fields: id, email, name, emailVerified,
+// createdAt, updatedAt (all the model below). Optional: image,
+// twoFactorEnabled.
+//
+// Project-owned extension fields:
+//  - `tenantId` — nullable so a Better-Auth signup can create a user
+//    before the tenant pre-pick happens. The TenantMember join-table
+//    is the canonical source of truth for "which tenants does this
+//    user belong to"; `tenantId` here is the user's *primary* tenant
+//    (set on first membership-activate or by the system-setup admin
+//    bootstrap).
 model User {
+  id               String   @id @default(uuid()) @db.Uuid
+  email            String   @unique
+  name             String   @default("")
+  emailVerified    Boolean  @default(false) @map("email_verified")
+  image            String?
+  twoFactorEnabled Boolean? @map("two_factor_enabled")
+  tenantId         String?  @map("tenant_id") @db.Uuid
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  tenant      Tenant?        @relation(fields: [tenantId], references: [id], onDelete: SetNull)
+  memberships TenantMember[]
+  apiKeys     ApiKey[]
+  sessions    Session[]
+  accounts    Account[]
+  twoFactors  TwoFactor[]
+  passkeys    Passkey[]
+
+  @@map("users")
+}
+
+// ---------- Better-Auth managed tables ----------
+//
+// Mapped 1:1 to Better-Auth's logical schema (camelCase TS field
+// names are what the adapter queries; @map() projects them to
+// snake_case Postgres columns). Plugin tables (Jwks, TwoFactor,
+// Passkey) are always present in the schema regardless of which
+// authMethods are toggled — keeping a single migration tree is
+// cheaper than feature-gated plugin schemas, and the unused tables
+// stay empty.
+
+model Session {
   id        String   @id @default(uuid()) @db.Uuid
-  email     String   @unique
-  tenantId  String   @map("tenant_id") @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  token     String   @unique
+  expiresAt DateTime @map("expires_at")
+  ipAddress String?  @map("ip_address")
+  userAgent String?  @map("user_agent")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  tenant      Tenant         @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  memberships TenantMember[]
-  apiKeys     ApiKey[]
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@map("users")
+  @@index([userId])
+  @@map("sessions")
+}
+
+model Account {
+  id                    String    @id @default(uuid()) @db.Uuid
+  userId                String    @map("user_id") @db.Uuid
+  accountId             String    @map("account_id")
+  providerId            String    @map("provider_id")
+  accessToken           String?   @map("access_token")
+  refreshToken          String?   @map("refresh_token")
+  idToken               String?   @map("id_token")
+  accessTokenExpiresAt  DateTime? @map("access_token_expires_at")
+  refreshTokenExpiresAt DateTime? @map("refresh_token_expires_at")
+  scope                 String?
+  password              String?
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("accounts")
+}
+
+model Verification {
+  id         String   @id @default(uuid()) @db.Uuid
+  identifier String
+  value      String
+  expiresAt  DateTime @map("expires_at")
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @updatedAt @map("updated_at")
+
+  @@index([identifier])
+  @@map("verifications")
+}
+
+model Jwks {
+  id         String    @id @default(uuid()) @db.Uuid
+  publicKey  String    @map("public_key")
+  privateKey String    @map("private_key")
+  createdAt  DateTime  @default(now()) @map("created_at")
+  expiresAt  DateTime? @map("expires_at")
+
+  @@map("jwks")
+}
+
+model TwoFactor {
+  id          String  @id @default(uuid()) @db.Uuid
+  userId      String  @map("user_id") @db.Uuid
+  secret      String
+  backupCodes String  @map("backup_codes")
+  verified    Boolean @default(true)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([secret])
+  @@index([userId])
+  @@map("two_factors")
+}
+
+model Passkey {
+  id           String    @id @default(uuid()) @db.Uuid
+  userId       String    @map("user_id") @db.Uuid
+  name         String?
+  publicKey    String    @map("public_key")
+  credentialID String    @map("credential_id")
+  counter      Int
+  deviceType   String    @map("device_type")
+  backedUp     Boolean   @map("backed_up")
+  transports   String?
+  createdAt    DateTime? @default(now()) @map("created_at")
+  aaguid       String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([credentialID])
+  @@map("passkeys")
 }
 
 model ApiKey {

--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -6,6 +6,7 @@ import { AuditLogModule } from "../audit/audit-log.module.js";
 import { ApiKeyModule } from "../auth/api-keys/api-key.module.js";
 import { BetterAuthModule } from "../auth/better-auth.module.js";
 import { PowerSyncModule } from "../auth/powersync.module.js";
+import { BetterAuthSessionMiddleware } from "../auth/session-middleware.js";
 import { ConfigModule } from "../config/config.module.js";
 import { DevHubModule } from "../dx/dev-hub.module.js";
 import { EmailModule } from "../email/email.module.js";
@@ -106,6 +107,7 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
   controllers: [AppController],
   providers: [
     RequestContextMiddleware,
+    BetterAuthSessionMiddleware,
     { provide: APP_GUARD, useClass: ThrottlerGuard },
     { provide: APP_INTERCEPTOR, useClass: OutputPipelineInterceptor },
     ...(features.multiTenancy.enabled
@@ -115,6 +117,11 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
+    // Order matters: RequestContext first (request id / trace id /
+    // tenant context populates the AsyncLocalStorage); then the
+    // session middleware sets `req.user` so `PermissionInterceptor`
+    // and downstream guards see a populated identity.
     consumer.apply(RequestContextMiddleware).forRoutes("*");
+    consumer.apply(BetterAuthSessionMiddleware).forRoutes("*");
   }
 }

--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 
 import { type Features, loadFeatures } from "../features/features.js";
+import { PrismaService } from "../prisma/prisma.service.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
 import { BetterAuthController } from "./better-auth.controller.js";
 import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from "./better-auth.token.js";
@@ -27,7 +28,7 @@ const MIN_SECRET_LEN = 32;
   providers: [
     {
       provide: BETTER_AUTH_INSTANCE,
-      useFactory: (): BetterAuthInstance | null => {
+      useFactory: (prisma: PrismaService): BetterAuthInstance | null => {
         const secret = process.env.BETTER_AUTH_SECRET ?? "";
         if (secret.length < MIN_SECRET_LEN) return null;
 
@@ -38,6 +39,11 @@ const MIN_SECRET_LEN = 32;
           secret,
           baseUrl: cfg.baseUrl,
           sessionExpiresInSeconds: 60 * 60 * 24 * 7,
+          // `prisma` is the global PrismaService — passing it switches
+          // Better-Auth from the in-memory storage (which silently
+          // dropped registrations on every restart) to the real
+          // Postgres-backed Prisma adapter.
+          prisma,
           ...(features.authMethods.twoFactor ? { twoFactor: { issuer: "nest-server" } } : {}),
           ...(features.authMethods.passkey ? { passkey: { rpName: "nest-server" } } : {}),
           ...(features.authMethods.socialProviders.length > 0
@@ -48,6 +54,7 @@ const MIN_SECRET_LEN = 32;
           ...(features.powerSync.enabled ? { jwtPlugin: { audience: "powersync" } } : {}),
         });
       },
+      inject: [PrismaService],
     },
   ],
   exports: [BETTER_AUTH_INSTANCE],

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -1,5 +1,6 @@
 import { passkey } from "@better-auth/passkey";
 import { type BetterAuthOptions, type BetterAuthPlugin, betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
 import { jwt } from "better-auth/plugins/jwt";
 import { twoFactor } from "better-auth/plugins/two-factor";
 
@@ -12,10 +13,12 @@ import { resolveBetterAuthMountPath } from "./better-auth-config.js";
  * `handler` function is what the NestJS adapter mounts under
  * `/api/auth/*` (Phase 2 / "Better-Auth Integration" slice).
  *
- * Storage adapter: in this iteration we use Better-Auth's built-in
- * memory adapter so factory + tests stay DB-free. The Prisma adapter
- * gets wired in once Better-Auth's schema migrations land alongside the
- * existing User / Tenant / Role tables.
+ * Storage adapter: when a `prisma` client is supplied, the factory
+ * wires Better-Auth's `prismaAdapter` so users / sessions / accounts
+ * / verifications persist to the Postgres tables declared in
+ * `prisma/schema.prisma`. Without `prisma`, we fall back to
+ * Better-Auth's built-in memory adapter — useful for the SDK / mount
+ * / plugin story tests that just need a callable handler.
  */
 
 const MIN_SECRET_LEN = 32;
@@ -41,12 +44,34 @@ export type SocialProviderId = "google" | "github" | "apple" | "discord";
 
 export type SocialProviderConfig = Partial<Record<SocialProviderId, SocialProviderCredentials>>;
 
+/**
+ * Minimal Prisma surface the Better-Auth Prisma adapter requires. We
+ * keep the contract structurally permissive (an opaque object) so the
+ * factory stays free of a hard dependency on `@prisma/client`'s
+ * generated types — `BetterAuthModule` passes its `PrismaService`
+ * instance and the adapter validates the shape at call time.
+ *
+ * The runtime requirement is a Prisma-shaped object exposing the
+ * `user / session / account / verification` model accessors plus
+ * `$transaction`; documenting that here without enforcing the full
+ * generic `PrismaClient<…>` type keeps the public API stable across
+ * generator regenerations.
+ */
+export type BuildBetterAuthPrisma = object;
+
 export interface BuildBetterAuthInput {
   secret: string;
   baseUrl: string;
   sessionExpiresInSeconds: number;
   /** Optional override; defaults to /api/auth via `resolveBetterAuthMountPath()`. */
   basePath?: string;
+  /**
+   * Optional Prisma client. When supplied, Better-Auth persists
+   * users / sessions / accounts / verifications via
+   * `better-auth/adapters/prisma`. When omitted, the built-in
+   * memory adapter is used (story / SDK tests).
+   */
+  prisma?: BuildBetterAuthPrisma;
   /** Switch on the TOTP plugin. */
   twoFactor?: TwoFactorOptions;
   /**
@@ -114,6 +139,31 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
     session: {
       expiresIn: input.sessionExpiresInSeconds,
     },
+    // `tenantId` is the project-specific extension on Better-Auth's
+    // user table. Marked non-required so the default sign-up flow
+    // works without forcing the caller to pre-pick a tenant; the
+    // canonical "which tenants does this user belong to" answer is
+    // the `TenantMember` join-table.
+    user: {
+      additionalFields: {
+        tenantId: { type: "string", required: false, input: true },
+      },
+    },
+    ...(input.prisma
+      ? {
+          // `provider: 'postgresql'` matches what `PrismaService` opens
+          // via `@prisma/adapter-pg`. The adapter's `transaction: false`
+          // default is fine — Better-Auth handles its own retry / unique
+          // collision flows at the API layer.
+          database: prismaAdapter(input.prisma as object, { provider: "postgresql" }),
+          // The Prisma `User.id` column is declared `@db.Uuid`. Without
+          // this override, Better-Auth's default ID generator emits a
+          // base32 nanoid that Postgres rejects with
+          // "invalid input syntax for type uuid". Switching to UUIDs
+          // keeps schema and adapter aligned.
+          advanced: { database: { generateId: "uuid" as const } },
+        }
+      : {}),
     ...(plugins.length > 0 ? { plugins } : {}),
     ...(input.socialProviders && Object.keys(input.socialProviders).length > 0
       ? { socialProviders: input.socialProviders as BetterAuthOptions["socialProviders"] }

--- a/src/core/auth/session-middleware.ts
+++ b/src/core/auth/session-middleware.ts
@@ -1,0 +1,124 @@
+import {
+  Inject,
+  Injectable,
+  type LoggerService,
+  Logger,
+  type NestMiddleware,
+  Optional,
+  UnauthorizedException,
+} from "@nestjs/common";
+import { fromNodeHeaders } from "better-auth/node";
+import type { NextFunction, Request, Response } from "express";
+
+import { isPathProtected } from "./jwt-middleware.js";
+import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from "./better-auth.token.js";
+
+/**
+ * Session-aware request augmentation.
+ *
+ * Mirrors what `PermissionInterceptor` and the `@Ability()` param
+ * decorator already expect on the request. Kept minimal — middleware
+ * downstream / domain code only reads `id` and `tenantId`.
+ */
+export interface AuthenticatedRequest extends Request {
+  user?: { id: string; tenantId: string | null };
+}
+
+/**
+ * BetterAuthSessionMiddleware
+ *
+ * Reads the Better-Auth session cookie / Authorization header, looks
+ * up the matching user, and assigns `req.user = { id, tenantId }` for
+ * downstream interceptors and guards. Anonymous requests on protected
+ * paths are rejected with `401 Unauthorized`.
+ *
+ * Why a middleware (rather than a guard or interceptor): the user
+ * lookup happens once per request, before *any* other guard or
+ * interceptor runs (`PermissionInterceptor`, `TenantInterceptor`).
+ * `req.user` is the contract every layer in the system reads from;
+ * pulling the lookup into a middleware keeps the request path
+ * deterministic.
+ *
+ * Public paths (per `isPathProtected`) skip the auth requirement —
+ * `/`, `/health/*`, `/api/auth/*`, `/docs/*`, `/dev/*`. Authenticated
+ * users on those paths still get `req.user` populated when a valid
+ * session cookie is present, so logging / per-user diagnostics see
+ * the real user.
+ */
+@Injectable()
+export class BetterAuthSessionMiddleware implements NestMiddleware {
+  private readonly logger: LoggerService = new Logger("BetterAuthSession");
+
+  constructor(
+    @Optional()
+    @Inject(BETTER_AUTH_INSTANCE)
+    private readonly auth: BetterAuthInstance | null = null,
+  ) {}
+
+  async use(req: AuthenticatedRequest, _res: Response, next: NextFunction): Promise<void> {
+    const path = (req.originalUrl ?? req.url ?? "/") as string;
+    const protectedPath = isPathProtected(stripQuery(path));
+
+    // Auth is opt-in — the BetterAuthModule returns `null` when
+    // `BETTER_AUTH_SECRET` isn't set. With no auth subsystem we can't
+    // look up sessions. Don't 401 here: a project that hasn't
+    // configured Better-Auth (e.g. a fresh starter, or an admin /
+    // diagnostics-only deployment) should still be reachable. The
+    // permission interceptor + `@Can()` decorators are what actually
+    // gate access; with `req.user` undefined every CASL ability is
+    // empty and `@Can()` denies anyway.
+    if (!this.auth) {
+      next();
+      return;
+    }
+
+    let session: SessionLookup = null;
+    try {
+      session = (await this.auth.api.getSession({
+        headers: fromNodeHeaders(req.headers),
+      })) as SessionLookup;
+    } catch (err) {
+      // A malformed / expired cookie should NOT 500. Better-Auth
+      // throws `APIError` on certain edge-cases (revoked session,
+      // bad signature). Treat as anonymous — protected paths handle
+      // the 401 below.
+      this.logger.debug?.(`session lookup failed: ${(err as Error).message}`);
+      session = null;
+    }
+
+    if (session?.user) {
+      req.user = {
+        id: session.user.id,
+        tenantId: extractTenantId(session.user),
+      };
+      next();
+      return;
+    }
+
+    if (protectedPath) {
+      throw new UnauthorizedException("Authentication required.");
+    }
+    next();
+  }
+}
+
+interface SessionUser {
+  id: string;
+  tenantId?: string | null;
+}
+
+type SessionLookup = { user: SessionUser } | null;
+
+function extractTenantId(user: SessionUser): string | null {
+  // `tenantId` is declared as `additionalFields.tenantId` on the
+  // Better-Auth user; the adapter projects it through. May be null
+  // for users that haven't been linked to a tenant yet.
+  return user.tenantId ?? null;
+}
+
+function stripQuery(path: string): string {
+  const queryAt = path.indexOf("?");
+  const hashAt = path.indexOf("#");
+  const cut = Math.min(...[queryAt, hashAt].filter((i) => i >= 0), path.length);
+  return path.slice(0, cut);
+}

--- a/src/core/multi-tenancy/prisma-tenant-member-storage.ts
+++ b/src/core/multi-tenancy/prisma-tenant-member-storage.ts
@@ -1,0 +1,117 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type {
+  TenantMemberRecord,
+  TenantMemberStatus,
+  TenantMemberStorage,
+} from "./tenant-member.service.js";
+
+/**
+ * Prisma-backed TenantMemberStorage.
+ *
+ * Persists memberships to the `tenant_members` table declared in
+ * `prisma/schema.prisma`. The earlier `InMemoryTenantMemberStorage`
+ * is kept around for tests / fake-prisma scenarios; this class is the
+ * production default wired up in `tenant-member.module.ts`.
+ *
+ * Why a separate class instead of inlining into `TenantMemberService`:
+ * the service stays storage-agnostic (matches the rest of the core's
+ * pure-planner / thin-runner split — every storage adapter passes the
+ * same `TenantMemberStorage` interface).
+ */
+export class PrismaTenantMemberStorage implements TenantMemberStorage {
+  constructor(private readonly prisma: Pick<PrismaClient, "tenantMember">) {}
+
+  async findByUserAndTenant(userId: string, tenantId: string): Promise<TenantMemberRecord | null> {
+    const row = await this.prisma.tenantMember.findFirst({
+      where: { userId, tenantId },
+    });
+    return row ? toRecord(row) : null;
+  }
+
+  async listByTenant(tenantId: string): Promise<TenantMemberRecord[]> {
+    const rows = await this.prisma.tenantMember.findMany({
+      where: { tenantId },
+      orderBy: { createdAt: "asc" },
+    });
+    return rows.map(toRecord);
+  }
+
+  async insert(record: TenantMemberRecord): Promise<TenantMemberRecord> {
+    const row = await this.prisma.tenantMember.create({
+      data: {
+        id: record.id,
+        userId: record.userId,
+        tenantId: record.tenantId,
+        role: record.role,
+        status: record.status,
+        invitedAt: record.invitedAt ?? null,
+        joinedAt: record.joinedAt ?? null,
+      },
+    });
+    return toRecord(row);
+  }
+
+  async updateStatus(id: string, status: TenantMemberStatus): Promise<TenantMemberRecord | null> {
+    try {
+      const row = await this.prisma.tenantMember.update({
+        where: { id },
+        data: {
+          status,
+          // Stamp `joined_at` on the INVITED → ACTIVE transition. The
+          // service's `activate()` does the same, but we set it here too
+          // so a direct adapter call doesn't need a follow-up write.
+          ...(status === "ACTIVE" ? { joinedAt: new Date() } : {}),
+        },
+      });
+      return toRecord(row);
+    } catch (err) {
+      // Prisma 7 throws P2025 for "record not found"; the contract
+      // says "return null" so the service can map it to its own
+      // not-found error.
+      if (isPrismaNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  async remove(id: string): Promise<boolean> {
+    try {
+      await this.prisma.tenantMember.delete({ where: { id } });
+      return true;
+    } catch (err) {
+      if (isPrismaNotFound(err)) return false;
+      throw err;
+    }
+  }
+}
+
+interface TenantMemberRow {
+  id: string;
+  userId: string;
+  tenantId: string;
+  role: string;
+  status: TenantMemberStatus;
+  invitedAt: Date | null;
+  joinedAt: Date | null;
+}
+
+function toRecord(row: TenantMemberRow): TenantMemberRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    tenantId: row.tenantId,
+    role: row.role,
+    status: row.status,
+    ...(row.invitedAt ? { invitedAt: row.invitedAt } : {}),
+    ...(row.joinedAt ? { joinedAt: row.joinedAt } : {}),
+  };
+}
+
+function isPrismaNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "P2025"
+  );
+}

--- a/src/core/multi-tenancy/tenant-member.module.ts
+++ b/src/core/multi-tenancy/tenant-member.module.ts
@@ -12,6 +12,8 @@ import {
   Put,
 } from "@nestjs/common";
 
+import { PrismaService } from "../prisma/prisma.service.js";
+import { PrismaTenantMemberStorage } from "./prisma-tenant-member-storage.js";
 import {
   type AddMemberInput,
   type TenantMemberRecord,
@@ -24,7 +26,15 @@ import {
 
 const TENANT_MEMBER_STORAGE = Symbol.for("lt:TenantMemberStorage");
 
-class InMemoryTenantMemberStorage implements TenantMemberStorage {
+/**
+ * In-memory fallback used by tests that exercise `TenantMemberService`
+ * without a Postgres testcontainer. Production wiring uses
+ * `PrismaTenantMemberStorage` — see the providers block below.
+ *
+ * Exported so tests can opt into the legacy behaviour without
+ * re-defining the storage shape.
+ */
+export class InMemoryTenantMemberStorage implements TenantMemberStorage {
   private readonly map = new Map<string, TenantMemberRecord>();
 
   async findByUserAndTenant(userId: string, tenantId: string): Promise<TenantMemberRecord | null> {
@@ -108,14 +118,21 @@ class TenantMemberController {
 }
 
 /**
- * TenantMemberModule — `/tenant-members` CRUD over an in-memory
- * `TenantMemberStorage`. Prisma-backed adapter lands once Better-Auth
- * + the membership join migration are hooked up.
+ * TenantMemberModule — `/tenant-members` CRUD over a Postgres-backed
+ * `TenantMemberStorage`. The `PrismaTenantMemberStorage` adapter
+ * writes through to the `tenant_members` table declared in
+ * `prisma/schema.prisma`; the previous in-memory storage is exported
+ * for tests that don't need a live DB but stays out of the production
+ * graph.
  */
 @Module({
   controllers: [TenantMemberController],
   providers: [
-    { provide: TENANT_MEMBER_STORAGE, useClass: InMemoryTenantMemberStorage },
+    {
+      provide: TENANT_MEMBER_STORAGE,
+      useFactory: (prisma: PrismaService) => new PrismaTenantMemberStorage(prisma),
+      inject: [PrismaService],
+    },
     {
       provide: TenantMemberService,
       useFactory: (storage: TenantMemberStorage) => new TenantMemberService(storage),

--- a/tests/better-auth-prisma-persistence.e2e-spec.ts
+++ b/tests/better-auth-prisma-persistence.e2e-spec.ts
@@ -57,9 +57,10 @@ describe("Better-Auth · Prisma persistence", () => {
       });
 
     // Better-Auth 1.6 returns 200 on a successful email/password
-    // sign-up. Anything else is either a config error (4xx/5xx) or a
-    // validation rejection — we want the persistence path here.
-    expect(res.status).toBe(200);
+    // sign-up; if a future schema-mismatch regresses persistence,
+    // include the response body in the failure message so the cause
+    // (column missing, RLS rejection, etc.) is one log line away.
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
 
     // The user row exists with the email Better-Auth received.
     const persisted = await prisma.user.findUnique({ where: { email } });

--- a/tests/better-auth-prisma-persistence.e2e-spec.ts
+++ b/tests/better-auth-prisma-persistence.e2e-spec.ts
@@ -1,0 +1,77 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { PrismaService } from "../src/core/prisma/prisma.service.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * Better-Auth → Prisma persistence (e2e).
+ *
+ * This is the closing-the-loop test for the "Better-Auth uses
+ * in-memory storage" finding. A sign-up via the public HTTP handler
+ * MUST land a row in the Prisma `users` (and `accounts`) table — the
+ * very fact that we can boot a second app instance and still find
+ * the user is the proof that persistence is wired correctly.
+ */
+describe("Better-Auth · Prisma persistence", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+  const email = `persisted-${Date.now()}@example.com`;
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    // Best-effort cleanup so subsequent runs don't see the email-unique
+    // collision; the testcontainer is tossed by global-setup anyway,
+    // but local re-runs against a shared DB benefit from the cleanup.
+    try {
+      await prisma.user.deleteMany({ where: { email } });
+    } catch {
+      // ignore — table may not exist if migrations haven't run
+    }
+    await app.close();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+  });
+
+  it("POST /api/auth/sign-up/email writes a User row to Postgres", async () => {
+    const res = await request(app.getHttpServer())
+      .post("/api/auth/sign-up/email")
+      .set("content-type", "application/json")
+      .send({
+        email,
+        password: "password-12345",
+        name: "Persisted User",
+      });
+
+    // Better-Auth 1.6 returns 200 on a successful email/password
+    // sign-up. Anything else is either a config error (4xx/5xx) or a
+    // validation rejection — we want the persistence path here.
+    expect(res.status).toBe(200);
+
+    // The user row exists with the email Better-Auth received.
+    const persisted = await prisma.user.findUnique({ where: { email } });
+    expect(persisted).not.toBeNull();
+    expect(persisted!.email).toBe(email);
+    expect(persisted!.name).toBe("Persisted User");
+
+    // Better-Auth also writes the credential into `accounts` with the
+    // hashed password — exactly what proves "no in-memory storage".
+    const accounts = await prisma.account.findMany({ where: { userId: persisted!.id } });
+    expect(accounts.length).toBeGreaterThanOrEqual(1);
+    expect(accounts[0]!.providerId).toBe("credential");
+    expect(accounts[0]!.password).toBeTruthy();
+  });
+});

--- a/tests/better-auth-session-middleware.e2e-spec.ts
+++ b/tests/better-auth-session-middleware.e2e-spec.ts
@@ -5,11 +5,8 @@ import type { Request } from "express";
 import request from "supertest";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
-import { bootstrap } from "../src/core/app/bootstrap.js";
 import { Can } from "../src/core/permissions/can.guard.js";
 import { PrismaService } from "../src/core/prisma/prisma.service.js";
-
-const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
 
 interface AuthenticatedRequest extends Request {
   user?: { id: string; tenantId: string | null };
@@ -83,12 +80,20 @@ describe("Better-Auth · Session middleware (req.user)", () => {
   // middleware doesn't read it, only the interceptor does.
   const TENANT_HEADER = "00000000-0000-7000-8000-000000000000";
 
-  it("anonymous request → req.user is undefined on a public route", async () => {
+  it("anonymous request to a protected route → 401 (auth required) — not 403 / not 200", async () => {
     const res = await request(app.getHttpServer())
       .get("/test-session/me")
       .set("x-tenant-id", TENANT_HEADER);
-    expect(res.status, JSON.stringify(res.body)).toBe(200);
-    expect(res.body.user).toBeUndefined();
+    expect(res.status).toBe(401);
+  });
+
+  it("anonymous request to a public route (`/health/ready`) → req.user undefined, request passes", async () => {
+    // `/health/ready` is in `isPathProtected`'s allowlist; the
+    // middleware skips the lookup and lets the request through.
+    const res = await request(app.getHttpServer()).get("/health/ready");
+    // Either 200 (if Postgres ready) or 503 — both prove the auth
+    // middleware did not 401 the public path.
+    expect([200, 503]).toContain(res.status);
   });
 
   it("authenticated request → req.user is populated from the Better-Auth session", async () => {
@@ -114,10 +119,24 @@ describe("Better-Auth · Session middleware (req.user)", () => {
     expect(me.body.user.id).toBe(persisted!.id);
   });
 
-  it("@Can() denies anonymous with 403 (Forbidden), not 404 (NotFound) — the route IS reachable", async () => {
-    const res = await request(app.getHttpServer())
+  it("authenticated user without policy → @Can() denies with 403 (anonymous on the same route is 401)", async () => {
+    // First confirm the anonymous case still 401s (auth-required
+    // before guard).
+    const anon = await request(app.getHttpServer())
       .get("/test-session/can-restricted")
       .set("x-tenant-id", TENANT_HEADER);
+    expect(anon.status).toBe(401);
+
+    // Now sign in with the user we created earlier and hit the
+    // guarded route — no policy matches, so CASL denies with 403.
+    const agent = request.agent(app.getHttpServer());
+    const signIn = await agent
+      .post("/api/auth/sign-in/email")
+      .set("content-type", "application/json")
+      .send({ email, password });
+    expect(signIn.status, JSON.stringify(signIn.body)).toBe(200);
+
+    const res = await agent.get("/test-session/can-restricted").set("x-tenant-id", TENANT_HEADER);
     expect(res.status).toBe(403);
   });
 });

--- a/tests/better-auth-session-middleware.e2e-spec.ts
+++ b/tests/better-auth-session-middleware.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { Controller, Get, Req } from "@nestjs/common";
+import type { INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import type { Request } from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { Can } from "../src/core/permissions/can.guard.js";
+import { PrismaService } from "../src/core/prisma/prisma.service.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+interface AuthenticatedRequest extends Request {
+  user?: { id: string; tenantId: string | null };
+}
+
+@Controller("test-session")
+class WhoAmIController {
+  @Get("me")
+  me(@Req() req: AuthenticatedRequest): { user: AuthenticatedRequest["user"] } {
+    return { user: req.user };
+  }
+
+  @Get("can-restricted")
+  @Can("read", "Project")
+  restricted(): { ok: true } {
+    return { ok: true };
+  }
+}
+
+/**
+ * Closes finding #3: there is now middleware that resolves a
+ * Better-Auth session from the request cookies / headers, looks up
+ * the matching Prisma user, and assigns `req.user`. Three properties
+ * are pinned:
+ *   1. Anonymous request to a public route → `req.user` undefined.
+ *   2. Authenticated request → `req.user.id` matches the signed-up
+ *      user.
+ *   3. The pre-existing `@Can(...)` flow now denies anonymous (no
+ *      ability) with 403, but with a session and a matching policy
+ *      the request would pass.
+ */
+describe("Better-Auth · Session middleware (req.user)", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+  const email = `session-${Date.now()}@example.com`;
+  const password = "password-12345";
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    // Build a slim test module that pulls the full AppModule (so the
+    // session middleware is wired globally) and adds the WhoAmI
+    // controller as a probe surface.
+    const { AppModule } = await import("../src/core/app/app.module.js");
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+      controllers: [WhoAmIController],
+    }).compile();
+    app = moduleRef.createNestApplication({ logger: false });
+    await app.init();
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    try {
+      await prisma.user.deleteMany({ where: { email } });
+    } catch {
+      // ignore — cleanup is best-effort
+    }
+    await app.close();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+  });
+
+  // The tenant interceptor still requires `x-tenant-id` on
+  // non-exempt paths. Any UUID works for these probe routes — the
+  // middleware doesn't read it, only the interceptor does.
+  const TENANT_HEADER = "00000000-0000-7000-8000-000000000000";
+
+  it("anonymous request → req.user is undefined on a public route", async () => {
+    const res = await request(app.getHttpServer())
+      .get("/test-session/me")
+      .set("x-tenant-id", TENANT_HEADER);
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.user).toBeUndefined();
+  });
+
+  it("authenticated request → req.user is populated from the Better-Auth session", async () => {
+    // 1. sign up. The response sets a Better-Auth cookie; supertest's
+    //    agent keeps it for the next call.
+    const agent = request.agent(app.getHttpServer());
+    const signUp = await agent
+      .post("/api/auth/sign-up/email")
+      .set("content-type", "application/json")
+      .send({ email, password, name: "Session User" });
+    expect(signUp.status, JSON.stringify(signUp.body)).toBe(200);
+
+    // 2. probe `/test-session/me` with the same agent — the cookie
+    //    rides on the request.
+    const me = await agent.get("/test-session/me").set("x-tenant-id", TENANT_HEADER);
+    expect(me.status, JSON.stringify(me.body)).toBe(200);
+    expect(me.body.user).toBeDefined();
+    expect(me.body.user.id).toBeTruthy();
+
+    // 3. The user lookup matches the persisted Prisma row.
+    const persisted = await prisma.user.findUnique({ where: { email } });
+    expect(persisted).not.toBeNull();
+    expect(me.body.user.id).toBe(persisted!.id);
+  });
+
+  it("@Can() denies anonymous with 403 (Forbidden), not 404 (NotFound) — the route IS reachable", async () => {
+    const res = await request(app.getHttpServer())
+      .get("/test-session/can-restricted")
+      .set("x-tenant-id", TENANT_HEADER);
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,4 +1,7 @@
+import { spawnSync } from "node:child_process";
+
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { Client } from "pg";
 
 /**
  * Vitest globalSetup hook.
@@ -11,6 +14,14 @@ import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testconta
  * Why testcontainers and not docker-compose: testcontainers gives us
  * parallel-safe, run-isolated databases with deterministic cleanup. The
  * docker-compose Postgres in this repo is for the dev workflow only.
+ *
+ * Migration step: once Better-Auth's Prisma adapter started persisting
+ * users / sessions / accounts to Postgres (instead of the previous
+ * in-memory storage), e2e tests that hit the auth surface need real
+ * tables. We run `prisma migrate deploy` against the testcontainer
+ * here so every spec inherits a migrated schema. The migration is
+ * idempotent — running it against an existing CI service container
+ * is safe.
  */
 let container: StartedPostgreSqlContainer | undefined;
 
@@ -27,6 +38,55 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
     process.env.DATABASE_URL = container.getConnectionUri();
   }
 
+  // Apply Prisma migrations to the (just-booted or pre-existing) DB.
+  // `migrate deploy` is the production-safe path: forward-only, no
+  // reset prompts, no `prisma db push` schema drift.
+  //
+  // The vanilla `postgres:18-alpine` image testcontainers boots does
+  // NOT bundle the `pg_uuidv7` extension — the project's docker-compose
+  // image (`docker/postgres/Dockerfile`) bakes it in for prod / local
+  // dev, but rebuilding that image for every test run is a 90s tax we
+  // avoid by:
+  //   1. installing a stub `uuid_generate_v7()` function (shape-compatible
+  //      with `pg_uuidv7`'s real implementation; tests exercise the
+  //      Better-Auth + Prisma persistence path, not the time-prefix
+  //      ordering invariant)
+  //   2. resolving the `pg_uuidv7` migration as already-applied so
+  //      `migrate deploy` skips its `CREATE EXTENSION` block.
+  //
+  // External CI service containers can override by exporting
+  // `TEST_SKIP_PG_UUIDV7_STUB=1`.
+  if (!process.env.TEST_SKIP_PG_UUIDV7_STUB) {
+    await ensurePgUuidV7Stub(process.env.DATABASE_URL!);
+    const resolve = spawnSync(
+      "bunx",
+      ["prisma", "migrate", "resolve", "--applied", "20260428000000_pg_uuidv7"],
+      { env: { ...process.env }, stdio: "pipe", encoding: "utf8" },
+    );
+    // `resolve` exits non-zero either when the migration is unknown or
+    // already applied — both are benign in a fresh testcontainer that
+    // has no `_prisma_migrations` table yet. Capture stderr only so a
+    // genuine connection issue still surfaces in the deploy step
+    // immediately after.
+    if (resolve.status !== 0 && !/already (applied|recorded)/i.test(resolve.stderr ?? "")) {
+      // Surface the error but let `migrate deploy` decide if it's fatal.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[global-setup] prisma migrate resolve --applied 20260428000000_pg_uuidv7: ${resolve.stderr ?? ""}`,
+      );
+    }
+  }
+
+  const result = spawnSync("bunx", ["prisma", "migrate", "deploy"], {
+    env: { ...process.env, DATABASE_URL: process.env.DATABASE_URL },
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const detail = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+    throw new Error(`prisma migrate deploy failed (exit ${result.status}):\n${detail}`);
+  }
+
   process.env.TEST_INFRA_READY = "1";
 
   return async () => {
@@ -36,4 +96,24 @@ export default async function globalSetup(): Promise<() => Promise<void>> {
       container = undefined;
     }
   };
+}
+
+/**
+ * Pre-create a stub `uuid_generate_v7()` so the `20260428000000_pg_uuidv7`
+ * migration's payload (`CREATE EXTENSION IF NOT EXISTS pg_uuidv7`) is no
+ * longer load-bearing for tests. The function returns a UUID built from
+ * `gen_random_uuid()` — the time-prefix ordering invariant of pg_uuidv7
+ * is not exercised by any current test. Production / local dev images
+ * still bundle the real extension, so this stub never runs there.
+ */
+async function ensurePgUuidV7Stub(databaseUrl: string): Promise<void> {
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    await client.query(
+      "CREATE OR REPLACE FUNCTION uuid_generate_v7() RETURNS uuid AS $$ SELECT gen_random_uuid() $$ LANGUAGE sql VOLATILE",
+    );
+  } finally {
+    await client.end();
+  }
 }

--- a/tests/stories/better-auth-prisma-factory.story.test.ts
+++ b/tests/stories/better-auth-prisma-factory.story.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBetterAuth } from "../../src/core/auth/better-auth.js";
+
+/**
+ * Story · Better-Auth factory accepts an optional Prisma instance.
+ *
+ * Without `prisma`, the factory falls back to Better-Auth's built-in
+ * memory adapter (suitable for the JWT/SDK story tests that build the
+ * instance just to inspect the handler). With `prisma`, the factory
+ * wires Better-Auth's `prismaAdapter` so sign-ups, sign-ins, sessions,
+ * and verification tokens persist into the Postgres tables declared
+ * in `prisma/schema.prisma`.
+ *
+ * The factory keeps `prisma` optional for two reasons:
+ *  1. unit / story tests that don't need a live DB
+ *  2. early boot — `BetterAuthModule` returns `null` when the secret
+ *     is missing; Prisma might not be wired in those cases either.
+ */
+describe("Story · Better-Auth factory · Prisma persistence", () => {
+  it("returns an instance whose options.database is the in-memory adapter when no prisma is passed", () => {
+    const auth = buildBetterAuth({
+      secret: "a".repeat(32),
+      baseUrl: "http://localhost:3000",
+      sessionExpiresInSeconds: 60,
+    });
+    // No persistence configured → Better-Auth's built-in memory adapter.
+    expect(auth.options.database).toBeUndefined();
+  });
+
+  it("wires `database: prismaAdapter(...)` when a `prisma` argument is supplied", () => {
+    // Minimal Prisma stand-in: the adapter only calls `$transaction`
+    // and the model accessors. We're exercising the wiring, not the
+    // real DB roundtrip — that's covered by the e2e spec.
+    const stubPrisma = {
+      $transaction: async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => cb(stubPrisma),
+      user: {},
+      session: {},
+      account: {},
+      verification: {},
+    };
+    const auth = buildBetterAuth({
+      secret: "a".repeat(32),
+      baseUrl: "http://localhost:3000",
+      sessionExpiresInSeconds: 60,
+      prisma: stubPrisma as unknown as never,
+    });
+    // Better-Auth normalises `database` into a function once a real
+    // adapter is supplied. Whatever the precise shape is, presence is
+    // the load-bearing assertion: without `prisma` it's `undefined`.
+    expect(auth.options.database).toBeDefined();
+  });
+});

--- a/tests/stories/better-auth-prisma-factory.story.test.ts
+++ b/tests/stories/better-auth-prisma-factory.story.test.ts
@@ -43,7 +43,7 @@ describe("Story · Better-Auth factory · Prisma persistence", () => {
       secret: "a".repeat(32),
       baseUrl: "http://localhost:3000",
       sessionExpiresInSeconds: 60,
-      prisma: stubPrisma as unknown as never,
+      prisma: stubPrisma,
     });
     // Better-Auth normalises `database` into a function once a real
     // adapter is supplied. Whatever the precise shape is, presence is

--- a/tests/stories/better-auth-prisma-persistence.story.test.ts
+++ b/tests/stories/better-auth-prisma-persistence.story.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..", "..");
+const SCHEMA = readFileSync(resolve(ROOT, "prisma/schema.prisma"), "utf8");
+
+/**
+ * Story · Better-Auth → Prisma persistence (schema)
+ *
+ * Replaces the previous in-memory storage. The Better-Auth Prisma
+ * adapter (`better-auth/adapters/prisma`) maps Better-Auth's logical
+ * "user / session / account / verification" tables to the Prisma
+ * models declared in `prisma/schema.prisma`.
+ *
+ * Per the project rule "Reuse Better-Auth's user. Don't shadow it",
+ * Better-Auth owns the `User` Prisma model. Our existing tenant /
+ * api-key / membership tables continue to FK against `users` — this
+ * story locks down the additive shape required by the adapter:
+ *   - `User` gets `name` / `emailVerified` / `image` columns
+ *   - `User.tenantId` becomes nullable so Better-Auth's sign-up flow
+ *     works without forcing the caller to pre-pick a tenant
+ *   - new models for `Session`, `Account`, `Verification` (core), plus
+ *     `Jwks` (jwt plugin), `TwoFactor` (twoFactor plugin), and
+ *     `Passkey` (passkey plugin) — all opt-in but always present in
+ *     the schema so a single `prisma migrate deploy` covers every
+ *     authMethods toggle.
+ */
+describe("Story · Better-Auth Prisma persistence (schema)", () => {
+  function blockOf(model: string): string {
+    const re = new RegExp(`model\\s+${model}\\s*\\{[\\s\\S]*?\\n\\}`, "m");
+    const match = SCHEMA.match(re);
+    expect(match, `model ${model} block not found`).not.toBeNull();
+    return match![0];
+  }
+
+  describe("User model — Better-Auth required fields", () => {
+    it("declares a `name` column (required by Better-Auth's user)", () => {
+      expect(blockOf("User")).toMatch(/^\s*name\s+String/m);
+    });
+
+    it("declares an `emailVerified` boolean mapped to email_verified", () => {
+      const b = blockOf("User");
+      expect(b).toMatch(/emailVerified\s+Boolean/);
+      expect(b).toMatch(/emailVerified[\s\S]*@map\(\s*"email_verified"\s*\)/);
+    });
+
+    it("declares an optional `image` column", () => {
+      expect(blockOf("User")).toMatch(/^\s*image\s+String\?/m);
+    });
+
+    it("makes tenantId optional so Better-Auth signups can create a user without a tenant pre-pick", () => {
+      const b = blockOf("User");
+      // Either `tenantId String?` (canonical) or a `?` after the @db.Uuid attribute is
+      // present. The strict shape we expect is `String? @map(...) @db.Uuid`.
+      expect(b).toMatch(/tenantId\s+String\?/);
+    });
+  });
+
+  describe("Session model", () => {
+    const block = (): string => blockOf("Session");
+
+    it("exists and maps to the `sessions` table", () => {
+      expect(block()).toMatch(/@@map\(\s*"sessions"\s*\)/);
+    });
+
+    it("has the four canonical Better-Auth columns: token, expiresAt, ipAddress, userAgent", () => {
+      const b = block();
+      expect(b).toMatch(/token\s+String\s+@unique/);
+      expect(b).toMatch(/expiresAt[\s\S]*@map\(\s*"expires_at"\s*\)/);
+      expect(b).toMatch(/ipAddress[\s\S]*@map\(\s*"ip_address"\s*\)/);
+      expect(b).toMatch(/userAgent[\s\S]*@map\(\s*"user_agent"\s*\)/);
+    });
+
+    it("FKs userId → User.id with cascade delete", () => {
+      const b = block();
+      expect(b).toMatch(/userId\s+String/);
+      expect(b).toMatch(/onDelete:\s*Cascade/);
+    });
+  });
+
+  describe("Account model (OAuth + email-password credentials)", () => {
+    const block = (): string => blockOf("Account");
+
+    it("exists and maps to the `accounts` table", () => {
+      expect(block()).toMatch(/@@map\(\s*"accounts"\s*\)/);
+    });
+
+    it("declares accountId, providerId, password (hashed), and the OAuth tokens", () => {
+      const b = block();
+      expect(b).toMatch(/accountId[\s\S]*@map\(\s*"account_id"\s*\)/);
+      expect(b).toMatch(/providerId[\s\S]*@map\(\s*"provider_id"\s*\)/);
+      // Better-Auth stores the argon2 hash under `password`. Optional —
+      // OAuth-only accounts have no password column populated.
+      expect(b).toMatch(/^\s*password\s+String\?/m);
+      expect(b).toMatch(/accessToken[\s\S]*@map\(\s*"access_token"\s*\)/);
+      expect(b).toMatch(/refreshToken[\s\S]*@map\(\s*"refresh_token"\s*\)/);
+    });
+  });
+
+  describe("Verification model (email + password reset tokens)", () => {
+    const block = (): string => blockOf("Verification");
+
+    it("exists and maps to the `verifications` table", () => {
+      expect(block()).toMatch(/@@map\(\s*"verifications"\s*\)/);
+    });
+
+    it("declares identifier, value, expiresAt", () => {
+      const b = block();
+      expect(b).toMatch(/^\s*identifier\s+String/m);
+      expect(b).toMatch(/^\s*value\s+String/m);
+      expect(b).toMatch(/expiresAt[\s\S]*@map\(\s*"expires_at"\s*\)/);
+    });
+  });
+
+  describe("Plugin tables", () => {
+    it("declares a Jwks model mapped to `jwks` (jwt plugin)", () => {
+      const b = blockOf("Jwks");
+      expect(b).toMatch(/@@map\(\s*"jwks"\s*\)/);
+      expect(b).toMatch(/publicKey[\s\S]*@map\(\s*"public_key"\s*\)/);
+      expect(b).toMatch(/privateKey[\s\S]*@map\(\s*"private_key"\s*\)/);
+    });
+
+    it("declares a TwoFactor model mapped to `two_factors` (twoFactor plugin)", () => {
+      const b = blockOf("TwoFactor");
+      expect(b).toMatch(/@@map\(\s*"two_factors"\s*\)/);
+      expect(b).toMatch(/^\s*secret\s+String/m);
+      expect(b).toMatch(/backupCodes[\s\S]*@map\(\s*"backup_codes"\s*\)/);
+    });
+
+    it("declares a Passkey model mapped to `passkeys` (passkey plugin)", () => {
+      const b = blockOf("Passkey");
+      expect(b).toMatch(/@@map\(\s*"passkeys"\s*\)/);
+      expect(b).toMatch(/credentialID[\s\S]*@map\(\s*"credential_id"\s*\)/);
+      expect(b).toMatch(/^\s*publicKey/m);
+      expect(b).toMatch(/^\s*counter\s+Int/m);
+    });
+
+    it("Passkey, TwoFactor, Session, Account all FK userId to User with cascade", () => {
+      for (const model of ["Passkey", "TwoFactor", "Session", "Account"]) {
+        const b = blockOf(model);
+        expect(b, `${model} should reference User`).toMatch(
+          /user\s+User\s+@relation\([^)]*onDelete:\s*Cascade/,
+        );
+      }
+    });
+  });
+});

--- a/tests/stories/tenant-member-prisma-storage.story.test.ts
+++ b/tests/stories/tenant-member-prisma-storage.story.test.ts
@@ -144,6 +144,36 @@ describe("Story · TenantMember Prisma persistence", () => {
     expect(await storage.remove(id)).toBe(false);
   });
 
+  it("updateStatus returns null when the row is missing (Prisma P2025 → soft miss)", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    expect(await storage.updateStatus(uuidV7(), "ACTIVE")).toBeNull();
+  });
+
+  it("updateStatus and remove rethrow non-P2025 errors (e.g. wrong column name) instead of swallowing", async () => {
+    // We construct a stub Prisma whose `update` throws something
+    // that is not P2025 — the storage must NOT swallow it.
+    class ExplodingPrisma {
+      tenantMember = {
+        update: () => {
+          throw new Error("kaboom");
+        },
+        delete: () => {
+          throw new Error("kaboom");
+        },
+        // unused in this assertion
+        findFirst: async () => null,
+        findMany: async () => [],
+        findUnique: async () => null,
+        create: async (input: { data: TenantMemberRecord }) => input.data,
+      };
+    }
+    const storage = new PrismaTenantMemberStorage(
+      new ExplodingPrisma() as unknown as Parameters<typeof PrismaTenantMemberStorage>[0],
+    );
+    await expect(storage.updateStatus("any", "ACTIVE")).rejects.toThrow("kaboom");
+    await expect(storage.remove("any")).rejects.toThrow("kaboom");
+  });
+
   it("works as the storage backend for the TenantMemberService", async () => {
     const storage = new PrismaTenantMemberStorage(prisma);
     const svc = new TenantMemberService(storage);

--- a/tests/stories/tenant-member-prisma-storage.story.test.ts
+++ b/tests/stories/tenant-member-prisma-storage.story.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+import { PrismaTenantMemberStorage } from "../../src/core/multi-tenancy/prisma-tenant-member-storage.js";
+import {
+  type TenantMemberRecord,
+  TenantMemberService,
+} from "../../src/core/multi-tenancy/tenant-member.service.js";
+import { uuidV7 } from "../../src/core/uuid/uuid-v7.js";
+
+/**
+ * Story · TenantMember Prisma persistence (closes finding #2)
+ *
+ * Replaces `InMemoryTenantMemberStorage` as the default. Memberships
+ * survive a process restart (the canonical proof: open a fresh
+ * Prisma client and find the row we just inserted).
+ */
+describe("Story · TenantMember Prisma persistence", () => {
+  let prisma: PrismaClient;
+  let tenantId: string;
+
+  beforeAll(async () => {
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL missing — global-setup did not run");
+    prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) });
+    await prisma.$connect();
+    // A real Tenant row to FK against — the storage adapter writes
+    // through to a foreign-keyed table. Using a unique name per run
+    // dodges concurrent-test collisions on the testcontainer.
+    const tenant = await prisma.tenant.create({
+      data: { id: uuidV7(), name: `prisma-tm-storage-${Date.now()}` },
+    });
+    tenantId = tenant.id;
+  });
+
+  afterAll(async () => {
+    if (tenantId) {
+      // tenant_members cascades on tenant delete; clean up users in
+      // a separate pass so the test container stays tidy.
+      await prisma.tenantMember.deleteMany({ where: { tenantId } });
+      await prisma.user.deleteMany({ where: { tenantId } });
+      await prisma.tenant.delete({ where: { id: tenantId } });
+    }
+    await prisma.$disconnect();
+  });
+
+  async function makeUser(): Promise<string> {
+    const id = uuidV7();
+    await prisma.user.create({
+      data: {
+        id,
+        email: `tm-user-${id}@example.test`,
+        name: "TM User",
+        tenantId,
+      },
+    });
+    return id;
+  }
+
+  it("insert + findByUserAndTenant round-trip writes to the `tenant_members` table", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    const userId = await makeUser();
+    const record: TenantMemberRecord = {
+      id: uuidV7(),
+      userId,
+      tenantId,
+      role: "editor",
+      status: "INVITED",
+      invitedAt: new Date(),
+    };
+    const inserted = await storage.insert(record);
+    expect(inserted.id).toBe(record.id);
+
+    const found = await storage.findByUserAndTenant(userId, tenantId);
+    expect(found).not.toBeNull();
+    expect(found!.role).toBe("editor");
+    expect(found!.status).toBe("INVITED");
+
+    // The row is in Postgres — re-reading via raw Prisma proves the
+    // claim "no in-memory adapter" the way no other assertion can.
+    const raw = await prisma.tenantMember.findFirst({ where: { id: record.id } });
+    expect(raw).not.toBeNull();
+  });
+
+  it("listByTenant returns rows filtered to the tenant", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    const u1 = await makeUser();
+    const u2 = await makeUser();
+    await storage.insert({
+      id: uuidV7(),
+      userId: u1,
+      tenantId,
+      role: "viewer",
+      status: "ACTIVE",
+    });
+    await storage.insert({
+      id: uuidV7(),
+      userId: u2,
+      tenantId,
+      role: "viewer",
+      status: "ACTIVE",
+    });
+
+    const rows = await storage.listByTenant(tenantId);
+    // The test creates `tenantId` per run but earlier `it` blocks may
+    // have inserted into the same tenant, so we just assert at least
+    // these two are visible.
+    expect(rows.map((r) => r.userId)).toEqual(expect.arrayContaining([u1, u2]));
+  });
+
+  it("updateStatus transitions INVITED → ACTIVE persistently", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    const userId = await makeUser();
+    const id = uuidV7();
+    await storage.insert({
+      id,
+      userId,
+      tenantId,
+      role: "editor",
+      status: "INVITED",
+      invitedAt: new Date(),
+    });
+
+    const updated = await storage.updateStatus(id, "ACTIVE");
+    expect(updated).not.toBeNull();
+    expect(updated!.status).toBe("ACTIVE");
+
+    // Re-read confirms persistence
+    const raw = await prisma.tenantMember.findUnique({ where: { id } });
+    expect(raw!.status).toBe("ACTIVE");
+  });
+
+  it("remove deletes the row", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    const userId = await makeUser();
+    const id = uuidV7();
+    await storage.insert({ id, userId, tenantId, role: "editor", status: "ACTIVE" });
+    expect(await storage.remove(id)).toBe(true);
+    expect(await prisma.tenantMember.findUnique({ where: { id } })).toBeNull();
+    // Idempotency: removing the same row twice returns false instead
+    // of throwing — matches the InMemory contract.
+    expect(await storage.remove(id)).toBe(false);
+  });
+
+  it("works as the storage backend for the TenantMemberService", async () => {
+    const storage = new PrismaTenantMemberStorage(prisma);
+    const svc = new TenantMemberService(storage);
+    const userId = await makeUser();
+    const member = await svc.add({ userId, tenantId, role: "editor" });
+    expect(member.status).toBe("INVITED");
+
+    const activated = await svc.activate(member.id);
+    expect(activated.status).toBe("ACTIVE");
+
+    const list = await svc.listByTenant(tenantId);
+    expect(list.find((r) => r.id === member.id)?.status).toBe("ACTIVE");
+  });
+});


### PR DESCRIPTION
Closes the four blockers surfaced in `/llm-test` pilot 3 (friction-log
archive: `~/.cache/lt-llm-test/archive/2026-04-30-13-42-45/`). After
this PR, a Better-Auth signup actually persists, tenant memberships
hit Postgres (so RLS on `tenant_members` is no longer dead-code), and
`@Can()` routes correctly distinguish `401` (anonymous) from `403`
(authenticated-but-denied).

## Summary

- **Finding #1 (blocker — Better-Auth in-memory storage).** The factory
  now accepts an optional `prisma` argument; when supplied,
  Better-Auth's `prismaAdapter` writes through to Postgres. Schema
  extends `User` with `name / emailVerified / image / twoFactorEnabled`,
  relaxes `tenantId` to nullable so a sign-up can create a user before
  the tenant pre-pick happens, and adds the new core + plugin tables
  (`Session`, `Account`, `Verification`, `Jwks`, `TwoFactor`,
  `Passkey`). Migration `20260430160000_better_auth_tables` ships
  alongside.
- **Finding #2 (blocker — TenantMember in-memory only).** New
  `PrismaTenantMemberStorage` implementing the existing
  `TenantMemberStorage` interface, registered as the default in
  `tenant-member.module.ts`. The in-memory adapter stays exported so
  fake-prisma / unit-only tests can still opt in.
- **Finding #3 (blocker — every `@Can()` returned 403).** New
  `BetterAuthSessionMiddleware` reads the Better-Auth session
  (cookie / Authorization header), looks up the matching Prisma user,
  and assigns `req.user = { id, tenantId }`. Wired in
  `AppModule.configure()` after `RequestContextMiddleware`. Behavior
  matches the plan-doc rule: *anonymous on a protected path → 401;
  authenticated-but-denied → 403*.
- **Finding #4 (medium — QUICKSTART/README promised `:3000`).**
  `.claude/QUICKSTART.md` and `README.md` now route the reader to
  the URL the dev runner prints, with one sentence explaining the
  portless-vs-dynamic-port fallback.

## Why one PR (not four)

Slice 1 unlocks the others — without persistence, a
`PrismaTenantMemberStorage` integration test has no DB to write to
and the session middleware has no Better-Auth user to look up.
Each finding still gets its own commit pair (`test:` red → `feat:`
green) so a future bisect / cherry-pick stays clean.

## Test plan

- [x] `bun run lint` (oxlint, 0 warnings 0 errors)
- [x] `bun run format` (oxfmt --check)
- [x] `bun run test:types` (tsc --noEmit on tests/types)
- [x] `bun run test:unit` (139 / 139 green)
- [x] `bun run test:e2e` (1608 / 1608 green; `tests/global-setup.ts`
  now runs `prisma migrate deploy` against the testcontainer so the
  Better-Auth Prisma adapter has tables to write to)
- [x] `bun run test:coverage` (lines 94.95 % overall, ≥ 90 % on
  `src/core/`, ≥ 80 % on `src/modules/`)
- [x] `bun run build` (dist artifacts emitted)
- [x] **Persistence smoke**: e2e spec
  `tests/better-auth-prisma-persistence.e2e-spec.ts` signs up an
  email, then re-reads the row out of `prisma.user` to prove the
  in-memory adapter is gone.
- [x] **Session smoke**: e2e spec
  `tests/better-auth-session-middleware.e2e-spec.ts` proves
  anonymous → 401, authenticated → req.user populated, and
  authenticated-but-denied → 403.
- [x] **TenantMember smoke**: story spec
  `tests/stories/tenant-member-prisma-storage.story.test.ts`
  exercises insert / list / updateStatus / remove against the
  testcontainer, plus a P2025 not-found path and an unknown-error
  rethrow.

## Design notes (please validate)

1. **Schema reconciliation: existing `User` extended in place, not
   replaced.** The plan-doc says "Reuse Better-Auth's user. Don't
   shadow it." We did that by *extending* the existing Prisma
   `User` model with Better-Auth's required columns
   (`name / emailVerified / image / twoFactorEnabled`) rather than
   dropping the table and recreating it. This:

   - keeps the existing `tenant_members` and `api_keys` foreign keys
     pointing at `users(id)` without re-pointing them
   - preserves any rows the SystemSetup admin bootstrap already
     provisioned (`name` defaults to `''`)
   - lets Better-Auth's `user.modelName` default match — no custom
     model name override needed in the factory

   The alternative — drop `users` and let Better-Auth recreate it
   — would have required either recreating the FKs or migrating the
   existing rows out and back. Worth a sanity check that the
   in-place extension is the right call.

2. **`tenantId` nullable on `User`.** Better-Auth's anonymous
   sign-up flow has no tenant context, so the row's `tenantId` is
   `NULL` until a `TenantMember.activate` flow runs. The RLS policy
   on `users` was relaxed to allow `tenant_id IS NULL` so the
   anonymous insert lands; tenant-scoped reads still require a
   matching `app.tenant_id`. The `TenantMember` join-table remains
   the canonical source of truth for "which tenants does this user
   belong to". Worth double-checking with the multi-tenancy
   maintainer that this matches the intended invariant.

3. **`generateId: 'uuid'`.** Better-Auth's default ID generator
   emits a base32 nanoid; our Prisma columns are `@db.Uuid`. We
   override to UUIDs so the schema and adapter line up. The
   alternative — `@db.Text` everywhere — would have changed every
   table's primary-key column type, which is a larger blast radius.

4. **`tests/global-setup.ts` migrates the testcontainer.** The
   pg_uuidv7 extension isn't bundled with `postgres:18-alpine`, so
   global-setup pre-creates a stub `uuid_generate_v7()` function
   and resolves the lonely extension migration as
   already-applied. Production / local-dev still use the custom
   image (`docker/postgres/Dockerfile`) that ships the real
   extension; this only kicks in for testcontainer runs.

5. **`BetterAuthSessionMiddleware` behaviour when auth is *not*
   configured.** When `BETTER_AUTH_SECRET` is missing the middleware
   skips the lookup entirely and `next()`s. Rationale: a fresh
   starter / admin-only deployment shouldn't hard-fail every request
   on the missing secret. `@Can()` still denies because no ability
   is built without `req.user`. If the security model demands a hard
   401 when Better-Auth is missing, that's a one-line flip — flag
   it and we'll revisit.

## PR #14 conflict surface

No overlap. PR #14 touches the Dev-Portal React migration + scripts
(`src/core/dx/clients/*`, `scripts/dev.ts`, `scripts/build.ts`,
`tsconfig*.json`, `package.json`, `vitest.config.ts`,
`docs/architecture.md`, etc.). This PR touches the auth + persistence
+ multi-tenancy + middleware stack (`src/core/auth/*`,
`src/core/multi-tenancy/*`, `prisma/*`, `tests/global-setup.ts`,
`README.md`, `.claude/QUICKSTART.md`). The two file sets are disjoint.

## Recommended next moves

1. **Sync `tenantId` from `TenantMember.activate` back to `User`** —
   right now `User.tenantId` stays `NULL` forever after a
   Better-Auth signup unless something explicitly sets it. The
   activate path is the natural hook.
2. **Add a `provisionInitialAdmin` Prisma adapter** so the
   SystemSetup admin bootstrap writes to `users` instead of the
   in-process Map. Same shape as the TenantMember slice — exactly
   the upgrade path the comment in `system-setup.module.ts`
   anticipated.
3. **Extend `tests/lib/fake-prisma.ts`** with `tenantMember`,
   `session`, `account`, `verification` table mocks so module-level
   story tests that don't want a testcontainer keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)