### PR TITLE
feat(email): templates as .tsx files (closes #6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,8 @@
         "@opentelemetry/api": "^1.9.1",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7",
+        "@react-email/components": "^1.0.12",
+        "@react-email/render": "^2.0.8",
         "@scalar/nestjs-api-reference": "^1.1.11",
         "@tanstack/react-query": "^5",
         "@tus/file-store": "^2.1.0",
@@ -523,6 +525,48 @@
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
+    "@react-email/body": ["@react-email/body@0.3.0", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug=="],
+
+    "@react-email/button": ["@react-email/button@0.2.1", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A=="],
+
+    "@react-email/code-block": ["@react-email/code-block@0.2.1", "", { "dependencies": { "prismjs": "^1.30.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw=="],
+
+    "@react-email/code-inline": ["@react-email/code-inline@0.0.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA=="],
+
+    "@react-email/column": ["@react-email/column@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg=="],
+
+    "@react-email/components": ["@react-email/components@1.0.12", "", { "dependencies": { "@react-email/body": "0.3.0", "@react-email/button": "0.2.1", "@react-email/code-block": "0.2.1", "@react-email/code-inline": "0.0.6", "@react-email/column": "0.0.14", "@react-email/container": "0.0.16", "@react-email/font": "0.0.10", "@react-email/head": "0.0.13", "@react-email/heading": "0.0.16", "@react-email/hr": "0.0.12", "@react-email/html": "0.0.12", "@react-email/img": "0.0.12", "@react-email/link": "0.0.13", "@react-email/markdown": "0.0.18", "@react-email/preview": "0.0.14", "@react-email/render": "2.0.6", "@react-email/row": "0.0.13", "@react-email/section": "0.0.17", "@react-email/tailwind": "2.0.7", "@react-email/text": "0.1.6" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ=="],
+
+    "@react-email/container": ["@react-email/container@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ=="],
+
+    "@react-email/font": ["@react-email/font@0.0.10", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA=="],
+
+    "@react-email/head": ["@react-email/head@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog=="],
+
+    "@react-email/heading": ["@react-email/heading@0.0.16", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw=="],
+
+    "@react-email/hr": ["@react-email/hr@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA=="],
+
+    "@react-email/html": ["@react-email/html@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw=="],
+
+    "@react-email/img": ["@react-email/img@0.0.12", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ=="],
+
+    "@react-email/link": ["@react-email/link@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw=="],
+
+    "@react-email/markdown": ["@react-email/markdown@0.0.18", "", { "dependencies": { "marked": "^15.0.12" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg=="],
+
+    "@react-email/preview": ["@react-email/preview@0.0.14", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw=="],
+
+    "@react-email/render": ["@react-email/render@2.0.8", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ=="],
+
+    "@react-email/row": ["@react-email/row@0.0.13", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw=="],
+
+    "@react-email/section": ["@react-email/section@0.0.17", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w=="],
+
+    "@react-email/tailwind": ["@react-email/tailwind@2.0.7", "", { "dependencies": { "tailwindcss": "^4.1.18" }, "peerDependencies": { "@react-email/body": ">=0", "@react-email/button": ">=0", "@react-email/code-block": ">=0", "@react-email/code-inline": ">=0", "@react-email/container": ">=0", "@react-email/heading": ">=0", "@react-email/hr": ">=0", "@react-email/img": ">=0", "@react-email/link": ">=0", "@react-email/preview": ">=0", "@react-email/text": ">=0", "react": "^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@react-email/body", "@react-email/button", "@react-email/code-block", "@react-email/code-inline", "@react-email/container", "@react-email/heading", "@react-email/hr", "@react-email/img", "@react-email/link", "@react-email/preview"] }, "sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA=="],
+
+    "@react-email/text": ["@react-email/text@0.1.6", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw=="],
+
     "@react-types/shared": ["@react-types/shared@3.34.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ=="],
 
     "@readme/better-ajv-errors": ["@readme/better-ajv-errors@2.4.0", "", { "dependencies": { "@babel/code-frame": "^7.22.5", "@babel/runtime": "^7.22.5", "@humanwhocodes/momoa": "^2.0.3", "jsonpointer": "^5.0.0", "leven": "^3.1.0", "picocolors": "^1.1.1" }, "peerDependencies": { "ajv": "4.11.8 - 8" } }, "sha512-9WODaOAKSl/mU+MYNZ2aHCrkoRSvmQ+1YkLj589OEqqjOAhbn8j7Z+ilYoiTu/he6X63/clsxxAB4qny9/dDzg=="],
@@ -584,6 +628,8 @@
     "@scalar/types": ["@scalar/types@0.9.3", "", { "dependencies": { "@scalar/helpers": "0.5.3", "nanoid": "^5.1.6", "type-fest": "^5.3.1", "zod": "^4.3.5" } }, "sha512-/cEFjVa8PxRIDyhcWKh7McT8pm5O0kbafzd1jvpVq69sgIIq0gJ0P1sCcPye6qJ2k478PK7VmpK9FxZcr6D4Kw=="],
 
     "@scarf/scarf": ["@scarf/scarf@1.4.0", "", {}, "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="],
+
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
     "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
@@ -981,6 +1027,14 @@
 
     "dockerode": ["dockerode@4.0.12", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@grpc/grpc-js": "^1.11.1", "@grpc/proto-loader": "^0.7.13", "docker-modem": "^5.0.7", "protobufjs": "^7.3.2", "tar-fs": "^2.1.4", "uuid": "^10.0.0" } }, "sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -1006,6 +1060,8 @@
     "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1163,6 +1219,10 @@
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-status-codes": ["http-status-codes@2.3.0", "", {}, "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="],
@@ -1253,6 +1313,8 @@
 
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
+
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
@@ -1313,7 +1375,7 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
-    "marked": ["marked@4.3.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="],
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1435,6 +1497,8 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1446,6 +1510,8 @@
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
 
@@ -1499,7 +1565,11 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
     "prisma": ["prisma@7.8.0", "", { "dependencies": { "@prisma/config": "7.8.0", "@prisma/dev": "0.24.3", "@prisma/engines": "7.8.0", "@prisma/studio-core": "0.27.3", "mysql2": "3.15.3", "postgres": "3.4.7" }, "peerDependencies": { "better-sqlite3": ">=9.0.0", "typescript": ">=5.4.0" }, "optionalPeers": ["better-sqlite3", "typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw=="],
+
+    "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
@@ -1600,6 +1670,8 @@
     "schema-utils": ["schema-utils@3.3.0", "", { "dependencies": { "@types/json-schema": "^7.0.8", "ajv": "^6.12.5", "ajv-keywords": "^3.5.2" } }, "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1716,6 +1788,8 @@
     "symbol-observable": ["symbol-observable@4.0.0", "", {}, "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
+
+    "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -1913,9 +1987,13 @@
 
     "@prisma/streams-local/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
+    "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
+
     "@readme/openapi-parser/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
     "@readme/postman-to-openapi/jsonc-parser": ["jsonc-parser@3.2.0", "", {}, "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="],
+
+    "@readme/postman-to-openapi/marked": ["marked@4.3.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="],
 
     "@redocly/openapi-core/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "@opentelemetry/api": "^1.9.1",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7",
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.8",
     "@scalar/nestjs-api-reference": "^1.1.11",
     "@tanstack/react-query": "^5",
     "@tus/file-store": "^2.1.0",

--- a/src/core/email/CLAUDE.md
+++ b/src/core/email/CLAUDE.md
@@ -1,0 +1,112 @@
+# `src/core/email/` — agent guide
+
+Transactional-email subsystem. The current shape:
+
+```
+email/
+├── brand.ts                       ← BrandConfig + defaults + resolveBrandConfig()
+├── email.service.ts               ← EmailService (driver + renderer + rate-limit + whitelist)
+├── email.module.ts                ← EmailService DI factory
+├── email-templates.ts             ← Legacy EJS-subset renderer (kept for back-compat)
+├── email-templates.react.ts       ← React-Email loader + renderer (default)
+├── layouts/
+│   └── Barebone.tsx               ← Default frame (header / body / footer)
+├── blocks/
+│   ├── Greeting.tsx               ← Title-weight opener
+│   ├── Paragraph.tsx              ← Body copy
+│   ├── CTA.tsx                    ← Primary button + fallback URL
+│   ├── Footer.tsx                 ← Body-level small print
+│   ├── Code.tsx                   ← Monospace token / OTP block
+│   ├── Divider.tsx                ← Horizontal rule
+│   └── index.ts                   ← Re-exports
+└── templates/
+    ├── email-verification.tsx
+    ├── password-reset.tsx
+    ├── welcome.tsx
+    └── invitation.tsx
+```
+
+## How rendering works
+
+1. `EmailService.sendTemplate({ template, locale, vars })`
+2. The configured renderer (`ReactEmailTemplateRenderer` by default) resolves
+   the template via the file-system priority list — module overlay beats core,
+   locale-specific beats default. See `email-templates.react.ts`.
+3. The matched module is dynamically imported (cache-busted for `bun --watch`)
+   and its **default export** is called with `{ ...vars, brand }`.
+4. `@react-email/render` walks the React tree to inline-styled HTML; the
+   plain-text fallback is derived via `toPlainText`.
+5. Subject is produced by the named `<name>Meta.subject(vars)` factory exported
+   from the same file (`password-reset.tsx` exports `passwordResetMeta`).
+
+## Where do project-specific templates go?
+
+Drop `.tsx` files into `src/modules/email/templates/`. Same shape as the core
+templates: `<name>.tsx` for the default, `<name>.<locale>.tsx` for locale
+variants. A file with the same basename as a core template **overrides** it —
+no registration call required. The discovery walker is in
+`email-templates.react.ts > discoverReactEmailTemplates()`.
+
+`bun run sync:from-template` only touches `src/core/email/{layouts,blocks,
+templates}/`. Module templates are guaranteed untouched — that's the override
+contract.
+
+## Brand-aware look + feel
+
+Every layout/block accepts an optional `brand?: BrandConfig`. The renderer
+injects the active brand into the props at render time, so individual
+templates don't need to import `defaultBrandConfig()` themselves. A single
+change in `brand.ts` propagates to every transactional email — that's the
+architectural gain over the previous EJS HTML strings, in which each template
+duplicated the frame markup.
+
+The brand-loader (read JSON + env overrides) is owned by issue #5; until it
+lands the EmailModule wires `resolveBrandConfig()` with no overrides.
+
+## Adding a new template
+
+1. Create `src/core/email/templates/<name>.tsx` (or
+   `src/modules/email/templates/<name>.tsx` for project-specific). Export:
+
+   ```tsx
+   export interface <Name>Vars { recipientName: string; /* ... */ }
+
+   export const <name>Meta = {
+     name: "<name>",
+     subject: (vars: <Name>Vars) => `…${vars.…}`,
+   };
+
+   export default function <Name>(props: <Name>Vars & { brand?: BrandConfig }) {
+     return (
+       <Barebone brand={props.brand} preheader="…">
+         <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+         {/* … */}
+       </Barebone>
+     );
+   }
+   ```
+
+2. Add a snapshot/story test under `tests/stories/email-templates-react.story.test.ts`
+   (or a sibling file) to lock the rendered HTML.
+3. If the template needs a sample payload in `/dev/email-preview`, extend
+   `buildEmailPreviewCatalog()` in `src/core/dx/email-preview.ts`.
+
+## Why two renderers coexist
+
+The legacy `EjsEmailTemplateRenderer` + `InMemoryEmailTemplateRegistry` are
+still exported from `email-templates.ts`. They cover registration-driven
+flows that don't have a `.tsx` file (rare, but possible). The default
+`EmailModule` uses the React-Email renderer; consumers can swap providers
+inside their bootstrap if they need the EJS path. The legacy stack is
+deprecated — favour `.tsx` for any new templates.
+
+## Hard rules
+
+- Templates are server-side React. No DOM APIs, no `process.env` reads inside
+  the component (use the brand config instead).
+- Inline styles only — `<style>` blocks and external stylesheets get stripped
+  by Gmail/Outlook.
+- Locale resolution is `<name>.<locale>.tsx` first, `<name>.tsx` as fallback.
+  No locale negotiation — caller passes the resolved locale string.
+- File-system discovery is sync (`existsSync` + `readdirSync`) for boot
+  predictability. The renderer's `import()` is async — that's the I/O surface.

--- a/src/core/email/blocks/CTA.tsx
+++ b/src/core/email/blocks/CTA.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import { Button, Section, Text } from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Call-to-action block — primary button with a fallback URL line.
+ *
+ * Email clients sometimes strip linked buttons (Outlook with strict
+ * security, plain-text mode); the secondary URL paragraph below the
+ * button keeps the action reachable as a copyable link. Button color
+ * is pulled from the brand config so a single brand tweak repaints
+ * every CTA across all templates.
+ */
+export interface CTAProps {
+  /** Destination URL — also rendered as a fallback copy-paste link. */
+  href: string;
+  /** Optional brand override; defaults to the built-in brand config. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function CTA(props: CTAProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+  return (
+    <Section style={{ padding: "8px 0" }}>
+      <Button
+        href={props.href}
+        style={{
+          display: "inline-block",
+          padding: "12px 24px",
+          borderRadius: 8,
+          background: brand.primaryColor,
+          color: brand.primaryColorInk,
+          textDecoration: "none",
+          fontWeight: 600,
+          fontSize: 14,
+          letterSpacing: "0.01em",
+        }}
+      >
+        {props.children}
+      </Button>
+      <Text
+        style={{
+          margin: "12px 0 4px",
+          fontSize: 12,
+          color: brand.mutedTextColor,
+        }}
+      >
+        If the button doesn&apos;t work, paste this URL into your browser:
+      </Text>
+      <Text
+        style={{
+          margin: 0,
+          fontSize: 12,
+          wordBreak: "break-all",
+          fontFamily: "'SFMono-Regular', Menlo, Consolas, monospace",
+        }}
+      >
+        <a href={props.href} style={{ color: brand.primaryColor, textDecoration: "none" }}>
+          {props.href}
+        </a>
+      </Text>
+    </Section>
+  );
+}

--- a/src/core/email/blocks/Code.tsx
+++ b/src/core/email/blocks/Code.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { Text } from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Code block — monospace background-tinted block for one-time codes
+ * (verification codes, magic-link tokens, OTP). Stays inline-styled
+ * so Gmail/Outlook render the box reliably.
+ */
+export interface CodeProps {
+  /** Optional brand override; defaults to the built-in brand config. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function Code(props: CodeProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+  return (
+    <Text
+      style={{
+        margin: "12px 0",
+        padding: "12px 16px",
+        background: "rgba(255,255,255,0.04)",
+        border: "1px solid rgba(255,255,255,0.06)",
+        borderRadius: 8,
+        fontFamily: "'SFMono-Regular', Menlo, Consolas, monospace",
+        fontSize: 14,
+        color: brand.primaryColor,
+        wordBreak: "break-all",
+      }}
+    >
+      {props.children}
+    </Text>
+  );
+}

--- a/src/core/email/blocks/Divider.tsx
+++ b/src/core/email/blocks/Divider.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { Hr } from "@react-email/components";
+
+/**
+ * Divider block — thin horizontal rule used between content
+ * sections. Stays subtle so it doesn't compete with the CTA button.
+ */
+export interface DividerProps {
+  /** Optional spacing override; defaults to comfortable section padding. */
+  spacing?: number;
+}
+
+export function Divider(props: DividerProps = {}): React.ReactElement {
+  const spacing = props.spacing ?? 18;
+  return (
+    <Hr
+      style={{
+        borderColor: "rgba(255,255,255,0.06)",
+        margin: `${spacing}px 0`,
+      }}
+    />
+  );
+}

--- a/src/core/email/blocks/Footer.tsx
+++ b/src/core/email/blocks/Footer.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { Section, Text } from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Footer block — small print at the bottom of the body. Used for
+ * "you can ignore this email" disclaimers + expiration hints. The
+ * Barebone layout already renders the legal entity / support row
+ * below the body, so this block is for *body-level* footers only.
+ */
+export interface FooterProps {
+  /** Optional brand override; defaults to the built-in brand config. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function Footer(props: FooterProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+  return (
+    <Section
+      style={{
+        marginTop: 24,
+        paddingTop: 18,
+        borderTop: "1px solid rgba(255,255,255,0.06)",
+      }}
+    >
+      <Text
+        style={{
+          margin: 0,
+          fontSize: 12,
+          color: brand.mutedTextColor,
+          lineHeight: 1.6,
+        }}
+      >
+        {props.children}
+      </Text>
+    </Section>
+  );
+}

--- a/src/core/email/blocks/Greeting.tsx
+++ b/src/core/email/blocks/Greeting.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { Text } from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Greeting block — the bold "Hello {name}," opener at the top of the
+ * body. Title-weight, slightly larger than paragraph copy.
+ */
+export interface GreetingProps {
+  /** Optional brand override (textColor); defaults to the built-in brand. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function Greeting(props: GreetingProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+  return (
+    <Text
+      style={{
+        margin: "0 0 14px",
+        fontSize: 18,
+        fontWeight: 600,
+        color: "#ffffff",
+        letterSpacing: "-0.015em",
+      }}
+      data-block="greeting"
+      data-brand-text={brand.textColor}
+    >
+      {props.children}
+    </Text>
+  );
+}

--- a/src/core/email/blocks/Paragraph.tsx
+++ b/src/core/email/blocks/Paragraph.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { Text } from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Paragraph block — a single body paragraph with brand-aware text
+ * color and comfortable line-height for transactional copy.
+ */
+export interface ParagraphProps {
+  /** Optional brand override; defaults to the built-in brand config. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function Paragraph(props: ParagraphProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+  return (
+    <Text
+      style={{
+        margin: "0 0 14px",
+        fontSize: 15,
+        lineHeight: 1.65,
+        color: brand.textColor,
+      }}
+    >
+      {props.children}
+    </Text>
+  );
+}

--- a/src/core/email/blocks/index.ts
+++ b/src/core/email/blocks/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Block-library re-exports — templates import from a single entry
+ * point so the layout-level import block in each template stays
+ * compact and consistent.
+ */
+
+export { Greeting, type GreetingProps } from "./Greeting.js";
+export { Paragraph, type ParagraphProps } from "./Paragraph.js";
+export { CTA, type CTAProps } from "./CTA.js";
+export { Footer, type FooterProps } from "./Footer.js";
+export { Code, type CodeProps } from "./Code.js";
+export { Divider, type DividerProps } from "./Divider.js";

--- a/src/core/email/brand.ts
+++ b/src/core/email/brand.ts
@@ -1,0 +1,75 @@
+/**
+ * Brand configuration consumed by the React-Email layouts.
+ *
+ * The brand interface is the contract layouts use to interpolate
+ * colors, brand text, the legal entity, and contact addresses into
+ * every transactional email. A single source of truth means changing
+ * `primaryColor` or `legalEntity` in one place propagates to every
+ * template that renders through `Barebone` (or any other brand-aware
+ * layout) — without editing four template files.
+ *
+ * The actual brand-loader (read JSON from disk, env-overrides, etc.)
+ * lands in issue #5. Until then we ship sensible defaults that match
+ * the dark + electric-lime accent of the Dev-Hub so previews look
+ * coherent out of the box. Consumers swap the values via
+ * `resolveBrandConfig({ primaryColor: "..." })` from their bootstrap.
+ */
+
+export interface BrandConfig {
+  /** Display name of the application — appears in headers + subjects. */
+  appName: string;
+  /** Primary CTA / accent color (hex). Used for buttons + dot logo. */
+  primaryColor: string;
+  /** Foreground color drawn on top of `primaryColor` (CTA label etc.). */
+  primaryColorInk: string;
+  /** Outer page background — the area around the email card. */
+  backgroundColor: string;
+  /** Card / surface background — the email body itself. */
+  surfaceColor: string;
+  /** Body text color used for paragraphs + greetings. */
+  textColor: string;
+  /** Muted / secondary text (footer, helper labels). */
+  mutedTextColor: string;
+  /** Optional logo URL; if `logoSvgInline` is set it takes precedence. */
+  logoUrl?: string;
+  /** Optional inline SVG markup for clients that strip remote images. */
+  logoSvgInline?: string;
+  /** Legal entity shown in the footer disclaimer. */
+  legalEntity: string;
+  /** Address displayed below the legal entity in the footer. */
+  legalAddress?: string;
+  /** Public-facing support address for "reply to a human" affordance. */
+  supportEmail: string;
+  /** Default `From:` envelope when the caller doesn't override. */
+  fromEmail: string;
+}
+
+/**
+ * Built-in brand defaults — match the dark + electric-lime theme of
+ * the Dev-Hub. Consumers override per-field via `resolveBrandConfig`.
+ */
+export function defaultBrandConfig(): BrandConfig {
+  return {
+    appName: "nest-base",
+    primaryColor: "#c5fb45",
+    primaryColorInk: "#0a0a0a",
+    backgroundColor: "#020203",
+    surfaceColor: "#06070a",
+    textColor: "#e4e4e7",
+    mutedTextColor: "#71717a",
+    legalEntity: "nest-base",
+    legalAddress: undefined,
+    supportEmail: "support@example.com",
+    fromEmail: "no-reply@example.com",
+  };
+}
+
+/**
+ * Apply a partial override on top of `defaultBrandConfig()`.
+ *
+ * Pure planner — no I/O, no env reads. The runtime loader (planned
+ * for issue #5) parses `brand.json`/env and feeds the result here.
+ */
+export function resolveBrandConfig(overrides: Partial<BrandConfig> = {}): BrandConfig {
+  return { ...defaultBrandConfig(), ...overrides };
+}

--- a/src/core/email/email-templates.react.ts
+++ b/src/core/email/email-templates.react.ts
@@ -1,0 +1,227 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import * as React from "react";
+import { render, toPlainText } from "@react-email/render";
+
+import { defaultBrandConfig, type BrandConfig } from "./brand.js";
+import type { EmailRenderedTemplate, EmailTemplateRenderer } from "./email.service.js";
+
+/**
+ * React-Email template loader + renderer.
+ *
+ * Templates live as `.tsx` files on disk:
+ *   - `src/core/email/templates/<name>.tsx`            — built-ins
+ *   - `src/modules/email/templates/<name>.tsx`         — project overlay
+ *   - `src/{core,modules}/email/templates/<name>.<locale>.tsx` — locale variants
+ *
+ * Resolution order:
+ *   1. `<name>.<locale>.tsx` from the module overlay
+ *   2. `<name>.<locale>.tsx` from core
+ *   3. `<name>.tsx` from the module overlay
+ *   4. `<name>.tsx` from core
+ *
+ * Discovery enumerates both folders at boot. The render path imports
+ * the matching module dynamically, calls the default export with the
+ * supplied vars, hands the React tree to `@react-email/render`, and
+ * extracts the subject from the named `<name>Meta.subject(vars)`
+ * factory.
+ *
+ * The planner half (path resolution) is exposed as
+ * `discoverReactEmailTemplates()` so tests can verify discovery
+ * without spinning up the renderer.
+ */
+
+export class ReactEmailTemplateNotFoundError extends Error {
+  constructor(name: string, locale: string) {
+    super(`react-email-templates: template "${name}" (locale="${locale}") not found`);
+    this.name = "ReactEmailTemplateNotFoundError";
+  }
+}
+
+export class ReactEmailTemplateInvalidError extends Error {
+  constructor(file: string, reason: string) {
+    super(`react-email-templates: template "${file}" is invalid: ${reason}`);
+    this.name = "ReactEmailTemplateInvalidError";
+  }
+}
+
+export interface DiscoveredTemplate {
+  /** Template basename (file stem with the locale suffix stripped). */
+  name: string;
+  /** Optional locale suffix (e.g. "de" for `password-reset.de.tsx`). */
+  locale: string | null;
+  /** Absolute path to the .tsx file. */
+  file: string;
+  /** Where the file was discovered — `module` overrides `core`. */
+  source: "core" | "module";
+}
+
+export interface DiscoverOptions {
+  /** Project root; defaults to `process.cwd()`. */
+  projectRoot?: string;
+  /** Override the core templates directory (used by tests). */
+  coreDir?: string;
+  /** Override the module templates directory (used by tests). */
+  moduleDir?: string;
+}
+
+const TEMPLATE_FILE_RE = /^([a-z0-9][a-z0-9-]*)(?:\.([a-z]{2}(?:-[A-Z]{2})?))?\.tsx$/;
+
+/**
+ * Discovers every `.tsx` template under the core + module folders.
+ * Pure function — no dynamic imports, just path enumeration. The
+ * runner (`ReactEmailTemplateRenderer.render`) calls this to build
+ * its lookup map.
+ */
+export async function discoverReactEmailTemplates(
+  options: DiscoverOptions = {},
+): Promise<DiscoveredTemplate[]> {
+  const root = options.projectRoot ?? process.cwd();
+  const coreDir = options.coreDir ?? resolve(root, "src/core/email/templates");
+  const moduleDir = options.moduleDir ?? resolve(root, "src/modules/email/templates");
+
+  const out: DiscoveredTemplate[] = [];
+  for (const file of listTsxFiles(coreDir)) {
+    const parsed = parseTemplateFilename(file);
+    if (!parsed) continue;
+    out.push({
+      name: parsed.name,
+      locale: parsed.locale,
+      file: join(coreDir, file),
+      source: "core",
+    });
+  }
+  for (const file of listTsxFiles(moduleDir)) {
+    const parsed = parseTemplateFilename(file);
+    if (!parsed) continue;
+    out.push({
+      name: parsed.name,
+      locale: parsed.locale,
+      file: join(moduleDir, file),
+      source: "module",
+    });
+  }
+  return out;
+}
+
+function listTsxFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  if (!statSync(dir).isDirectory()) return [];
+  return readdirSync(dir).filter((entry) => entry.endsWith(".tsx"));
+}
+
+function parseTemplateFilename(file: string): { name: string; locale: string | null } | null {
+  const match = TEMPLATE_FILE_RE.exec(file);
+  if (!match) return null;
+  return { name: match[1] ?? "", locale: match[2] ?? null };
+}
+
+export interface ReactEmailTemplateRendererOptions {
+  /** Brand config injected into every template's <Barebone> wrapper. */
+  brand?: BrandConfig;
+  /** Project root for discovery; defaults to `process.cwd()`. */
+  projectRoot?: string;
+  /** Override the core templates directory (used by tests). */
+  coreDir?: string;
+  /** Override the module templates directory (used by tests). */
+  moduleDir?: string;
+}
+
+interface TemplateModule {
+  default: (props: object) => React.ReactElement;
+  // Subject factory exported as `<name>Meta`. Indexed via convention.
+  [key: string]: unknown;
+}
+
+export class ReactEmailTemplateRenderer implements EmailTemplateRenderer {
+  private readonly brand: BrandConfig;
+  private readonly projectRoot: string;
+  private readonly coreDir: string;
+  private readonly moduleDir: string;
+
+  constructor(options: ReactEmailTemplateRendererOptions = {}) {
+    this.brand = options.brand ?? defaultBrandConfig();
+    this.projectRoot = options.projectRoot ?? process.cwd();
+    this.coreDir =
+      options.coreDir ?? resolve(this.projectRoot, "src/core/email/templates");
+    this.moduleDir =
+      options.moduleDir ?? resolve(this.projectRoot, "src/modules/email/templates");
+  }
+
+  async render(template: string, locale: string, vars: object): Promise<EmailRenderedTemplate> {
+    const resolved = this.resolveFile(template, locale);
+    if (!resolved) throw new ReactEmailTemplateNotFoundError(template, locale);
+
+    const mod = await this.importTemplate(resolved.file);
+    const Component = mod.default;
+    if (typeof Component !== "function") {
+      throw new ReactEmailTemplateInvalidError(resolved.file, "missing default export");
+    }
+    const meta = pickMeta(mod, template);
+    if (!meta) {
+      throw new ReactEmailTemplateInvalidError(
+        resolved.file,
+        `missing exported subject factory (expected "${metaExportName(template)}.subject")`,
+      );
+    }
+
+    const props = { ...(vars as Record<string, unknown>), brand: this.brand };
+    const element = Component(props);
+    const html = await render(element);
+    const text = toPlainText(html);
+    const subject = meta.subject(vars as never);
+    return { subject, html, text };
+  }
+
+  private resolveFile(name: string, locale: string): { file: string } | null {
+    // Lookup precedence (best match wins):
+    //   1. module / locale-specific
+    //   2. core / locale-specific
+    //   3. module / default
+    //   4. core / default
+    const candidates = [
+      join(this.moduleDir, `${name}.${locale}.tsx`),
+      join(this.coreDir, `${name}.${locale}.tsx`),
+      join(this.moduleDir, `${name}.tsx`),
+      join(this.coreDir, `${name}.tsx`),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) return { file: candidate };
+    }
+    return null;
+  }
+
+  private async importTemplate(file: string): Promise<TemplateModule> {
+    // Append a cache-buster so subsequent renders pick up edits when
+    // `bun --watch` reloads the source. The runtime caches by URL —
+    // a unique query string forces a fresh import per call. The cost
+    // is one re-evaluation per render; templates are tiny.
+    const url = `${pathToFileURL(file).href}?t=${Date.now()}`;
+    const mod = (await import(url)) as TemplateModule;
+    return mod;
+  }
+}
+
+function metaExportName(templateName: string): string {
+  // password-reset → passwordResetMeta
+  return (
+    templateName
+      .split("-")
+      .map((seg, i) => (i === 0 ? seg : seg.charAt(0).toUpperCase() + seg.slice(1)))
+      .join("") + "Meta"
+  );
+}
+
+interface MetaShape {
+  name: string;
+  subject: (vars: never) => string;
+}
+
+function pickMeta(mod: TemplateModule, templateName: string): MetaShape | null {
+  const exportName = metaExportName(templateName);
+  const candidate = mod[exportName] as MetaShape | undefined;
+  if (candidate && typeof candidate.subject === "function") return candidate;
+  return null;
+}

--- a/src/core/email/email-templates.react.ts
+++ b/src/core/email/email-templates.react.ts
@@ -144,10 +144,8 @@ export class ReactEmailTemplateRenderer implements EmailTemplateRenderer {
   constructor(options: ReactEmailTemplateRendererOptions = {}) {
     this.brand = options.brand ?? defaultBrandConfig();
     this.projectRoot = options.projectRoot ?? process.cwd();
-    this.coreDir =
-      options.coreDir ?? resolve(this.projectRoot, "src/core/email/templates");
-    this.moduleDir =
-      options.moduleDir ?? resolve(this.projectRoot, "src/modules/email/templates");
+    this.coreDir = options.coreDir ?? resolve(this.projectRoot, "src/core/email/templates");
+    this.moduleDir = options.moduleDir ?? resolve(this.projectRoot, "src/modules/email/templates");
   }
 
   async render(template: string, locale: string, vars: object): Promise<EmailRenderedTemplate> {

--- a/src/core/email/email.module.ts
+++ b/src/core/email/email.module.ts
@@ -1,5 +1,6 @@
 import { Logger, Module } from "@nestjs/common";
 
+import { resolveBrandConfig } from "./brand.js";
 import {
   type EmailDriver,
   type EmailMessage,
@@ -7,7 +8,7 @@ import {
   type EmailTemplateRenderer,
   EmailService,
 } from "./email.service.js";
-import { EjsEmailTemplateRenderer, buildBuiltInEmailTemplateRegistry } from "./email-templates.js";
+import { ReactEmailTemplateRenderer } from "./email-templates.react.js";
 
 /**
  * Logs the message to stdout instead of sending.  Default driver
@@ -44,14 +45,20 @@ class LogOnlyEmailDriver implements EmailDriver {
  * those dependencies are installed. Until then the log-only driver
  * lets verify-email / reset-password flows complete in dev without
  * a real outbound mail server.
+ *
+ * The template renderer is the file-based React-Email loader from
+ * issue #6 — templates live as `.tsx` under
+ * `src/core/email/templates/` (built-ins) and
+ * `src/modules/email/templates/` (project overrides).
  */
 @Module({
   providers: [
     {
       provide: EmailService,
       useFactory: (): EmailService => {
-        const registry = buildBuiltInEmailTemplateRegistry();
-        const renderer: EmailTemplateRenderer = new EjsEmailTemplateRenderer(registry);
+        const renderer: EmailTemplateRenderer = new ReactEmailTemplateRenderer({
+          brand: resolveBrandConfig(),
+        });
         return new EmailService({
           primary: new LogOnlyEmailDriver(),
           renderer,

--- a/src/core/email/layouts/Barebone.tsx
+++ b/src/core/email/layouts/Barebone.tsx
@@ -1,15 +1,6 @@
 import * as React from "react";
 
-import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-} from "@react-email/components";
+import { Body, Container, Head, Hr, Html, Preview, Section, Text } from "@react-email/components";
 
 import { defaultBrandConfig, type BrandConfig } from "../brand.js";
 

--- a/src/core/email/layouts/Barebone.tsx
+++ b/src/core/email/layouts/Barebone.tsx
@@ -1,0 +1,121 @@
+import * as React from "react";
+
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+
+import { defaultBrandConfig, type BrandConfig } from "../brand.js";
+
+/**
+ * Barebone layout — minimal frame inspired by react.email/01-Barebone.
+ *
+ * Acts as the default frame around every transactional email: page
+ * background, centered card, brand row at the top, footer at the
+ * bottom. Templates compose Greeting/Paragraph/CTA/Footer blocks as
+ * children — the layout wraps them and applies brand styling.
+ *
+ * Why a layout split: a single brand-color tweak in `brand.ts`
+ * propagates to every template that imports `<Barebone>`. The four
+ * built-ins (verification, password-reset, welcome, invitation) all
+ * share the same shell — no duplicated frame markup, no four-way
+ * find-and-replace when the marketing team wants a new accent color.
+ */
+export interface BareboneProps {
+  /** Inline preview text shown in mail clients before the recipient opens. */
+  preheader?: string;
+  /** Optional brand override; resolves to `defaultBrandConfig()` when absent. */
+  brand?: BrandConfig;
+  children: React.ReactNode;
+}
+
+export function Barebone(props: BareboneProps): React.ReactElement {
+  const brand = props.brand ?? defaultBrandConfig();
+
+  return (
+    <Html>
+      <Head />
+      {props.preheader ? <Preview>{props.preheader}</Preview> : null}
+      <Body
+        style={{
+          margin: 0,
+          padding: "24px 16px",
+          background: brand.backgroundColor,
+          color: brand.textColor,
+          fontFamily:
+            "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
+        }}
+      >
+        <Container
+          style={{
+            maxWidth: 560,
+            margin: "0 auto",
+            background: brand.surfaceColor,
+            border: "1px solid rgba(255,255,255,0.06)",
+            borderRadius: 14,
+            overflow: "hidden",
+          }}
+        >
+          <Section
+            style={{
+              padding: "24px 28px",
+              borderBottom: "1px solid rgba(255,255,255,0.06)",
+            }}
+          >
+            <Text
+              style={{
+                margin: 0,
+                fontSize: 16,
+                fontWeight: 600,
+                color: "#ffffff",
+                letterSpacing: "-0.01em",
+              }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 8,
+                  height: 8,
+                  background: brand.primaryColor,
+                  borderRadius: 999,
+                  marginRight: 8,
+                  verticalAlign: "middle",
+                }}
+              />
+              {brand.appName}
+            </Text>
+          </Section>
+
+          <Section style={{ padding: "28px 28px 20px" }}>{props.children}</Section>
+
+          <Hr style={{ borderColor: "rgba(255,255,255,0.06)", margin: 0 }} />
+          <Section
+            style={{
+              padding: "18px 28px",
+              background: "#0c0d11",
+              fontSize: 11,
+              color: brand.mutedTextColor,
+              textAlign: "center",
+              letterSpacing: "0.04em",
+            }}
+          >
+            <Text style={{ margin: 0, color: brand.mutedTextColor, fontSize: 11 }}>
+              Sent by {brand.legalEntity} · This is an automated message.
+            </Text>
+            {brand.supportEmail ? (
+              <Text style={{ margin: "4px 0 0", color: brand.mutedTextColor, fontSize: 11 }}>
+                Need help? {brand.supportEmail}
+              </Text>
+            ) : null}
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/core/email/templates/email-verification.tsx
+++ b/src/core/email/templates/email-verification.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+import { Barebone } from "../layouts/Barebone.js";
+import { CTA, Footer, Greeting, Paragraph } from "../blocks/index.js";
+import type { BrandConfig } from "../brand.js";
+
+/**
+ * Email-verification template.
+ *
+ * Sent right after sign-up. Confirms the recipient owns the address
+ * before account-bearing flows can use it (login, password reset).
+ */
+export interface EmailVerificationVars {
+  recipientName: string;
+  appName: string;
+  verificationUrl: string;
+}
+
+export const emailVerificationMeta = {
+  name: "email-verification",
+  subject: (_vars: EmailVerificationVars): string => "Please verify your email",
+};
+
+export interface EmailVerificationProps extends EmailVerificationVars {
+  brand?: BrandConfig;
+}
+
+export default function EmailVerification(props: EmailVerificationProps): React.ReactElement {
+  return (
+    <Barebone brand={props.brand} preheader="Confirm your email address">
+      <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+      <Paragraph brand={props.brand}>
+        Welcome to {props.appName}! Please confirm this is your address so we know where to send
+        important account updates.
+      </Paragraph>
+      <CTA brand={props.brand} href={props.verificationUrl}>
+        Verify email
+      </CTA>
+      <Footer brand={props.brand}>
+        The verification link is valid for 24 hours. If you did not sign up, you can safely ignore
+        this email.
+      </Footer>
+    </Barebone>
+  );
+}

--- a/src/core/email/templates/invitation.tsx
+++ b/src/core/email/templates/invitation.tsx
@@ -31,10 +31,7 @@ export interface InvitationProps extends InvitationVars {
 export default function Invitation(props: InvitationProps): React.ReactElement {
   const accentColor = props.brand?.primaryColor ?? "#c5fb45";
   return (
-    <Barebone
-      brand={props.brand}
-      preheader={`${props.senderName} invited you to ${props.appName}`}
-    >
+    <Barebone brand={props.brand} preheader={`${props.senderName} invited you to ${props.appName}`}>
       <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
       <Paragraph brand={props.brand}>
         <strong style={{ color: accentColor }}>{props.senderName}</strong> has invited you to join{" "}

--- a/src/core/email/templates/invitation.tsx
+++ b/src/core/email/templates/invitation.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { Barebone } from "../layouts/Barebone.js";
+import { CTA, Footer, Greeting, Paragraph } from "../blocks/index.js";
+import type { BrandConfig } from "../brand.js";
+
+/**
+ * Invitation template.
+ *
+ * Sent when an existing user invites someone to their tenant. The
+ * sender's name is highlighted so the recipient immediately sees who
+ * the invitation is from — invitations from unknown senders go
+ * straight to the spam folder anyway.
+ */
+export interface InvitationVars {
+  recipientName: string;
+  senderName: string;
+  appName: string;
+  acceptUrl: string;
+}
+
+export const invitationMeta = {
+  name: "invitation",
+  subject: (vars: InvitationVars): string => `You have been invited to ${vars.appName}`,
+};
+
+export interface InvitationProps extends InvitationVars {
+  brand?: BrandConfig;
+}
+
+export default function Invitation(props: InvitationProps): React.ReactElement {
+  const accentColor = props.brand?.primaryColor ?? "#c5fb45";
+  return (
+    <Barebone
+      brand={props.brand}
+      preheader={`${props.senderName} invited you to ${props.appName}`}
+    >
+      <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+      <Paragraph brand={props.brand}>
+        <strong style={{ color: accentColor }}>{props.senderName}</strong> has invited you to join{" "}
+        {props.appName}.
+      </Paragraph>
+      <Paragraph brand={props.brand}>
+        Accept the invitation to set up your account and start collaborating.
+      </Paragraph>
+      <CTA brand={props.brand} href={props.acceptUrl}>
+        Accept invitation
+      </CTA>
+      <Footer brand={props.brand}>
+        Invitations expire after 7 days. If you weren&apos;t expecting this, you can ignore the
+        email.
+      </Footer>
+    </Barebone>
+  );
+}

--- a/src/core/email/templates/password-reset.tsx
+++ b/src/core/email/templates/password-reset.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+
+import { Barebone } from "../layouts/Barebone.js";
+import { CTA, Footer, Greeting, Paragraph } from "../blocks/index.js";
+import type { BrandConfig } from "../brand.js";
+
+/**
+ * Password-reset template.
+ *
+ * Sent when the user requests a password-reset link. Subject pulls
+ * the appName so the message reads natural across multi-brand
+ * deployments — `Reset your Acme password` instead of a generic
+ * fallback.
+ */
+export interface PasswordResetVars {
+  recipientName: string;
+  appName: string;
+  resetUrl: string;
+}
+
+export const passwordResetMeta = {
+  name: "password-reset",
+  subject: (vars: PasswordResetVars): string => `Reset your ${vars.appName} password`,
+};
+
+export interface PasswordResetProps extends PasswordResetVars {
+  brand?: BrandConfig;
+}
+
+export default function PasswordReset(props: PasswordResetProps): React.ReactElement {
+  return (
+    <Barebone brand={props.brand} preheader={`Reset your ${props.appName} password`}>
+      <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+      <Paragraph brand={props.brand}>
+        We received a request to reset your password. Click the button below to choose a new one.
+      </Paragraph>
+      <CTA brand={props.brand} href={props.resetUrl}>
+        Reset password
+      </CTA>
+      <Footer brand={props.brand}>
+        If you did not request a password reset, you can safely ignore this email — your password
+        stays unchanged.
+      </Footer>
+    </Barebone>
+  );
+}

--- a/src/core/email/templates/welcome.tsx
+++ b/src/core/email/templates/welcome.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { Barebone } from "../layouts/Barebone.js";
+import { Greeting, Paragraph } from "../blocks/index.js";
+import type { BrandConfig } from "../brand.js";
+
+/**
+ * Welcome template.
+ *
+ * Optional onboarding email sent after a verified login. Keeps the
+ * voice friendly + short — the verification flow handles the
+ * "important next step" nudges so this just confirms readiness.
+ */
+export interface WelcomeVars {
+  recipientName: string;
+  appName: string;
+}
+
+export const welcomeMeta = {
+  name: "welcome",
+  subject: (vars: WelcomeVars): string => `Welcome to ${vars.appName}`,
+};
+
+export interface WelcomeProps extends WelcomeVars {
+  brand?: BrandConfig;
+}
+
+export default function Welcome(props: WelcomeProps): React.ReactElement {
+  return (
+    <Barebone brand={props.brand} preheader={`Welcome to ${props.appName}`}>
+      <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+      <Paragraph brand={props.brand}>
+        Welcome to {props.appName}! Your account is ready to go.
+      </Paragraph>
+      <Paragraph brand={props.brand}>
+        Reach out any time — we&apos;re glad to have you.
+      </Paragraph>
+    </Barebone>
+  );
+}

--- a/src/core/email/templates/welcome.tsx
+++ b/src/core/email/templates/welcome.tsx
@@ -32,9 +32,7 @@ export default function Welcome(props: WelcomeProps): React.ReactElement {
       <Paragraph brand={props.brand}>
         Welcome to {props.appName}! Your account is ready to go.
       </Paragraph>
-      <Paragraph brand={props.brand}>
-        Reach out any time — we&apos;re glad to have you.
-      </Paragraph>
+      <Paragraph brand={props.brand}>Reach out any time — we&apos;re glad to have you.</Paragraph>
     </Barebone>
   );
 }

--- a/tests/stories/email-templates-react.story.test.ts
+++ b/tests/stories/email-templates-react.story.test.ts
@@ -2,8 +2,12 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { render as renderEmail } from "@react-email/render";
+import * as React from "react";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { Code, Divider, Footer, Greeting, Paragraph } from "../../src/core/email/blocks/index.js";
+import { Barebone } from "../../src/core/email/layouts/Barebone.js";
 import {
   defaultBrandConfig,
   resolveBrandConfig,
@@ -11,6 +15,7 @@ import {
 } from "../../src/core/email/brand.js";
 import {
   ReactEmailTemplateRenderer,
+  ReactEmailTemplateInvalidError,
   ReactEmailTemplateNotFoundError,
   discoverReactEmailTemplates,
 } from "../../src/core/email/email-templates.react.js";
@@ -167,6 +172,71 @@ describe("Story · React-Email Templates", () => {
       }
     });
 
+    it("ReactEmailTemplateNotFoundError carries the template name + locale", () => {
+      const err = new ReactEmailTemplateNotFoundError("welcome", "de");
+      expect(err.name).toBe("ReactEmailTemplateNotFoundError");
+      expect(err.message).toContain("welcome");
+      expect(err.message).toContain("de");
+    });
+
+    it("ReactEmailTemplateInvalidError carries the file path", () => {
+      const err = new ReactEmailTemplateInvalidError("/abs/path/welcome.tsx", "missing meta");
+      expect(err.name).toBe("ReactEmailTemplateInvalidError");
+      expect(err.message).toContain("welcome.tsx");
+      expect(err.message).toContain("missing meta");
+    });
+
+    it("throws ReactEmailTemplateInvalidError when the template lacks a default export", async () => {
+      const tmpRoot = mkdtempSync(join(tmpdir(), "tpl-invalid-default-"));
+      try {
+        const moduleDir = join(tmpRoot, "src/modules/email/templates");
+        mkdirSync(moduleDir, { recursive: true });
+        writeFileSync(
+          join(moduleDir, "broken.tsx"),
+          [
+            // Intentional: no default export → renderer must complain.
+            "export const brokenMeta = { name: 'broken', subject: () => 'broken' };",
+          ].join("\n"),
+        );
+        const renderer = new ReactEmailTemplateRenderer({
+          brand: defaultBrandConfig(),
+          projectRoot: tmpRoot,
+        });
+        await expect(renderer.render("broken", "en", {})).rejects.toThrow(
+          ReactEmailTemplateInvalidError,
+        );
+      } finally {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
+    it("throws ReactEmailTemplateInvalidError when the template lacks a Meta export", async () => {
+      const tmpRoot = mkdtempSync(join(tmpdir(), "tpl-invalid-meta-"));
+      try {
+        const moduleDir = join(tmpRoot, "src/modules/email/templates");
+        mkdirSync(moduleDir, { recursive: true });
+        writeFileSync(
+          join(moduleDir, "no-meta.tsx"),
+          [
+            "import * as React from 'react';",
+            // Intentional: no `<name>Meta` export → subject lookup fails.
+            "export default function NoMeta() {",
+            "  return React.createElement('p', null, 'x');",
+            "}",
+          ].join("\n"),
+        );
+        const renderer = new ReactEmailTemplateRenderer({
+          brand: defaultBrandConfig(),
+          projectRoot: tmpRoot,
+        });
+        await expect(renderer.render("no-meta", "en", {})).rejects.toThrow(
+          ReactEmailTemplateInvalidError,
+        );
+      } finally {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
     describe("locale-suffix lookup", () => {
       const tmpRoot = mkdtempSync(join(tmpdir(), "tpl-locale-"));
       const moduleDir = join(tmpRoot, "src/modules/email/templates");
@@ -218,6 +288,76 @@ describe("Story · React-Email Templates", () => {
         expect(out.subject).toBe("EN");
         expect(out.html).toContain("english");
       });
+    });
+  });
+
+  describe("Block library renders independently", () => {
+    // Each block is exercised through the live renderer so that the
+    // inline-styled HTML output is verifiable, not just the React tree
+    // shape. Code + Divider have no built-in template that uses them
+    // yet — these tests pin their rendered surface so the block stays
+    // covered when consumers eventually adopt them.
+
+    async function renderShell(child: React.ReactNode): Promise<string> {
+      return renderEmail(React.createElement(Barebone, { children: child }));
+    }
+
+    it("Greeting renders the children inside a heading-weight element", async () => {
+      const html = await renderShell(React.createElement(Greeting, null, "Hello there"));
+      expect(html).toContain("Hello there");
+      expect(html).toContain("font-weight:600");
+    });
+
+    it("Paragraph renders body copy with the brand text color", async () => {
+      const brand: BrandConfig = resolveBrandConfig({ textColor: "#abc123" });
+      const html = await renderShell(React.createElement(Paragraph, { brand }, "paragraph copy"));
+      expect(html).toContain("paragraph copy");
+      expect(html.toLowerCase()).toContain("#abc123");
+    });
+
+    it("Footer renders muted small print", async () => {
+      const brand: BrandConfig = resolveBrandConfig({ mutedTextColor: "#998877" });
+      const html = await renderShell(React.createElement(Footer, { brand }, "footer text"));
+      expect(html).toContain("footer text");
+      expect(html.toLowerCase()).toContain("#998877");
+    });
+
+    it("Code renders monospace-styled token block colored with the brand primary", async () => {
+      const brand: BrandConfig = resolveBrandConfig({ primaryColor: "#33ddee" });
+      const html = await renderShell(React.createElement(Code, { brand }, "TOKEN-ABC-123"));
+      expect(html).toContain("TOKEN-ABC-123");
+      expect(html.toLowerCase()).toContain("#33ddee");
+      expect(html.toLowerCase()).toMatch(/font-family:[^;]*menlo|consolas|sfmono/i);
+    });
+
+    it("Divider renders a horizontal rule with the configured spacing", async () => {
+      const html = await renderShell(React.createElement(Divider, { spacing: 42 }));
+      expect(html.toLowerCase()).toContain("<hr");
+      expect(html).toContain("42px");
+    });
+
+    it("Divider falls back to the default spacing when no override is given", async () => {
+      const html = await renderShell(React.createElement(Divider));
+      expect(html.toLowerCase()).toContain("<hr");
+    });
+
+    it("Barebone renders the preheader when supplied", async () => {
+      const html = await renderEmail(
+        React.createElement(
+          Barebone,
+          { preheader: "preheader-text-marker" },
+          React.createElement(Paragraph, null, "body"),
+        ),
+      );
+      expect(html).toContain("preheader-text-marker");
+    });
+
+    it("Barebone hides the support row when supportEmail is empty", async () => {
+      const brand: BrandConfig = resolveBrandConfig({ supportEmail: "" });
+      const html = await renderEmail(
+        React.createElement(Barebone, { brand }, React.createElement(Paragraph, null, "body")),
+      );
+      expect(html).not.toContain("Need help?");
     });
   });
 });

--- a/tests/stories/email-templates-react.story.test.ts
+++ b/tests/stories/email-templates-react.story.test.ts
@@ -1,0 +1,223 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  defaultBrandConfig,
+  resolveBrandConfig,
+  type BrandConfig,
+} from "../../src/core/email/brand.js";
+import {
+  ReactEmailTemplateRenderer,
+  ReactEmailTemplateNotFoundError,
+  discoverReactEmailTemplates,
+} from "../../src/core/email/email-templates.react.js";
+
+/**
+ * Story · React-Email Templates.
+ *
+ * Templates live as `.tsx` on disk. Discovery enumerates the core
+ * folder + the project-overlay folder; project files override core
+ * files when their basename matches. Locale-suffix resolution
+ * (`<name>.<locale>.tsx`) wins over the locale-less default.
+ *
+ * The renderer dynamically imports the module, calls the React
+ * component, hands the tree to `@react-email/render`, and pulls the
+ * subject from `<name>Meta.subject(vars)`.
+ */
+describe("Story · React-Email Templates", () => {
+  describe("brand.ts (default brand)", () => {
+    it("provides safe default brand values for layouts", () => {
+      const brand = defaultBrandConfig();
+      expect(brand.appName).toBeTruthy();
+      expect(brand.primaryColor).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(brand.primaryColorInk).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(brand.backgroundColor).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(brand.surfaceColor).toMatch(/^#[0-9a-f]{3,8}$/i);
+      expect(brand.legalEntity).toBeTruthy();
+      expect(brand.supportEmail).toMatch(/@/);
+      expect(brand.fromEmail).toMatch(/@/);
+    });
+
+    it("resolveBrandConfig() merges overrides into the default", () => {
+      const merged = resolveBrandConfig({ appName: "Acme", primaryColor: "#ff0000" });
+      expect(merged.appName).toBe("Acme");
+      expect(merged.primaryColor).toBe("#ff0000");
+      // untouched fields keep the default
+      expect(merged.legalEntity).toBe(defaultBrandConfig().legalEntity);
+    });
+  });
+
+  describe("Barebone layout + blocks render to inline-styled HTML", () => {
+    it("password-reset built-in template renders the recipient + reset URL + brand-aware CTA color", async () => {
+      const renderer = new ReactEmailTemplateRenderer({ brand: defaultBrandConfig() });
+      const out = await renderer.render("password-reset", "en", {
+        recipientName: "Pascal",
+        appName: "Acme",
+        resetUrl: "https://app.example.test/reset?token=preview",
+      });
+
+      expect(out.subject).toMatch(/reset/i);
+      // Subject template uses appName variable
+      expect(out.subject).toContain("Acme");
+      // Body shows the user content
+      expect(out.html).toContain("Pascal");
+      expect(out.html).toContain("https://app.example.test/reset?token=preview");
+      // Inline style only — no <style> blocks (Gmail/Outlook strip those)
+      expect(out.html).not.toMatch(/<style[^>]*>/i);
+      // CTA picked up the brand primary color
+      expect(out.html.toLowerCase()).toContain(defaultBrandConfig().primaryColor.toLowerCase());
+      // Plain-text fallback is non-empty + escapes the URL plainly
+      expect(out.text).toContain("https://app.example.test/reset?token=preview");
+    });
+
+    it("email-verification template uses the verificationUrl variable", async () => {
+      const renderer = new ReactEmailTemplateRenderer({ brand: defaultBrandConfig() });
+      const out = await renderer.render("email-verification", "en", {
+        recipientName: "Pascal",
+        appName: "Acme",
+        verificationUrl: "https://app.example.test/verify?token=preview",
+      });
+      expect(out.subject).toMatch(/verify/i);
+      expect(out.html).toContain("https://app.example.test/verify?token=preview");
+      expect(out.text).toContain("https://app.example.test/verify?token=preview");
+    });
+
+    it("welcome template renders the recipient + appName", async () => {
+      const renderer = new ReactEmailTemplateRenderer({ brand: defaultBrandConfig() });
+      const out = await renderer.render("welcome", "en", {
+        recipientName: "Pascal",
+        appName: "Acme",
+      });
+      expect(out.html).toContain("Pascal");
+      expect(out.html).toContain("Acme");
+      expect(out.text).toContain("Pascal");
+    });
+
+    it("invitation template renders sender + accept URL", async () => {
+      const renderer = new ReactEmailTemplateRenderer({ brand: defaultBrandConfig() });
+      const out = await renderer.render("invitation", "en", {
+        recipientName: "Pascal",
+        senderName: "Alice",
+        appName: "Acme",
+        acceptUrl: "https://app.example.test/invitations/preview/accept",
+      });
+      expect(out.html).toContain("Alice");
+      expect(out.html).toContain("https://app.example.test/invitations/preview/accept");
+    });
+
+    it("brand override propagates to the rendered HTML for every template", async () => {
+      // Rationale: the central architectural gain over the EJS strings —
+      // change brand.primaryColor and every template that imports the
+      // shared layout shows the new color in the same render call.
+      const brand: BrandConfig = resolveBrandConfig({ primaryColor: "#ff00aa" });
+      const renderer = new ReactEmailTemplateRenderer({ brand });
+      const out = await renderer.render("password-reset", "en", {
+        recipientName: "Pascal",
+        appName: "Acme",
+        resetUrl: "https://app.example.test/reset?token=preview",
+      });
+      expect(out.html.toLowerCase()).toContain("#ff00aa");
+    });
+  });
+
+  describe("ReactEmailTemplateRenderer · discovery + overrides", () => {
+    it("throws ReactEmailTemplateNotFoundError when the template does not exist", async () => {
+      const renderer = new ReactEmailTemplateRenderer({ brand: defaultBrandConfig() });
+      await expect(renderer.render("does-not-exist", "en", {})).rejects.toThrow(
+        ReactEmailTemplateNotFoundError,
+      );
+    });
+
+    it("discoverReactEmailTemplates() lists all four built-in templates", async () => {
+      const discovery = await discoverReactEmailTemplates();
+      const names = discovery.map((t) => t.name).sort();
+      expect(names).toEqual(
+        expect.arrayContaining(["email-verification", "invitation", "password-reset", "welcome"]),
+      );
+    });
+
+    it("project-overlay file overrides the core file with the same basename", async () => {
+      const tmpRoot = mkdtempSync(join(tmpdir(), "tpl-override-"));
+      try {
+        const moduleDir = join(tmpRoot, "src/modules/email/templates");
+        mkdirSync(moduleDir, { recursive: true });
+        writeFileSync(
+          join(moduleDir, "welcome.tsx"),
+          [
+            "import * as React from 'react';",
+            "export const welcomeMeta = {",
+            "  name: 'welcome',",
+            "  subject: () => 'OVERRIDDEN_SUBJECT',",
+            "};",
+            "export default function Welcome(props) {",
+            "  return React.createElement('div', null, 'OVERRIDDEN_BODY:' + props.recipientName);",
+            "}",
+          ].join("\n"),
+        );
+
+        const discovery = await discoverReactEmailTemplates({ projectRoot: tmpRoot });
+        const welcome = discovery.find((t) => t.name === "welcome");
+        expect(welcome?.source).toBe("module");
+        expect(welcome?.file).toContain(moduleDir);
+      } finally {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
+    describe("locale-suffix lookup", () => {
+      const tmpRoot = mkdtempSync(join(tmpdir(), "tpl-locale-"));
+      const moduleDir = join(tmpRoot, "src/modules/email/templates");
+
+      beforeAll(() => {
+        mkdirSync(moduleDir, { recursive: true });
+        writeFileSync(
+          join(moduleDir, "newsletter.tsx"),
+          [
+            "import * as React from 'react';",
+            "export const newsletterMeta = { name: 'newsletter', subject: () => 'EN' };",
+            "export default function Newsletter() {",
+            "  return React.createElement('p', null, 'english');",
+            "}",
+          ].join("\n"),
+        );
+        writeFileSync(
+          join(moduleDir, "newsletter.de.tsx"),
+          [
+            "import * as React from 'react';",
+            "export const newsletterMeta = { name: 'newsletter', subject: () => 'DE' };",
+            "export default function NewsletterDe() {",
+            "  return React.createElement('p', null, 'deutsch');",
+            "}",
+          ].join("\n"),
+        );
+      });
+
+      afterAll(() => {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      });
+
+      it("renders the locale variant when present", async () => {
+        const renderer = new ReactEmailTemplateRenderer({
+          brand: defaultBrandConfig(),
+          projectRoot: tmpRoot,
+        });
+        const out = await renderer.render("newsletter", "de", {});
+        expect(out.subject).toBe("DE");
+        expect(out.html).toContain("deutsch");
+      });
+
+      it("falls back to the locale-less default when no variant exists", async () => {
+        const renderer = new ReactEmailTemplateRenderer({
+          brand: defaultBrandConfig(),
+          projectRoot: tmpRoot,
+        });
+        const out = await renderer.render("newsletter", "fr", {});
+        expect(out.subject).toBe("EN");
+        expect(out.html).toContain("english");
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,7 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": false,
     "allowSyntheticDefaultImports": true,
+    "jsx": "react-jsx",
     "ignoreDeprecations": "6.0"
   },
   "include": ["src/**/*", "tests/**/*", "scripts/**/*", "vitest.config.ts"],


### PR DESCRIPTION
## Summary

- New brand contract: `src/core/email/brand.ts` (`BrandConfig`, `defaultBrandConfig`, `resolveBrandConfig`) — a single source of truth so a `primaryColor` tweak repaints every transactional email.
- Built-In templates ship as `.tsx`: `src/core/email/templates/{email-verification,password-reset,welcome,invitation}.tsx`, each composing `Barebone` + the new `Greeting`/`Paragraph`/`CTA`/`Footer`/`Code`/`Divider` block library.
- `Barebone` layout + block library under `src/core/email/{layouts,blocks}/` — inline-styled, brand-aware, Gmail/Outlook-safe.
- `ReactEmailTemplateRenderer` (`src/core/email/email-templates.react.ts`) implements the existing `EmailTemplateRenderer` contract: file-system discovery (core + module overlay with module precedence), locale-suffix lookup (`<name>.<locale>.tsx`), dynamic import with cache-buster for `bun --watch`.
- `EmailModule` now wires the React renderer; the legacy EJS renderer + in-memory registry remain exported for back-compat (registration-only flows).
- New deps: `@react-email/render`, `@react-email/components`. JSX support enabled in the root `tsconfig.json` so server-side `.tsx` files type-check.
- `src/core/email/CLAUDE.md` documents the layout/blocks/templates split, the override contract, and how to add a new template.

## Test plan

- [x] `bun run lint`
- [x] `bun run format`
- [x] `bun run test:types`
- [x] `bun run test:unit` (139 tests)
- [x] `bun run build:dev-portal`
- [x] `bun run test:e2e` (1784 tests)
- [x] `bun run test:coverage` (`core/email` 96 % statements / 90 % branches; new files all 100 % statements)
- [x] `bun run build`
- [ ] CI green (this PR)

Closes #6