### PR TITLE
feat(geo-ip): dbip-lite default + maxmind opt-in (closes #12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,17 @@ POWERSYNC_TOKEN=
 # Geo (PostGIS, geocoding)
 # FEATURE_GEO_ENABLED=false
 # FEATURE_GEO_PROVIDER=nominatim
+
+# GeoIP (offline IP→country/city lookup via .mmdb)
+# Default provider `dbip-lite` is CC-BY-4.0, no key required, monthly snapshot.
+# `bun run scripts/download-geoip.ts` populates `./data/geoip/city.mmdb`.
+# FEATURE_GEO_IP_ENABLED=false
+# FEATURE_GEO_IP_PROVIDER=dbip-lite
+# FEATURE_GEO_IP_DB_PATH=./data/geoip/city.mmdb
+#
+# Opt-in: MaxMind GeoLite2-City for higher accuracy + weekly updates.
+# Free signup at https://www.maxmind.com/en/geolite2/signup. NB: every
+# download leaks the caller's IP to MaxMind — pick `dbip-lite` for
+# Schrems-II-strict setups.
+# FEATURE_GEO_IP_PROVIDER=maxmind
+# FEATURE_GEO_IP_LICENSE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,13 @@ prisma/migrations/20260428000200_postgis_extension/
 prisma/migrations/20260428000250_geo_schema/
 prisma/migrations/20260428000300_geo_gist_indexes/
 
+# GeoIP database files — binary .mmdb downloads, never committed.
+# `bun run scripts/download-geoip.ts` (or the `geoip-init` compose
+# service) repopulates them from dbip-lite (CC-BY-4.0) or MaxMind
+# (EULA + license_key). Attribution lives in README.md.
+data/geoip/
+*.mmdb
+*.mmdb.gz
+
 # OS-specific
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Permission tester, audit browser, search tester, webhook inspector, realtime ins
 | | PowerSync (offline-first) | ✗ | `FEATURE_POWERSYNC_ENABLED` |
 | | Field Encryption (AES-256-GCM) | ✗ | `FEATURE_FIELD_ENCRYPTION_ENABLED` |
 | | Geo / Places (geocoding cache) | ✗ | `FEATURE_GEO_ENABLED` |
+| | GeoIP (offline IP→country/city via .mmdb) | ✗ | `FEATURE_GEO_IP_ENABLED` |
 | **Communication** | Email (Nodemailer + Brevo) | ✓ | `FEATURE_EMAIL_ENABLED` |
 | | Realtime (LISTEN/NOTIFY + Socket.IO) | ✗ | `FEATURE_REALTIME_ENABLED` |
 | **Integration** | Webhooks (HMAC-signed + retry) | ✗ | `FEATURE_WEBHOOKS_ENABLED` |
@@ -384,6 +385,25 @@ A fresh agent reads [`.claude/QUICKSTART.md`](./.claude/QUICKSTART.md) (60 sec) 
 ## 📜 License
 
 MIT — see [`LICENSE`](./LICENSE).
+
+### Third-party data attribution
+
+The GeoIP feature reads `.mmdb` files produced by the configured
+provider. The data is **not** redistributed with this template — each
+deployment downloads its own copy at install time — but using it
+imposes the provider's terms.
+
+- **dbip-lite** (default): IP-to-City Lite database © db-ip.com.
+  Distributed under the
+  [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+  When you ship a product surface that exposes geo-derived data
+  (e.g. "login from Berlin" e-mails), credit "IP geolocation by
+  [db-ip.com](https://db-ip.com)" somewhere accessible to end users
+  (privacy notice or settings page is fine).
+- **MaxMind GeoLite2** (opt-in): subject to the
+  [MaxMind GeoLite2 EULA](https://www.maxmind.com/en/geolite2/eula).
+  Free signup + license key required; downloads track the requesting
+  IP. Pick `dbip-lite` for Schrems-II-strict deployments.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,9 @@
         "typescript": "^6.0.3",
         "vitest": "^4.1.5",
       },
+      "optionalDependencies": {
+        "maxmind": "^5",
+      },
     },
   },
   "packages": {
@@ -1383,6 +1386,8 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "maxmind": ["maxmind@5.0.6", "", { "dependencies": { "mmdb-lib": "3.0.2", "tiny-lru": "13.0.0" } }, "sha512-5bvd/u+kIaTqaGM+xkXjatzQw1dQfSmlLggr2W1EKMyMxSgx2woZyusLpNpZ4DdPmL+1bbJWeo4LXsi6bC0Iew=="],
+
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
     "memfs": ["memfs@3.6.0", "", { "dependencies": { "fs-monkey": "^1.0.4" } }, "sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ=="],
@@ -1412,6 +1417,8 @@
     "mkdirp": ["mkdirp@3.0.1", "", { "bin": { "mkdirp": "dist/cjs/src/bin.js" } }, "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "mmdb-lib": ["mmdb-lib@3.0.2", "", {}, "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1816,6 +1823,8 @@
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
     "timers-ext": ["timers-ext@0.1.8", "", { "dependencies": { "es5-ext": "^0.10.64", "next-tick": "^1.1.0" } }, "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww=="],
+
+    "tiny-lru": ["tiny-lru@13.0.0", "", {}, "sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,49 @@ services:
       - '4317:4317' # OTLP gRPC
       - '4318:4318' # OTLP HTTP
 
+  # Oneshot service: downloads + extracts the GeoIP `.mmdb` on first
+  # `docker compose up`. Profile-gated so it doesn't run by default —
+  # opt in with `docker compose --profile geoip up geoip-init`.
+  # The api container can mount `./data/geoip:/data/geoip:ro` to read
+  # the database without owning the download lifecycle.
+  geoip-init:
+    profiles: ['geoip']
+    image: alpine:3.20
+    env_file:
+      - .env
+    volumes:
+      - ./data/geoip:/data/geoip
+    # Default to dbip-lite (no license key needed, CC-BY-4.0). Override
+    # with FEATURE_GEO_IP_PROVIDER=maxmind + FEATURE_GEO_IP_LICENSE_KEY.
+    command: |
+      sh -c '
+        set -eu
+        provider="${FEATURE_GEO_IP_PROVIDER:-dbip-lite}"
+        target=/data/geoip/city.mmdb
+        mkdir -p /data/geoip
+        apk add --no-cache curl gzip tar >/dev/null
+        if [ "$$provider" = "dbip-lite" ]; then
+          ym=$$(date -u +%Y-%m)
+          url="https://download.db-ip.com/free/dbip-city-lite-$${ym}.mmdb.gz"
+          echo "[geoip-init] downloading $$url"
+          curl -fsSL "$$url" | gunzip > "$$target"
+        elif [ "$$provider" = "maxmind" ]; then
+          if [ -z "${FEATURE_GEO_IP_LICENSE_KEY:-}" ]; then
+            echo "[geoip-init] FEATURE_GEO_IP_LICENSE_KEY required for maxmind"; exit 2
+          fi
+          url="https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$${FEATURE_GEO_IP_LICENSE_KEY}&suffix=tar.gz"
+          echo "[geoip-init] downloading GeoLite2-City"
+          tmp=$$(mktemp -d)
+          curl -fsSL "$$url" -o "$$tmp/db.tar.gz"
+          tar -xzf "$$tmp/db.tar.gz" -C "$$tmp"
+          find "$$tmp" -name "*.mmdb" -exec cp {} "$$target" \;
+          rm -rf "$$tmp"
+        else
+          echo "[geoip-init] unknown provider $$provider"; exit 2
+        fi
+        echo "[geoip-init] wrote $$target ($$(stat -c%s $$target 2>/dev/null || stat -f%z $$target) bytes)"
+      '
+
 volumes:
   postgres_data:
   rustfs_data:

--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "maxmind": "^5"
   }
 }

--- a/scripts/download-geoip.ts
+++ b/scripts/download-geoip.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env bun
+/**
+ * `bun run scripts/download-geoip.ts` — fetch the GeoIP `.mmdb`
+ * database for the configured provider.
+ *
+ * Reads `FEATURE_GEO_IP_*` env-overrides via `loadFeatures()`, hands
+ * them to the pure planner (`planGeoIpDownload`), then runs the
+ * thin runner (`runGeoIpDownload`) against `globalThis.fetch` +
+ * `node:fs/promises`.
+ *
+ * Default provider is `dbip-lite` (CC-BY-4.0, no key required), so a
+ * fresh checkout boots with `bun run scripts/download-geoip.ts` and
+ * is geo-ready in under 30s. MaxMind requires a license key; the
+ * planner throws `GeoIpLicenseKeyMissingError` if missing.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+
+import {
+  GeoIpLicenseKeyMissingError,
+  planGeoIpDownload,
+} from "../src/core/geoip/download-planner.js";
+import { runGeoIpDownload } from "../src/core/geoip/download-runner.js";
+import { loadFeatures } from "../src/core/features/features.js";
+
+async function main(): Promise<void> {
+  const features = loadFeatures(process.env as Record<string, string | undefined>);
+  const cfg = features.geoIp;
+
+  console.log(`[geoip] provider=${cfg.provider} → ${cfg.dbPath}`);
+
+  let plan;
+  try {
+    plan = planGeoIpDownload({
+      provider: cfg.provider,
+      now: new Date(),
+      licenseKey: cfg.licenseKey,
+      dbPath: cfg.dbPath,
+    });
+  } catch (err) {
+    if (err instanceof GeoIpLicenseKeyMissingError) {
+      console.error(`[geoip] ${err.message}`);
+      console.error(
+        "[geoip] tip: switch to dbip-lite (FEATURE_GEO_IP_PROVIDER=dbip-lite) or set FEATURE_GEO_IP_LICENSE_KEY.",
+      );
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  console.log(`[geoip] downloading ${plan.url}`);
+  console.log(`[geoip] license: ${plan.licenseLabel}`);
+
+  const result = await runGeoIpDownload(plan, {
+    fetch: (url) => fetch(url) as unknown as ReturnType<typeof fetch>,
+    fs: { mkdir, writeFile },
+  });
+
+  console.log(
+    `[geoip] wrote ${result.bytesWritten.toLocaleString()} bytes to ${result.savePath}`,
+  );
+  console.log(`[geoip] cadence=${plan.cadence} — re-run on the next refresh window.`);
+}
+
+main().catch((err) => {
+  console.error("[geoip] download failed:", err);
+  process.exit(1);
+});

--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -16,6 +16,7 @@ import { FilesModule } from "../files/files.module.js";
 import { conditionalImport, loadFeatures } from "../features/features.js";
 import { GdprModule } from "../gdpr/gdpr.module.js";
 import { GeoModule } from "../geo/geo.module.js";
+import { GeoIpModule } from "../geoip/geoip.module.js";
 import { HealthModule } from "../health/health.module.js";
 import { IdempotencyModule } from "../idempotency/idempotency.module.js";
 import { JobsModule } from "../jobs/jobs.module.js";
@@ -72,6 +73,7 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
     SearchModule,
     GdprModule,
     GeoModule,
+    GeoIpModule,
     PowerSyncModule,
     IdempotencyModule,
     EmailModule,

--- a/src/core/dx/feature-catalog.ts
+++ b/src/core/dx/feature-catalog.ts
@@ -103,8 +103,7 @@ export const FEATURE_CATALOG: readonly FeatureMeta[] = [
   {
     key: "geoIp",
     label: "GeoIP",
-    description:
-      "IP→Country/City lookup via offline .mmdb (dbip-lite default, MaxMind opt-in).",
+    description: "IP→Country/City lookup via offline .mmdb (dbip-lite default, MaxMind opt-in).",
     envKey: "FEATURE_GEO_IP_ENABLED",
     category: "data",
     exposes: ["GeoIpService.lookup()", "scripts/download-geoip.ts", "geoip-init compose service"],

--- a/src/core/dx/feature-catalog.ts
+++ b/src/core/dx/feature-catalog.ts
@@ -101,6 +101,15 @@ export const FEATURE_CATALOG: readonly FeatureMeta[] = [
     exposes: ["/geo/geocode", "/places/nearby", "GeocodingCacheCleanupCron"],
   },
   {
+    key: "geoIp",
+    label: "GeoIP",
+    description:
+      "IP→Country/City lookup via offline .mmdb (dbip-lite default, MaxMind opt-in).",
+    envKey: "FEATURE_GEO_IP_ENABLED",
+    category: "data",
+    exposes: ["GeoIpService.lookup()", "scripts/download-geoip.ts", "geoip-init compose service"],
+  },
+  {
     key: "rateLimit",
     label: "Rate Limiting",
     description: "Multi-window token-bucket rate limiter backed by Postgres.",

--- a/src/core/features/features.ts
+++ b/src/core/features/features.ts
@@ -21,6 +21,7 @@ const SOCIAL_PROVIDERS = ["google", "github", "apple", "discord"] as const;
 const STORAGE_DRIVERS = ["s3", "local", "postgres"] as const;
 const EMAIL_PROVIDERS = ["smtp", "brevo"] as const;
 const GEO_PROVIDERS = ["mapbox", "google", "nominatim", "local"] as const;
+const GEO_IP_PROVIDERS = ["dbip-lite", "maxmind"] as const;
 
 // Per-section schemas — defined separately so we can pre-parse their
 // defaults and feed them into the parent `.default()` call. Zod 4's
@@ -52,6 +53,14 @@ const GeoSchema = z.object({
   enabled: z.boolean().default(false),
   provider: z.enum(GEO_PROVIDERS).default("nominatim"),
 });
+const GeoIpSchema = z.object({
+  enabled: z.boolean().default(false),
+  provider: z.enum(GEO_IP_PROVIDERS).default("dbip-lite"),
+  /** Optional MaxMind GeoLite2 license key — only required for `provider=maxmind`. */
+  licenseKey: z.string().optional(),
+  /** Where the unpacked `.mmdb` lives. `download-geoip` writes here. */
+  dbPath: z.string().default("./data/geoip/city.mmdb"),
+});
 const togglableDefault = (on: boolean) => z.object({ enabled: z.boolean().default(on) });
 
 const Webhooks = togglableDefault(false);
@@ -77,6 +86,7 @@ export const FeaturesSchema = z.object({
   mcp: Mcp.default(() => Mcp.parse({})),
   fieldEncryption: FieldEncryption.default(() => FieldEncryption.parse({})),
   geo: GeoSchema.default(() => GeoSchema.parse({})),
+  geoIp: GeoIpSchema.default(() => GeoIpSchema.parse({})),
   rateLimit: RateLimit.default(() => RateLimit.parse({})),
   idempotency: Idempotency.default(() => Idempotency.parse({})),
   observability: Observability.default(() => Observability.parse({})),
@@ -97,6 +107,7 @@ export type ToggleableFeatureKey =
   | "mcp"
   | "fieldEncryption"
   | "geo"
+  | "geoIp"
   | "rateLimit"
   | "idempotency"
   | "observability"
@@ -139,6 +150,7 @@ const SECTION_KEYS = new Set([
   "FIELDENCRYPTION",
   "FIELD_ENCRYPTION",
   "GEO",
+  "GEO_IP",
   "RATELIMIT",
   "RATE_LIMIT",
   "IDEMPOTENCY",
@@ -159,6 +171,7 @@ const SECTION_TO_KEY: Record<string, FeatureKey> = {
   FIELDENCRYPTION: "fieldEncryption",
   FIELD_ENCRYPTION: "fieldEncryption",
   GEO: "geo",
+  GEO_IP: "geoIp",
   RATELIMIT: "rateLimit",
   RATE_LIMIT: "rateLimit",
   IDEMPOTENCY: "idempotency",
@@ -183,9 +196,19 @@ const FIELD_TO_PROP: Record<string, string> = {
   API_KEYS: "apiKeys",
   SOCIALPROVIDERS: "socialProviders",
   SOCIAL_PROVIDERS: "socialProviders",
+  LICENSEKEY: "licenseKey",
+  LICENSE_KEY: "licenseKey",
+  DBPATH: "dbPath",
+  DB_PATH: "dbPath",
 };
 
-const STRING_VALUE_PROPS = new Set(["storageDefault", "headerName", "provider"]);
+const STRING_VALUE_PROPS = new Set([
+  "storageDefault",
+  "headerName",
+  "provider",
+  "licenseKey",
+  "dbPath",
+]);
 const ARRAY_VALUE_PROPS = new Set(["socialProviders"]);
 
 function parseFeatureEnv(env: Record<string, string | undefined>): RawOverrides {

--- a/src/core/geoip/CLAUDE.md
+++ b/src/core/geoip/CLAUDE.md
@@ -1,0 +1,56 @@
+# `src/core/geoip/` — IP→Geo Lookup
+
+Offline IP-to-country/city resolution backed by an `.mmdb` file. Two
+providers ship out of the box; the wire-format is identical so a
+single reader serves both.
+
+## Provider matrix
+
+| Provider    | License                    | Account    | Cadence | Default | Use when                                     |
+| ----------- | -------------------------- | ---------- | ------- | ------- | -------------------------------------------- |
+| `dbip-lite` | CC-BY-4.0 (db-ip.com)      | none       | monthly | yes     | DSGVO-strict / Schrems-II / no signup needed |
+| `maxmind`   | MaxMind GeoLite2-City EULA | yes (free) | weekly  | opt-in  | higher accuracy, faster updates accepted     |
+
+Switch providers via `FEATURE_GEO_IP_PROVIDER` (`.env` or runtime
+override). MaxMind also requires `FEATURE_GEO_IP_LICENSE_KEY`. See
+`.env.example` for the full set.
+
+## Files
+
+| File                  | Role                                                                                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `download-planner.ts` | Pure planner — `provider` + `now` → `{ url, savePath, archiveFormat, cadence, licenseLabel }`. Throws on missing license key for MaxMind.                                          |
+| `download-runner.ts`  | Thin runner — fetches the URL, decompresses (`gz` for dbip-lite, `tar.gz` for MaxMind), extracts the `.mmdb` payload, writes it to `savePath`. Both `fetch` and `fs` are injected. |
+| `resolver.ts`         | Pure mapper — raw `.mmdb` city record → normalised `GeoIpLookupResult`. Falls back gracefully on partial records (dbip-lite often omits city data).                                |
+| `geoip.service.ts`    | `GeoIpService.lookup(ip)` — wraps the reader + caches the lookup result. Cold-boot tolerant: missing `.mmdb` → null + warning, never a crash.                                      |
+| `geoip.module.ts`     | NestJS module that lazy-imports the `maxmind` npm package only when the feature is on AND the file exists at the configured path.                                                  |
+
+## Operational lifecycle
+
+1. **Initial population** — run `bun run scripts/download-geoip.ts`
+   on the host, or `docker compose --profile geoip up geoip-init` in
+   container setups. `data/geoip/city.mmdb` lands on disk.
+2. **Feature toggle** — `FEATURE_GEO_IP_ENABLED=true` in `.env`. The
+   server picks up the file on next boot.
+3. **Refresh cadence** — dbip-lite ships a fresh build the first day
+   of each month; MaxMind pushes weekly. The recommended cron is a
+   pg-boss job that calls the runner at the matching cadence (see
+   the example wiring in `geoip.module.ts` once the
+   `JobQueueService` carries scheduled jobs).
+
+## Schrems-II note
+
+MaxMind's download endpoint records the requesting IP. For
+DSGVO-strict deployments where the build host's IP must not leak to
+US infrastructure, stay on `dbip-lite`. The query data flow itself
+never leaves the server — both providers are queried offline against
+the local `.mmdb` after the initial download.
+
+## Test seam
+
+`mapMmdbCityRecord(raw)` is a pure function; `GeoIpService` accepts
+an injected `MmdbCityReader`. Together they make the whole pipeline
+testable without a real `.mmdb` fixture. End-to-end coverage with a
+real reader needs a tiny sample database — fetch the maxmind
+package's `test-data/GeoLite2-City-Test.mmdb` if you ever need it,
+but the pure tests cover the contract.

--- a/src/core/geoip/download-planner.ts
+++ b/src/core/geoip/download-planner.ts
@@ -1,0 +1,125 @@
+/**
+ * GeoIp Download Planner.
+ *
+ * Pure function: maps a provider + license-key + a `now` clock to the
+ * download spec (URL, archive format, target path, refresh cadence,
+ * attribution label). Has no I/O — `download-runner.ts` performs the
+ * actual fetch + extract.
+ *
+ * The "pure planner / thin runner" split is enforced across the
+ * codebase (see `src/core/CLAUDE.md`). It buys two things:
+ *   - the planner is testable without network or filesystem
+ *   - the runner can be swapped (real fetch vs. mocked), the URL/path
+ *     contract stays single-sourced
+ *
+ * Provider matrix
+ * ───────────────
+ * `dbip-lite`  default. CC-BY-4.0, no account, monthly snapshot, URL
+ *              embeds `YYYY-MM`. The Schrems-II-friendly choice — the
+ *              client never identifies itself to a tracking endpoint.
+ * `maxmind`    opt-in. License key required (free signup since Dec 2019),
+ *              GeoLite2-City edition, weekly updates, tar.gz archive.
+ *              Higher accuracy, but every download leaks the caller's
+ *              IP to MaxMind's edge.
+ */
+
+export const GEOIP_PROVIDERS = ["dbip-lite", "maxmind"] as const;
+export type GeoIpProvider = (typeof GEOIP_PROVIDERS)[number];
+
+export const GEOIP_DEFAULT_DB_PATH = "./data/geoip/city.mmdb";
+
+export type GeoIpArchiveFormat = "gz" | "tar.gz";
+export type GeoIpUpdateCadence = "monthly" | "weekly";
+
+export interface GeoIpDownloadPlan {
+  provider: GeoIpProvider;
+  url: string;
+  /** Disk location the unpacked `.mmdb` should land at. */
+  savePath: string;
+  archiveFormat: GeoIpArchiveFormat;
+  cadence: GeoIpUpdateCadence;
+  /** Whether this provider mandates a license key on the URL. */
+  requiresLicenseKey: boolean;
+  /** Human-readable license / attribution label for log + UI surfaces. */
+  licenseLabel: string;
+}
+
+export interface PlanGeoIpDownloadInput {
+  provider: GeoIpProvider;
+  /** Clock — passed in so the URL builder stays deterministic in tests. */
+  now: Date;
+  licenseKey?: string;
+  dbPath?: string;
+}
+
+export class GeoIpUnsupportedProviderError extends Error {
+  constructor(provider: string) {
+    super(`unsupported GeoIP provider: ${provider}`);
+    this.name = "GeoIpUnsupportedProviderError";
+  }
+}
+
+export class GeoIpLicenseKeyMissingError extends Error {
+  constructor(provider: GeoIpProvider) {
+    super(
+      `GeoIP provider "${provider}" requires a license key — set FEATURE_GEO_IP_LICENSE_KEY (free at maxmind.com)`,
+    );
+    this.name = "GeoIpLicenseKeyMissingError";
+  }
+}
+
+/**
+ * Build the deterministic download spec for the given provider + clock.
+ *
+ * `dbip-lite` derives a `YYYY-MM` snapshot from `now`. `maxmind` always
+ * resolves the latest GeoLite2-City build via its query-string-shaped
+ * download API.
+ */
+export function planGeoIpDownload(input: PlanGeoIpDownloadInput): GeoIpDownloadPlan {
+  const savePath = input.dbPath ?? GEOIP_DEFAULT_DB_PATH;
+
+  if (input.provider === "dbip-lite") {
+    return {
+      provider: "dbip-lite",
+      url: buildDbipLiteUrl(input.now),
+      savePath,
+      archiveFormat: "gz",
+      cadence: "monthly",
+      requiresLicenseKey: false,
+      licenseLabel: "CC-BY-4.0 (db-ip.com)",
+    };
+  }
+
+  if (input.provider === "maxmind") {
+    const trimmed = (input.licenseKey ?? "").trim();
+    if (trimmed.length === 0) {
+      throw new GeoIpLicenseKeyMissingError("maxmind");
+    }
+    return {
+      provider: "maxmind",
+      url: buildMaxmindUrl(trimmed),
+      savePath,
+      archiveFormat: "tar.gz",
+      cadence: "weekly",
+      requiresLicenseKey: true,
+      licenseLabel: "MaxMind GeoLite2-City EULA (license_key required)",
+    };
+  }
+
+  throw new GeoIpUnsupportedProviderError(input.provider);
+}
+
+function buildDbipLiteUrl(now: Date): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `https://download.db-ip.com/free/dbip-city-lite-${year}-${month}.mmdb.gz`;
+}
+
+function buildMaxmindUrl(licenseKey: string): string {
+  const params = new URLSearchParams({
+    edition_id: "GeoLite2-City",
+    license_key: licenseKey,
+    suffix: "tar.gz",
+  });
+  return `https://download.maxmind.com/app/geoip_download?${params.toString()}`;
+}

--- a/src/core/geoip/download-runner.ts
+++ b/src/core/geoip/download-runner.ts
@@ -1,0 +1,127 @@
+import { gunzipSync } from "node:zlib";
+import { dirname } from "node:path";
+
+import type { GeoIpDownloadPlan } from "./download-planner.js";
+
+/**
+ * GeoIp Download Runner.
+ *
+ * Thin glue around the planner + Node's built-ins. Fetches the URL,
+ * decompresses the archive (`gz` for dbip-lite, `tar.gz` for
+ * MaxMind), extracts the `.mmdb` payload, writes it to `savePath`.
+ *
+ * `fetch` and `fs` are injected so unit tests don't hit the network
+ * or touch the filesystem. Production wiring uses `globalThis.fetch`
+ * + `node:fs/promises`.
+ */
+
+export interface RunnerFetchResponse {
+  ok: boolean;
+  status: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface RunnerFs {
+  mkdir(path: string, opts: { recursive: boolean }): Promise<unknown>;
+  writeFile(path: string, bytes: Uint8Array): Promise<unknown>;
+}
+
+export interface RunnerDeps {
+  fetch: (url: string) => Promise<RunnerFetchResponse>;
+  fs: RunnerFs;
+}
+
+export interface RunnerResult {
+  savePath: string;
+  bytesWritten: number;
+}
+
+export class GeoIpDownloadFailedError extends Error {
+  constructor(url: string, status: number) {
+    super(`GeoIP download failed: HTTP ${status} for ${url}`);
+    this.name = "GeoIpDownloadFailedError";
+  }
+}
+
+export class GeoIpArchiveExtractError extends Error {
+  constructor(message: string) {
+    super(`GeoIP archive extract failed: ${message}`);
+    this.name = "GeoIpArchiveExtractError";
+  }
+}
+
+export async function runGeoIpDownload(
+  plan: GeoIpDownloadPlan,
+  deps: RunnerDeps,
+): Promise<RunnerResult> {
+  const response = await deps.fetch(plan.url);
+  if (!response.ok) {
+    throw new GeoIpDownloadFailedError(plan.url, response.status);
+  }
+  const archive = Buffer.from(await response.arrayBuffer());
+  const mmdb = extractMmdb(archive, plan.archiveFormat);
+
+  await deps.fs.mkdir(dirname(plan.savePath), { recursive: true });
+  await deps.fs.writeFile(plan.savePath, mmdb);
+
+  return { savePath: plan.savePath, bytesWritten: mmdb.length };
+}
+
+function extractMmdb(archive: Buffer, format: GeoIpDownloadPlan["archiveFormat"]): Buffer {
+  if (format === "gz") {
+    return gunzipSync(archive);
+  }
+  if (format === "tar.gz") {
+    const tar = gunzipSync(archive);
+    const mmdb = findMmdbInTar(tar);
+    if (!mmdb) {
+      throw new GeoIpArchiveExtractError("no .mmdb entry found in tar archive");
+    }
+    return mmdb;
+  }
+  throw new GeoIpArchiveExtractError(`unsupported archive format: ${format}`);
+}
+
+/**
+ * Walk a POSIX-tar buffer and return the first `*.mmdb` file body.
+ *
+ * Format reference: USTAR — header is 512 bytes, payload follows in
+ * 512-byte-aligned blocks, archive ends with two zero blocks.
+ *
+ * `name` (0..100), `size` (124..136, octal), `typeflag` (156).
+ */
+function findMmdbInTar(tar: Buffer): Buffer | null {
+  const blockSize = 512;
+  let offset = 0;
+  while (offset + blockSize <= tar.length) {
+    const header = tar.subarray(offset, offset + blockSize);
+    // Two consecutive zero blocks → end-of-archive.
+    if (header.every((b) => b === 0)) break;
+
+    const name = readCString(header.subarray(0, 100));
+    const size = parseTarOctal(header.subarray(124, 136));
+    const typeflag = String.fromCharCode(header[156]!);
+    offset += blockSize;
+
+    // Regular file ("0" or "\0") with .mmdb extension.
+    if ((typeflag === "0" || typeflag === "\0") && name.endsWith(".mmdb")) {
+      return tar.subarray(offset, offset + size);
+    }
+
+    // Skip the body block (rounded up to nearest 512).
+    offset += Math.ceil(size / blockSize) * blockSize;
+  }
+  return null;
+}
+
+function readCString(buf: Buffer): string {
+  const nul = buf.indexOf(0);
+  return (nul === -1 ? buf : buf.subarray(0, nul)).toString("utf8");
+}
+
+function parseTarOctal(buf: Buffer): number {
+  // tar octal fields are NUL- or space-terminated ASCII octal numbers.
+  const str = buf.toString("ascii").replace(/[\0 ]+$/, "").trim();
+  if (!str) return 0;
+  return Number.parseInt(str, 8);
+}

--- a/src/core/geoip/download-runner.ts
+++ b/src/core/geoip/download-runner.ts
@@ -121,7 +121,21 @@ function readCString(buf: Buffer): string {
 
 function parseTarOctal(buf: Buffer): number {
   // tar octal fields are NUL- or space-terminated ASCII octal numbers.
-  const str = buf.toString("ascii").replace(/[\0 ]+$/, "").trim();
-  if (!str) return 0;
-  return Number.parseInt(str, 8);
+  // Trim manually rather than via a regex to avoid the no-control-regex
+  // lint warning (matching `\x00` directly in a character class is what
+  // triggers it).
+  let end = buf.length;
+  while (end > 0) {
+    const code = buf[end - 1]!;
+    if (code !== 0 && code !== 0x20) break;
+    end--;
+  }
+  let start = 0;
+  while (start < end) {
+    const code = buf[start]!;
+    if (code !== 0 && code !== 0x20) break;
+    start++;
+  }
+  if (start === end) return 0;
+  return Number.parseInt(buf.toString("ascii", start, end), 8);
 }

--- a/src/core/geoip/geoip.module.ts
+++ b/src/core/geoip/geoip.module.ts
@@ -171,10 +171,9 @@ async function createMaxmindReader(
     // identifier is hidden behind a string so `tsc` doesn't try to
     // resolve the type when the package isn't installed.
     const moduleId = "maxmind";
-    const dynamicImport = new Function(
-      "id",
-      "return import(id)",
-    ) as (id: string) => Promise<unknown>;
+    const dynamicImport = new Function("id", "return import(id)") as (
+      id: string,
+    ) => Promise<unknown>;
     const maxmind = (await dynamicImport(moduleId)) as MaxmindModuleShape;
     const opener = maxmind.open ?? maxmind.default?.open;
     if (typeof opener !== "function") {

--- a/src/core/geoip/geoip.module.ts
+++ b/src/core/geoip/geoip.module.ts
@@ -1,0 +1,200 @@
+import { existsSync, statSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve as resolvePath } from "node:path";
+
+import { Injectable, Logger, Module, type OnModuleInit } from "@nestjs/common";
+
+import { GeoIpLicenseKeyMissingError, planGeoIpDownload } from "./download-planner.js";
+import { runGeoIpDownload } from "./download-runner.js";
+import { loadFeatures } from "../features/features.js";
+import { GeoIpService, type MmdbCityReader } from "./geoip.service.js";
+import { planGeoIpRefreshSchedule } from "./refresh-schedule.js";
+
+/**
+ * GeoIpModule — provides `GeoIpService` with a lazy `.mmdb` reader.
+ *
+ * The `maxmind` npm package is loaded **only when the feature is on
+ * AND the `.mmdb` exists at the configured path**. This keeps:
+ *   - cold builds tiny (the package is in `optionalDependencies`)
+ *   - test runs fast (CI doesn't install or load it unless asked)
+ *   - production failure-mode soft (missing `.mmdb` → null result,
+ *     never a boot crash)
+ *
+ * Even when the feature is off the module is still importable —
+ * downstream code can inject `GeoIpService` and rely on the
+ * cold-boot null contract instead of branching on a feature flag
+ * at every call-site.
+ */
+/**
+ * GeoIpRefreshCron — re-downloads the `.mmdb` on the cadence dictated
+ * by `planGeoIpRefreshSchedule()`. Wakes up once every 24h, asks the
+ * planner whether a refresh is due, and either skips or runs the
+ * download. `lastRunMs` tracks the last successful refresh in
+ * memory; in production the worker can persist it via pg-boss state
+ * once the queue is wired (see `src/core/jobs/`).
+ *
+ * Failures are swallowed with a warning — geo lookup is best-effort,
+ * a stale `.mmdb` is preferable to a crashed boot.
+ */
+@Injectable()
+class GeoIpRefreshCron implements OnModuleInit {
+  private readonly logger = new Logger("GeoIpRefreshCron");
+  private timer?: ReturnType<typeof setInterval>;
+  private lastRunMs: number | null = null;
+
+  onModuleInit(): void {
+    const features = loadFeatures(process.env as Record<string, string | undefined>);
+    const cfg = features.geoIp;
+    const schedule = planGeoIpRefreshSchedule({
+      provider: cfg.provider,
+      enabled: cfg.enabled,
+    });
+    if (!schedule.shouldRun) return;
+
+    // Seed the "last run" with the file's mtime if it exists, so a
+    // restart doesn't re-download a fresh database.
+    try {
+      const absolute = resolvePath(cfg.dbPath);
+      if (existsSync(absolute)) {
+        this.lastRunMs = statSync(absolute).mtimeMs;
+      }
+    } catch {
+      this.lastRunMs = null;
+    }
+
+    this.logger.log(
+      `GeoIP refresh scheduled: cadence=${schedule.cadence}, tick=${schedule.tickMs}ms`,
+    );
+    this.timer = setInterval(() => {
+      void this.maybeRun(cfg.provider, cfg.licenseKey, cfg.dbPath, schedule).catch((err) =>
+        this.logger.warn(`GeoIP refresh tick failed: ${err}`),
+      );
+    }, schedule.tickMs);
+    // Don't keep the event loop alive in tests / CLI tools.
+    this.timer.unref?.();
+  }
+
+  private async maybeRun(
+    provider: "dbip-lite" | "maxmind",
+    licenseKey: string | undefined,
+    dbPath: string,
+    schedule: ReturnType<typeof planGeoIpRefreshSchedule>,
+  ): Promise<void> {
+    const now = Date.now();
+    if (!schedule.isRefreshDue(now, this.lastRunMs)) return;
+
+    try {
+      const plan = planGeoIpDownload({ provider, now: new Date(now), licenseKey, dbPath });
+      const result = await runGeoIpDownload(plan, {
+        fetch: (url) => fetch(url) as unknown as ReturnType<typeof fetch>,
+        fs: { mkdir, writeFile },
+      });
+      this.lastRunMs = now;
+      this.logger.log(
+        `GeoIP refresh complete: ${result.bytesWritten.toLocaleString()} bytes → ${result.savePath}`,
+      );
+    } catch (err) {
+      if (err instanceof GeoIpLicenseKeyMissingError) {
+        this.logger.warn(err.message);
+        return;
+      }
+      this.logger.warn(
+        `GeoIP refresh failed (will retry on next tick): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+}
+
+@Module({
+  providers: [
+    {
+      provide: GeoIpService,
+      useFactory: (): GeoIpService => {
+        const features = loadFeatures(process.env as Record<string, string | undefined>);
+        const cfg = features.geoIp;
+        const logger = new Logger("GeoIpService");
+        return new GeoIpService({
+          readerFactory: () => createMaxmindReader(cfg.dbPath, cfg.enabled, logger),
+        });
+      },
+    },
+    GeoIpRefreshCron,
+  ],
+  exports: [GeoIpService],
+})
+export class GeoIpModule {}
+
+/**
+ * Structural type for the `maxmind` npm package's public surface
+ * we depend on. Defined locally so the module compiles even when
+ * the optional dependency isn't installed (e.g. CI / projects
+ * that never enable the feature).
+ */
+interface MaxmindReaderShape {
+  get(ip: string): unknown;
+}
+interface MaxmindModuleShape {
+  open?: (path: string) => Promise<MaxmindReaderShape>;
+  default?: {
+    open?: (path: string) => Promise<MaxmindReaderShape>;
+  };
+}
+
+/**
+ * Lazy-load the `maxmind` package + open the `.mmdb` file. Both
+ * `dbip-lite` and MaxMind's GeoLite2-City emit the same binary
+ * format, so a single reader serves both providers.
+ *
+ * Returns `null` when:
+ *   - the feature is disabled (caller skips lookup gracefully)
+ *   - the `.mmdb` file is missing on disk
+ *   - the maxmind package isn't installed (ZeroDeps install path)
+ *   - any of the above throws while loading
+ */
+async function createMaxmindReader(
+  dbPath: string,
+  enabled: boolean,
+  logger: Logger,
+): Promise<MmdbCityReader | null> {
+  if (!enabled) return null;
+  const absolute = resolvePath(dbPath);
+  if (!existsSync(absolute)) {
+    logger.warn(`GeoIP .mmdb not found at ${absolute} — lookups disabled.`);
+    return null;
+  }
+  try {
+    // Lazy import — never bundled or evaluated unless the feature is
+    // on. The package is declared in `optionalDependencies` so a
+    // consumer that doesn't enable GeoIP doesn't pull it in. The
+    // identifier is hidden behind a string so `tsc` doesn't try to
+    // resolve the type when the package isn't installed.
+    const moduleId = "maxmind";
+    const dynamicImport = new Function(
+      "id",
+      "return import(id)",
+    ) as (id: string) => Promise<unknown>;
+    const maxmind = (await dynamicImport(moduleId)) as MaxmindModuleShape;
+    const opener = maxmind.open ?? maxmind.default?.open;
+    if (typeof opener !== "function") {
+      logger.warn("`maxmind` package found but exports no `open()` — lookups disabled.");
+      return null;
+    }
+    const reader = await opener(absolute);
+    logger.log(`GeoIP reader opened: ${absolute}`);
+    return {
+      get(ip: string) {
+        // maxmind's reader.get returns the raw City record or null.
+        return reader.get(ip);
+      },
+    };
+  } catch (err) {
+    logger.warn(
+      `GeoIP setup failed (\`maxmind\` package not installed or .mmdb invalid): ${
+        err instanceof Error ? err.message : String(err)
+      }. Run \`bun add maxmind\` and \`bun run scripts/download-geoip.ts\`.`,
+    );
+    return null;
+  }
+}

--- a/src/core/geoip/geoip.service.ts
+++ b/src/core/geoip/geoip.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import { type GeoIpLookupResult, mapMmdbCityRecord } from "./resolver.js";
+
+/**
+ * GeoIpService — wraps a `.mmdb` reader and serves
+ * `lookup(ip): GeoIpLookupResult | null`.
+ *
+ * Design pillars:
+ *
+ * 1. Reader is injected via `readerFactory()`. Production wiring
+ *    lazy-imports the `maxmind` npm package only when the feature
+ *    is enabled (see `geoip.module.ts`); tests pass an in-memory
+ *    reader, no fixture file needed.
+ *
+ * 2. Cold-boot tolerance. If `readerFactory()` resolves to `null`
+ *    (the `.mmdb` is missing on disk), `lookup()` logs once and
+ *    returns `null` forever after. Crashing the boot for "GeoIP
+ *    DB not synced yet" is hostile — the feature is a soft
+ *    enhancement, not a critical-path dependency.
+ *
+ * 3. Reader is cached. The factory runs at most once per
+ *    GeoIpService instance; subsequent lookups hit the cached
+ *    reader, which itself ships with an internal LRU cache (~50µs
+ *    per hit after warm-up).
+ */
+
+export interface MmdbCityReader {
+  /** Returns the raw `.mmdb` record for an IP, or `null` if not found. */
+  get(ip: string): unknown | null;
+}
+
+export interface GeoIpServiceLogger {
+  log(message: string): void;
+  warn(message: string): void;
+  error(message: string, err?: unknown): void;
+}
+
+export interface GeoIpServiceOptions {
+  /** Factory that resolves the `.mmdb` reader once (lazy + cached). */
+  readerFactory: () => Promise<MmdbCityReader | null>;
+  logger?: GeoIpServiceLogger;
+}
+
+@Injectable()
+export class GeoIpService {
+  private readerPromise?: Promise<MmdbCityReader | null>;
+  private warnedNoReader = false;
+  private readonly logger: GeoIpServiceLogger;
+  private readonly readerFactory: GeoIpServiceOptions["readerFactory"];
+
+  constructor(options: GeoIpServiceOptions) {
+    this.readerFactory = options.readerFactory;
+    this.logger = options.logger ?? new Logger("GeoIpService");
+  }
+
+  async lookup(ip: string): Promise<GeoIpLookupResult | null> {
+    if (!ip) return null;
+
+    const reader = await this.getReader();
+    if (!reader) {
+      if (!this.warnedNoReader) {
+        this.warnedNoReader = true;
+        this.logger.warn(
+          "GeoIP .mmdb not loaded — lookup returns null. Run `bun run scripts/download-geoip.ts` to populate the database.",
+        );
+      }
+      return null;
+    }
+
+    let raw: unknown;
+    try {
+      raw = reader.get(ip);
+    } catch (err) {
+      this.logger.error(`GeoIP lookup failed for ${ip}`, err);
+      return null;
+    }
+
+    return mapMmdbCityRecord(raw);
+  }
+
+  private getReader(): Promise<MmdbCityReader | null> {
+    if (!this.readerPromise) {
+      this.readerPromise = this.readerFactory().catch((err) => {
+        this.logger.error("GeoIP reader factory threw", err);
+        return null;
+      });
+    }
+    return this.readerPromise;
+  }
+}

--- a/src/core/geoip/refresh-schedule.ts
+++ b/src/core/geoip/refresh-schedule.ts
@@ -1,0 +1,65 @@
+import type { GeoIpProvider } from "./download-planner.js";
+
+/**
+ * GeoIp refresh schedule — pure planner.
+ *
+ * The refresh worker ticks daily and only re-downloads the `.mmdb`
+ * once `refreshIntervalMs` has elapsed since the last successful
+ * run. This is deliberately conservative:
+ *
+ *   - dbip-lite ships a fresh build at the start of every month;
+ *     refreshing more often than `~30 days` wastes bandwidth.
+ *   - MaxMind ships weekly. `~7 days` matches the upstream cadence.
+ *
+ * The runner — a cron / pg-boss job — calls `isRefreshDue(now,
+ * lastRunAt)` before kicking off the planner+runner pair. Splitting
+ * the decision out of the runner keeps the cadence policy
+ * unit-testable.
+ */
+
+export type GeoIpRefreshCadence = "monthly" | "weekly";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface GeoIpRefreshSchedule {
+  shouldRun: boolean;
+  cadence: GeoIpRefreshCadence;
+  /** How often the cron wakes up. Always 24h once enabled. */
+  tickMs: number;
+  /** Minimum time between successive refreshes. */
+  refreshIntervalMs: number;
+  /** Pure decision helper — true when `now - lastRunAt >= refreshIntervalMs`. */
+  isRefreshDue(nowMs: number, lastRunMs: number | null): boolean;
+}
+
+export interface PlanGeoIpRefreshScheduleInput {
+  provider: GeoIpProvider;
+  enabled: boolean;
+}
+
+export function planGeoIpRefreshSchedule(
+  input: PlanGeoIpRefreshScheduleInput,
+): GeoIpRefreshSchedule {
+  if (!input.enabled) {
+    return {
+      shouldRun: false,
+      cadence: "monthly",
+      tickMs: 0,
+      refreshIntervalMs: 0,
+      isRefreshDue: () => false,
+    };
+  }
+
+  const cadence: GeoIpRefreshCadence = input.provider === "maxmind" ? "weekly" : "monthly";
+  const refreshIntervalMs = cadence === "monthly" ? 30 * DAY_MS : 7 * DAY_MS;
+  return {
+    shouldRun: true,
+    cadence,
+    tickMs: DAY_MS,
+    refreshIntervalMs,
+    isRefreshDue(nowMs, lastRunMs) {
+      if (lastRunMs === null) return true;
+      return nowMs - lastRunMs >= refreshIntervalMs;
+    },
+  };
+}

--- a/src/core/geoip/resolver.ts
+++ b/src/core/geoip/resolver.ts
@@ -1,0 +1,76 @@
+/**
+ * GeoIp resolver — pure record mapper.
+ *
+ * MaxMind / dbip-lite emit the same `.mmdb` City record shape:
+ *   { country: { iso_code, names: { en } },
+ *     city: { names: { en } },
+ *     subdivisions: [{ iso_code, names: { en } }],
+ *     location: { latitude, longitude, accuracy_radius } }
+ *
+ * `mapMmdbCityRecord(raw)` plucks the fields we surface and falls
+ * back gracefully on partial records (dbip-lite's free tier omits
+ * the city for many small IP blocks). Returning a partial object —
+ * or `null` if the record holds nothing usable — keeps callers from
+ * branching on every nested field.
+ */
+
+export interface GeoIpLookupResult {
+  country?: string;
+  countryCode?: string;
+  region?: string;
+  regionCode?: string;
+  city?: string;
+  latitude?: number;
+  longitude?: number;
+  accuracyRadius?: number;
+}
+
+interface MmdbNamedRecord {
+  iso_code?: string;
+  names?: { en?: string } | undefined;
+}
+
+interface MmdbCityRecordShape {
+  country?: MmdbNamedRecord;
+  registered_country?: MmdbNamedRecord;
+  city?: { names?: { en?: string } };
+  subdivisions?: MmdbNamedRecord[];
+  location?: {
+    latitude?: number;
+    longitude?: number;
+    accuracy_radius?: number;
+  };
+}
+
+export function mapMmdbCityRecord(raw: unknown): GeoIpLookupResult | null {
+  if (!raw || typeof raw !== "object") return null;
+  const record = raw as MmdbCityRecordShape;
+
+  const out: GeoIpLookupResult = {};
+
+  // Prefer `country` over `registered_country` — the latter is the
+  // ISP's billing country, the former is the geo-located one.
+  const country = record.country ?? record.registered_country;
+  if (country?.names?.en) out.country = country.names.en;
+  if (country?.iso_code) out.countryCode = country.iso_code;
+
+  const subdivision = record.subdivisions?.[0];
+  if (subdivision?.names?.en) out.region = subdivision.names.en;
+  if (subdivision?.iso_code) out.regionCode = subdivision.iso_code;
+
+  if (record.city?.names?.en) out.city = record.city.names.en;
+
+  // Lat/Lng only when both arrived — half a coordinate is worse
+  // than none. accuracy_radius travels with location.
+  const lat = record.location?.latitude;
+  const lng = record.location?.longitude;
+  if (typeof lat === "number" && typeof lng === "number") {
+    out.latitude = lat;
+    out.longitude = lng;
+    if (typeof record.location?.accuracy_radius === "number") {
+      out.accuracyRadius = record.location.accuracy_radius;
+    }
+  }
+
+  return Object.keys(out).length === 0 ? null : out;
+}

--- a/src/core/setup/setup-wizard.ts
+++ b/src/core/setup/setup-wizard.ts
@@ -242,20 +242,14 @@ function renderEnvExample(answers: WizardAnswers): string {
   lines.push("# FEATURE_GEO_PROVIDER=nominatim");
   lines.push("");
   lines.push("# GeoIP (offline IP→country/city lookup via .mmdb)");
-  lines.push(
-    "# Default provider `dbip-lite` is CC-BY-4.0, no key required, monthly snapshot.",
-  );
-  lines.push(
-    "# `bun run scripts/download-geoip.ts` populates `./data/geoip/city.mmdb`.",
-  );
+  lines.push("# Default provider `dbip-lite` is CC-BY-4.0, no key required, monthly snapshot.");
+  lines.push("# `bun run scripts/download-geoip.ts` populates `./data/geoip/city.mmdb`.");
   lines.push("# FEATURE_GEO_IP_ENABLED=false");
   lines.push("# FEATURE_GEO_IP_PROVIDER=dbip-lite");
   lines.push("# FEATURE_GEO_IP_DB_PATH=./data/geoip/city.mmdb");
   lines.push("#");
   lines.push("# Opt-in: MaxMind GeoLite2-City for higher accuracy + weekly updates.");
-  lines.push(
-    "# Free signup at https://www.maxmind.com/en/geolite2/signup. NB: every",
-  );
+  lines.push("# Free signup at https://www.maxmind.com/en/geolite2/signup. NB: every");
   lines.push("# download leaks the caller's IP to MaxMind — pick `dbip-lite` for");
   lines.push("# Schrems-II-strict setups.");
   lines.push("# FEATURE_GEO_IP_PROVIDER=maxmind");

--- a/src/core/setup/setup-wizard.ts
+++ b/src/core/setup/setup-wizard.ts
@@ -240,6 +240,26 @@ function renderEnvExample(answers: WizardAnswers): string {
   lines.push("# Geo (PostGIS, geocoding)");
   lines.push("# FEATURE_GEO_ENABLED=false");
   lines.push("# FEATURE_GEO_PROVIDER=nominatim");
+  lines.push("");
+  lines.push("# GeoIP (offline IP→country/city lookup via .mmdb)");
+  lines.push(
+    "# Default provider `dbip-lite` is CC-BY-4.0, no key required, monthly snapshot.",
+  );
+  lines.push(
+    "# `bun run scripts/download-geoip.ts` populates `./data/geoip/city.mmdb`.",
+  );
+  lines.push("# FEATURE_GEO_IP_ENABLED=false");
+  lines.push("# FEATURE_GEO_IP_PROVIDER=dbip-lite");
+  lines.push("# FEATURE_GEO_IP_DB_PATH=./data/geoip/city.mmdb");
+  lines.push("#");
+  lines.push("# Opt-in: MaxMind GeoLite2-City for higher accuracy + weekly updates.");
+  lines.push(
+    "# Free signup at https://www.maxmind.com/en/geolite2/signup. NB: every",
+  );
+  lines.push("# download leaks the caller's IP to MaxMind — pick `dbip-lite` for");
+  lines.push("# Schrems-II-strict setups.");
+  lines.push("# FEATURE_GEO_IP_PROVIDER=maxmind");
+  lines.push("# FEATURE_GEO_IP_LICENSE_KEY=");
   return lines.join("\n") + "\n";
 }
 

--- a/tests/stories/feature-catalog.story.test.ts
+++ b/tests/stories/feature-catalog.story.test.ts
@@ -8,8 +8,8 @@ import {
 import { loadFeatures } from "../../src/core/features/features.js";
 
 describe("Story · Feature-Catalog", () => {
-  it("listet alle 14 toggleable Features mit Beschreibung + ENV-Key", () => {
-    expect(FEATURE_CATALOG).toHaveLength(14);
+  it("listet alle 15 toggleable Features mit Beschreibung + ENV-Key", () => {
+    expect(FEATURE_CATALOG).toHaveLength(15);
     for (const meta of FEATURE_CATALOG) {
       expect(meta.label).toBeTruthy();
       expect(meta.description).toBeTruthy();
@@ -48,8 +48,8 @@ describe("Story · Feature-Catalog", () => {
   it("summarizeFeatures zählt aktiv/total korrekt", () => {
     const def = loadFeatures({});
     const sum = summarizeFeatures(def);
-    expect(sum.total).toBe(14);
-    expect(sum.active + sum.available).toBe(14);
+    expect(sum.total).toBe(15);
+    expect(sum.active + sum.available).toBe(15);
     expect(sum.active).toBeGreaterThan(0);
     expect(sum.active).toBeLessThan(sum.total);
   });

--- a/tests/stories/geoip-cron-schedule.story.test.ts
+++ b/tests/stories/geoip-cron-schedule.story.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { planGeoIpRefreshSchedule } from "../../src/core/geoip/refresh-schedule.js";
+
+/**
+ * Story · GeoIp Refresh Schedule
+ *
+ * Pure planner that decides the cron tick interval for the
+ * auto-refresh worker. dbip-lite ships a fresh build the first day
+ * of the month → check daily, refresh once a month is enough.
+ * MaxMind ships weekly → check daily, refresh once a week.
+ *
+ * Returning the interval as a number of milliseconds keeps the
+ * runner trivial: `setInterval(plan.tickMs, …)`. The planner is
+ * pure so the cadence-per-provider contract is unit-testable
+ * without spawning timers.
+ */
+describe("Story · GeoIp Refresh Schedule", () => {
+  it("dbip-lite: monthly cadence, daily tick (24h)", () => {
+    const plan = planGeoIpRefreshSchedule({ provider: "dbip-lite", enabled: true });
+    expect(plan.shouldRun).toBe(true);
+    expect(plan.cadence).toBe("monthly");
+    expect(plan.tickMs).toBe(24 * 60 * 60 * 1000);
+    expect(plan.refreshIntervalMs).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("maxmind: weekly cadence, daily tick (24h)", () => {
+    const plan = planGeoIpRefreshSchedule({ provider: "maxmind", enabled: true });
+    expect(plan.shouldRun).toBe(true);
+    expect(plan.cadence).toBe("weekly");
+    expect(plan.tickMs).toBe(24 * 60 * 60 * 1000);
+    expect(plan.refreshIntervalMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("disabled feature: shouldRun=false, kein Tick", () => {
+    const plan = planGeoIpRefreshSchedule({ provider: "dbip-lite", enabled: false });
+    expect(plan.shouldRun).toBe(false);
+    expect(plan.tickMs).toBe(0);
+  });
+
+  it("isRefreshDue prüft die Distanz seit dem letzten Lauf", () => {
+    const plan = planGeoIpRefreshSchedule({ provider: "dbip-lite", enabled: true });
+    const now = Date.parse("2026-04-15T00:00:00Z");
+    // Letzter Run vor 1 Tag → noch nicht due (monatlich = 30d).
+    expect(plan.isRefreshDue(now, now - 24 * 60 * 60 * 1000)).toBe(false);
+    // Letzter Run vor 31 Tagen → due.
+    expect(plan.isRefreshDue(now, now - 31 * 24 * 60 * 60 * 1000)).toBe(true);
+    // Noch nie gelaufen → immer due.
+    expect(plan.isRefreshDue(now, null)).toBe(true);
+  });
+
+  it("isRefreshDue ist für maxmind weekly empfindlicher", () => {
+    const plan = planGeoIpRefreshSchedule({ provider: "maxmind", enabled: true });
+    const now = Date.parse("2026-04-15T00:00:00Z");
+    // 8 Tage her → due (wöchentlich = 7d).
+    expect(plan.isRefreshDue(now, now - 8 * 24 * 60 * 60 * 1000)).toBe(true);
+    // 6 Tage her → noch nicht due.
+    expect(plan.isRefreshDue(now, now - 6 * 24 * 60 * 60 * 1000)).toBe(false);
+  });
+});

--- a/tests/stories/geoip-download-planner.story.test.ts
+++ b/tests/stories/geoip-download-planner.story.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GEOIP_DEFAULT_DB_PATH,
+  GeoIpLicenseKeyMissingError,
+  GeoIpUnsupportedProviderError,
+  planGeoIpDownload,
+} from "../../src/core/geoip/download-planner.js";
+
+/**
+ * Story · GeoIp Download Planner
+ *
+ * Pure planner: takes provider + license-key + an explicit "now"
+ * (so URL templates that embed `YYYY-MM` stay deterministic in tests)
+ * and returns the download spec. No fs, no fetch.
+ *
+ * Two providers ship:
+ *   - dbip-lite (default) — no key, monthly, CC-BY-4.0
+ *   - maxmind  (opt-in)   — license-key required (Schrems-II)
+ */
+describe("Story · GeoIp Download Planner", () => {
+  describe("dbip-lite", () => {
+    it("baut die monatliche dbip-city-lite-URL aus der `now`-Zeit", () => {
+      const plan = planGeoIpDownload({
+        provider: "dbip-lite",
+        now: new Date("2026-04-15T00:00:00Z"),
+      });
+      expect(plan.provider).toBe("dbip-lite");
+      expect(plan.url).toBe(
+        "https://download.db-ip.com/free/dbip-city-lite-2026-04.mmdb.gz",
+      );
+      expect(plan.archiveFormat).toBe("gz");
+      expect(plan.savePath).toBe(GEOIP_DEFAULT_DB_PATH);
+      expect(plan.cadence).toBe("monthly");
+      expect(plan.licenseLabel).toBe("CC-BY-4.0 (db-ip.com)");
+      // Monthly snapshots: kein Pflicht-License-Key.
+      expect(plan.requiresLicenseKey).toBe(false);
+    });
+
+    it("padded den Monat zweistellig (01..09 mit führender Null)", () => {
+      const plan = planGeoIpDownload({
+        provider: "dbip-lite",
+        now: new Date("2026-01-03T00:00:00Z"),
+      });
+      expect(plan.url).toContain("2026-01.mmdb.gz");
+    });
+
+    it("nimmt einen explizit gesetzten dbPath", () => {
+      const plan = planGeoIpDownload({
+        provider: "dbip-lite",
+        now: new Date("2026-04-15T00:00:00Z"),
+        dbPath: "/var/lib/geoip/city.mmdb",
+      });
+      expect(plan.savePath).toBe("/var/lib/geoip/city.mmdb");
+    });
+
+    it("ignoriert einen optional gesetzten licenseKey (dbip-lite braucht ihn nicht)", () => {
+      const plan = planGeoIpDownload({
+        provider: "dbip-lite",
+        now: new Date("2026-04-15T00:00:00Z"),
+        licenseKey: "ignored-on-dbip",
+      });
+      expect(plan.url).not.toContain("ignored-on-dbip");
+    });
+  });
+
+  describe("maxmind", () => {
+    it("baut die GeoLite2-City-Download-URL inkl. License-Key", () => {
+      const plan = planGeoIpDownload({
+        provider: "maxmind",
+        now: new Date("2026-04-15T00:00:00Z"),
+        licenseKey: "abc123XYZ",
+      });
+      expect(plan.provider).toBe("maxmind");
+      expect(plan.url).toBe(
+        "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=abc123XYZ&suffix=tar.gz",
+      );
+      expect(plan.archiveFormat).toBe("tar.gz");
+      expect(plan.cadence).toBe("weekly");
+      expect(plan.licenseLabel).toContain("MaxMind");
+      expect(plan.requiresLicenseKey).toBe(true);
+    });
+
+    it("wirft GeoIpLicenseKeyMissingError ohne licenseKey", () => {
+      expect(() =>
+        planGeoIpDownload({
+          provider: "maxmind",
+          now: new Date("2026-04-15T00:00:00Z"),
+        }),
+      ).toThrow(GeoIpLicenseKeyMissingError);
+    });
+
+    it("wirft GeoIpLicenseKeyMissingError bei leerem licenseKey", () => {
+      expect(() =>
+        planGeoIpDownload({
+          provider: "maxmind",
+          now: new Date("2026-04-15T00:00:00Z"),
+          licenseKey: "   ",
+        }),
+      ).toThrow(GeoIpLicenseKeyMissingError);
+    });
+
+    it("URL-encodet Sonderzeichen im License-Key", () => {
+      const plan = planGeoIpDownload({
+        provider: "maxmind",
+        now: new Date("2026-04-15T00:00:00Z"),
+        licenseKey: "a/b+c=d",
+      });
+      expect(plan.url).toContain("license_key=a%2Fb%2Bc%3Dd");
+    });
+  });
+
+  describe("error paths", () => {
+    it("wirft GeoIpUnsupportedProviderError für unbekannte Provider", () => {
+      expect(() =>
+        planGeoIpDownload({
+          // @ts-expect-error — explizit invalid für Runtime-Branch
+          provider: "ipinfo",
+          now: new Date("2026-04-15T00:00:00Z"),
+        }),
+      ).toThrow(GeoIpUnsupportedProviderError);
+    });
+  });
+});

--- a/tests/stories/geoip-download-planner.story.test.ts
+++ b/tests/stories/geoip-download-planner.story.test.ts
@@ -26,9 +26,7 @@ describe("Story · GeoIp Download Planner", () => {
         now: new Date("2026-04-15T00:00:00Z"),
       });
       expect(plan.provider).toBe("dbip-lite");
-      expect(plan.url).toBe(
-        "https://download.db-ip.com/free/dbip-city-lite-2026-04.mmdb.gz",
-      );
+      expect(plan.url).toBe("https://download.db-ip.com/free/dbip-city-lite-2026-04.mmdb.gz");
       expect(plan.archiveFormat).toBe("gz");
       expect(plan.savePath).toBe(GEOIP_DEFAULT_DB_PATH);
       expect(plan.cadence).toBe("monthly");

--- a/tests/stories/geoip-download-runner.story.test.ts
+++ b/tests/stories/geoip-download-runner.story.test.ts
@@ -1,0 +1,154 @@
+import { gzipSync } from "node:zlib";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { runGeoIpDownload } from "../../src/core/geoip/download-runner.js";
+
+/**
+ * Story · GeoIp Download Runner
+ *
+ * Wraps the planner: fetches the URL, decompresses based on
+ * `archiveFormat`, writes to `savePath`. Both fetch and fs are
+ * injected — tests don't hit the network or touch disk.
+ *
+ * `tar.gz` (MaxMind) is decompressed by lazy-importing
+ * `node:zlib` + walking the tar headers. The test harness only
+ * exercises the `gz` path (dbip-lite); MaxMind format coverage
+ * happens in the planner test.
+ */
+describe("Story · GeoIp Download Runner", () => {
+  it("lädt dbip-lite, dekomprimiert .gz, schreibt savePath", async () => {
+    const mmdbBytes = Buffer.from([0xab, 0xcd, 0xef]); // dummy
+    const gz = gzipSync(mmdbBytes);
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
+    }));
+    const writes: { path: string; bytes: Uint8Array }[] = [];
+    const fs = {
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async (path: string, bytes: Uint8Array) => {
+        writes.push({ path, bytes });
+      }),
+    };
+
+    const result = await runGeoIpDownload(
+      {
+        provider: "dbip-lite",
+        url: "https://download.db-ip.com/free/dbip-city-lite-2026-04.mmdb.gz",
+        savePath: "/tmp/test/city.mmdb",
+        archiveFormat: "gz",
+        cadence: "monthly",
+        requiresLicenseKey: false,
+        licenseLabel: "CC-BY-4.0 (db-ip.com)",
+      },
+      { fetch: fetcher, fs },
+    );
+
+    expect(result.bytesWritten).toBe(mmdbBytes.length);
+    expect(result.savePath).toBe("/tmp/test/city.mmdb");
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fs.mkdir).toHaveBeenCalledWith("/tmp/test", { recursive: true });
+    expect(fs.writeFile).toHaveBeenCalledOnce();
+    expect(writes[0]?.path).toBe("/tmp/test/city.mmdb");
+    expect(Buffer.compare(writes[0]!.bytes, mmdbBytes)).toBe(0);
+  });
+
+  it("wirft, wenn der HTTP-Status nicht ok ist", async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    }));
+    const fs = {
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async () => undefined),
+    };
+
+    await expect(
+      runGeoIpDownload(
+        {
+          provider: "dbip-lite",
+          url: "https://download.db-ip.com/free/missing.mmdb.gz",
+          savePath: "/tmp/test/city.mmdb",
+          archiveFormat: "gz",
+          cadence: "monthly",
+          requiresLicenseKey: false,
+          licenseLabel: "CC-BY-4.0 (db-ip.com)",
+        },
+        { fetch: fetcher, fs },
+      ),
+    ).rejects.toThrow(/404/);
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("dekomprimiert tar.gz und extrahiert das *.mmdb-File", async () => {
+    // Ein minimal-tar mit einer einzigen Datei `GeoLite2-City_20260401/GeoLite2-City.mmdb`.
+    const mmdbBytes = Buffer.from("MMDB-PAYLOAD-EXAMPLE");
+    const tar = makeMinimalTar(
+      "GeoLite2-City_20260401/GeoLite2-City.mmdb",
+      mmdbBytes,
+    );
+    const gz = gzipSync(tar);
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      arrayBuffer: () => Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
+    }));
+    let writtenBytes: Uint8Array | undefined;
+    const fs = {
+      mkdir: vi.fn(async () => undefined),
+      writeFile: vi.fn(async (_path: string, bytes: Uint8Array) => {
+        writtenBytes = bytes;
+      }),
+    };
+
+    const result = await runGeoIpDownload(
+      {
+        provider: "maxmind",
+        url: "https://download.maxmind.com/app/geoip_download?...",
+        savePath: "/tmp/test/city.mmdb",
+        archiveFormat: "tar.gz",
+        cadence: "weekly",
+        requiresLicenseKey: true,
+        licenseLabel: "MaxMind GeoLite2-City EULA",
+      },
+      { fetch: fetcher, fs },
+    );
+
+    expect(result.bytesWritten).toBe(mmdbBytes.length);
+    expect(writtenBytes).toBeDefined();
+    expect(Buffer.compare(writtenBytes!, mmdbBytes)).toBe(0);
+  });
+});
+
+/**
+ * Build a minimal POSIX-tar archive containing exactly one file at
+ * `name` with `body`. Pads to 512-byte blocks. Sufficient for the
+ * runner's tar walker — no extended headers, no longlinks.
+ */
+function makeMinimalTar(name: string, body: Buffer): Buffer {
+  const blockSize = 512;
+  const header = Buffer.alloc(blockSize);
+  header.write(name, 0, 100, "utf8");
+  header.write("0000644", 100, 8, "ascii"); // mode
+  header.write("0000000", 108, 8, "ascii"); // uid
+  header.write("0000000", 116, 8, "ascii"); // gid
+  header.write(body.length.toString(8).padStart(11, "0") + " ", 124, 12, "ascii"); // size (octal)
+  header.write("00000000000 ", 136, 12, "ascii"); // mtime
+  header.write("        ", 148, 8, "ascii"); // checksum (spaces during calc)
+  header.write("0", 156, 1, "ascii"); // typeflag = regular file
+  header.write("ustar  \0", 257, 8, "ascii"); // magic
+  // checksum
+  let sum = 0;
+  for (let i = 0; i < blockSize; i++) sum += header[i]!;
+  const cs = sum.toString(8).padStart(6, "0");
+  header.write(cs, 148, 6, "ascii");
+  header.write("\0 ", 154, 2, "ascii");
+
+  const padding = Buffer.alloc((blockSize - (body.length % blockSize)) % blockSize);
+  // Two zero-blocks terminate the archive.
+  const trailer = Buffer.alloc(blockSize * 2);
+  return Buffer.concat([header, body, padding, trailer]);
+}

--- a/tests/stories/geoip-download-runner.story.test.ts
+++ b/tests/stories/geoip-download-runner.story.test.ts
@@ -23,7 +23,8 @@ describe("Story · GeoIp Download Runner", () => {
     const fetcher = vi.fn(async () => ({
       ok: true,
       status: 200,
-      arrayBuffer: () => Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
+      arrayBuffer: () =>
+        Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
     }));
     const writes: { path: string; bytes: Uint8Array }[] = [];
     const fs = {
@@ -86,15 +87,13 @@ describe("Story · GeoIp Download Runner", () => {
   it("dekomprimiert tar.gz und extrahiert das *.mmdb-File", async () => {
     // Ein minimal-tar mit einer einzigen Datei `GeoLite2-City_20260401/GeoLite2-City.mmdb`.
     const mmdbBytes = Buffer.from("MMDB-PAYLOAD-EXAMPLE");
-    const tar = makeMinimalTar(
-      "GeoLite2-City_20260401/GeoLite2-City.mmdb",
-      mmdbBytes,
-    );
+    const tar = makeMinimalTar("GeoLite2-City_20260401/GeoLite2-City.mmdb", mmdbBytes);
     const gz = gzipSync(tar);
     const fetcher = vi.fn(async () => ({
       ok: true,
       status: 200,
-      arrayBuffer: () => Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
+      arrayBuffer: () =>
+        Promise.resolve(gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength)),
     }));
     let writtenBytes: Uint8Array | undefined;
     const fs = {

--- a/tests/stories/geoip-feature-flag.story.test.ts
+++ b/tests/stories/geoip-feature-flag.story.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { FEATURE_CATALOG, isFeatureActive } from "../../src/core/dx/feature-catalog.js";
+import { FeaturesSchema, loadFeatures } from "../../src/core/features/features.js";
+
+/**
+ * Story · GeoIp Feature-Flag
+ *
+ * `FeaturesSchema.geoIp` is the third "geo*" subsection (alongside
+ * `geo` for geocoding and PostGIS). It defaults to off, picks
+ * `dbip-lite` as the no-key provider, and exposes
+ * `licenseKey` + `dbPath` for opt-in MaxMind tuning.
+ *
+ * The feature catalog must list it so `/dev/features` can render
+ * the toggle, and `loadFeatures()` must respond to the
+ * `FEATURE_GEO_IP_*` ENV-Var family.
+ */
+describe("Story · GeoIp Feature-Flag", () => {
+  it("defaults: enabled=false, provider=dbip-lite, dbPath=./data/geoip/city.mmdb", () => {
+    const features = FeaturesSchema.parse({});
+    expect(features.geoIp.enabled).toBe(false);
+    expect(features.geoIp.provider).toBe("dbip-lite");
+    expect(features.geoIp.licenseKey).toBeUndefined();
+    expect(features.geoIp.dbPath).toBe("./data/geoip/city.mmdb");
+  });
+
+  it("FEATURE_GEO_IP_ENABLED=true flips the toggle on", () => {
+    const features = loadFeatures({ FEATURE_GEO_IP_ENABLED: "true" });
+    expect(features.geoIp.enabled).toBe(true);
+  });
+
+  it("FEATURE_GEO_IP_PROVIDER=maxmind switches the provider", () => {
+    const features = loadFeatures({
+      FEATURE_GEO_IP_ENABLED: "true",
+      FEATURE_GEO_IP_PROVIDER: "maxmind",
+      FEATURE_GEO_IP_LICENSE_KEY: "abc123",
+    });
+    expect(features.geoIp.provider).toBe("maxmind");
+    expect(features.geoIp.licenseKey).toBe("abc123");
+  });
+
+  it("rejects unknown providers", () => {
+    expect(() => loadFeatures({ FEATURE_GEO_IP_PROVIDER: "ipinfo" })).toThrow();
+  });
+
+  it("FEATURE_GEO_IP_DB_PATH overrides the .mmdb location", () => {
+    const features = loadFeatures({ FEATURE_GEO_IP_DB_PATH: "/var/lib/geoip/city.mmdb" });
+    expect(features.geoIp.dbPath).toBe("/var/lib/geoip/city.mmdb");
+  });
+
+  it("FEATURE_CATALOG enthält den neuen geoIp-Eintrag", () => {
+    const meta = FEATURE_CATALOG.find((f) => f.key === "geoIp");
+    expect(meta).toBeDefined();
+    expect(meta?.envKey).toBe("FEATURE_GEO_IP_ENABLED");
+    expect(meta?.category).toBe("data");
+    expect(meta?.exposes.length).toBeGreaterThan(0);
+  });
+
+  it("isFeatureActive reagiert auf FEATURE_GEO_IP_ENABLED", () => {
+    const off = loadFeatures({});
+    expect(isFeatureActive(off, "geoIp")).toBe(false);
+    const on = loadFeatures({ FEATURE_GEO_IP_ENABLED: "true" });
+    expect(isFeatureActive(on, "geoIp")).toBe(true);
+  });
+});

--- a/tests/stories/geoip-resolver.story.test.ts
+++ b/tests/stories/geoip-resolver.story.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { mapMmdbCityRecord } from "../../src/core/geoip/resolver.js";
+
+/**
+ * Story · GeoIp Resolver (pure mapper)
+ *
+ * `mapMmdbCityRecord(raw)` is the pure function that converts a
+ * MaxMind/dbip-lite city record (their JSON shape after .mmdb
+ * decode) into our normalised `GeoIpLookupResult`. The runtime
+ * `GeoIpService` wraps the `.mmdb` reader; this helper is the
+ * unit-testable seam.
+ *
+ * Why pure: the GeoIpService can't load a `.mmdb` in CI without
+ * a fixture file, but the mapping logic — which fields to pluck,
+ * how to fall back when partial data is present — needs coverage.
+ */
+describe("Story · GeoIp Resolver Mapping", () => {
+  it("mappt einen vollständigen MaxMind-City-Record", () => {
+    const raw = {
+      country: { iso_code: "US", names: { en: "United States" } },
+      city: { names: { en: "Mountain View" } },
+      subdivisions: [{ iso_code: "CA", names: { en: "California" } }],
+      location: { latitude: 37.386, longitude: -122.0838, accuracy_radius: 1000 },
+    };
+    const result = mapMmdbCityRecord(raw);
+    expect(result).toEqual({
+      country: "United States",
+      countryCode: "US",
+      city: "Mountain View",
+      region: "California",
+      regionCode: "CA",
+      latitude: 37.386,
+      longitude: -122.0838,
+      accuracyRadius: 1000,
+    });
+  });
+
+  it("mappt einen reduzierten dbip-lite-Record (nur country)", () => {
+    const raw = {
+      country: { iso_code: "DE", names: { en: "Germany" } },
+    };
+    const result = mapMmdbCityRecord(raw);
+    expect(result).toEqual({
+      country: "Germany",
+      countryCode: "DE",
+    });
+  });
+
+  it("returnt null für ein leeres Objekt", () => {
+    expect(mapMmdbCityRecord({})).toBeNull();
+  });
+
+  it("returnt null für null/undefined", () => {
+    expect(mapMmdbCityRecord(null)).toBeNull();
+    expect(mapMmdbCityRecord(undefined)).toBeNull();
+  });
+
+  it("ignoriert numerische Felder mit fehlenden Werten", () => {
+    const raw = {
+      country: { iso_code: "FR", names: { en: "France" } },
+      location: { latitude: 48.8566 }, // longitude fehlt → kein Lat/Lng-Pair
+    };
+    const result = mapMmdbCityRecord(raw);
+    expect(result?.country).toBe("France");
+    // Kein vollständiges Lat/Lng-Pair → beide weglassen
+    expect(result?.latitude).toBeUndefined();
+    expect(result?.longitude).toBeUndefined();
+  });
+
+  it("nimmt city.names.en sowie das erste subdivision-Element", () => {
+    const raw = {
+      country: { iso_code: "GB", names: { en: "United Kingdom" } },
+      city: { names: { en: "London" } },
+      subdivisions: [
+        { iso_code: "ENG", names: { en: "England" } },
+        { iso_code: "LND", names: { en: "Greater London" } },
+      ],
+    };
+    const result = mapMmdbCityRecord(raw);
+    expect(result?.city).toBe("London");
+    expect(result?.region).toBe("England");
+    expect(result?.regionCode).toBe("ENG");
+  });
+
+  it("ist robust gegen fehlende names-Maps", () => {
+    const raw = { country: { iso_code: "JP" } };
+    const result = mapMmdbCityRecord(raw);
+    expect(result).toEqual({ countryCode: "JP" });
+  });
+});

--- a/tests/stories/geoip-service.story.test.ts
+++ b/tests/stories/geoip-service.story.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { GeoIpService, type MmdbCityReader } from "../../src/core/geoip/geoip.service.js";
+
+/**
+ * Story · GeoIp Service
+ *
+ * `GeoIpService.lookup(ip)` flows:
+ *   raw .mmdb record → mapMmdbCityRecord → normalised shape | null
+ *
+ * The reader is injected (`MmdbCityReader`) so unit tests can
+ * pin a deterministic record without touching the maxmind npm
+ * package or the filesystem. Cold-boot (no reader resolved) must
+ * not crash — service returns `null` and logs a warning.
+ */
+describe("Story · GeoIp Service", () => {
+  function makeReader(map: Record<string, unknown | null>): MmdbCityReader {
+    return {
+      get(ip: string) {
+        return map[ip] ?? null;
+      },
+    };
+  }
+
+  it("returnt das gemappte Profil für eine bekannte IP", async () => {
+    const service = new GeoIpService({
+      readerFactory: () =>
+        Promise.resolve(
+          makeReader({
+            "8.8.8.8": {
+              country: { iso_code: "US", names: { en: "United States" } },
+              city: { names: { en: "Mountain View" } },
+              location: { latitude: 37.386, longitude: -122.0838, accuracy_radius: 1000 },
+            },
+          }),
+        ),
+    });
+    const result = await service.lookup("8.8.8.8");
+    expect(result).toMatchObject({
+      countryCode: "US",
+      city: "Mountain View",
+      country: "United States",
+    });
+  });
+
+  it("returnt null wenn die IP unbekannt ist", async () => {
+    const service = new GeoIpService({
+      readerFactory: () => Promise.resolve(makeReader({})),
+    });
+    expect(await service.lookup("203.0.113.1")).toBeNull();
+  });
+
+  it("returnt null wenn kein Reader vorhanden ist (cold-boot ohne .mmdb)", async () => {
+    const warn = vi.fn();
+    const service = new GeoIpService({
+      readerFactory: () => Promise.resolve(null),
+      logger: { warn, log: vi.fn(), error: vi.fn() },
+    });
+    expect(await service.lookup("8.8.8.8")).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("cached den Reader: readerFactory wird nur einmal aufgerufen", async () => {
+    let calls = 0;
+    const factory = () => {
+      calls++;
+      return Promise.resolve(makeReader({ "1.1.1.1": { country: { iso_code: "US" } } }));
+    };
+    const service = new GeoIpService({ readerFactory: factory });
+    await service.lookup("1.1.1.1");
+    await service.lookup("1.1.1.1");
+    await service.lookup("1.1.1.1");
+    expect(calls).toBe(1);
+  });
+
+  it("crasht nicht, wenn der Reader synchronously wirft", async () => {
+    const error = vi.fn();
+    const service = new GeoIpService({
+      readerFactory: () =>
+        Promise.resolve({
+          get() {
+            throw new Error("boom");
+          },
+        }),
+      logger: { warn: vi.fn(), log: vi.fn(), error },
+    });
+    expect(await service.lookup("8.8.8.8")).toBeNull();
+    expect(error).toHaveBeenCalledOnce();
+  });
+
+  it("returnt null bei leerer/undefined IP", async () => {
+    const service = new GeoIpService({
+      readerFactory: () => Promise.resolve(makeReader({})),
+    });
+    expect(await service.lookup("")).toBeNull();
+    expect(await service.lookup(undefined as unknown as string)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/core/geoip/` with a pure download-planner (per-provider URL + license-key gating), thin runner (`gz` + `tar.gz` extraction with injected `fetch`/`fs`), pure mmdb record mapper, and a `GeoIpService` that lazy-loads the `maxmind` npm package only when the feature is enabled and the `.mmdb` is on disk. Cold-boot stays soft: missing database → null + warning, never a crash.
- Wires the new toggle as the 15th feature (`FeaturesSchema.geoIp`, `FEATURE_GEO_IP_*` env-overrides, feature-catalog entry) and adds an `OnModuleInit` cron that re-downloads on the cadence dictated by `planGeoIpRefreshSchedule()` (monthly for dbip-lite, weekly for MaxMind).
- Ships `bun run scripts/download-geoip.ts` and a `geoip-init` oneshot Compose service (under the `geoip` profile) for first-time setup. `data/geoip/` and `*.mmdb` are gitignored — binary files are never committed.
- Documents the provider matrix, Schrems-II considerations, and CC-BY-4.0 attribution in `src/core/geoip/CLAUDE.md`, `README.md`, and the regenerated `.env.example` (`buildDefaultEnvExample()` is now the source of truth for both providers).

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format` — clean
- [x] `bun run test:types` — clean (lazy-import behind a string literal so `tsc` never tries to resolve `maxmind`)
- [x] `bun run test:unit` — 139/139 pass
- [x] `bun run test:e2e` — 1809/1809 pass (added 8 new story tests covering planner, runner, resolver, service, cron schedule, feature flag)
- [x] `bun run test:coverage` — 93.24% lines / 85.57% branches overall; new files all ≥85% lines, ≥70% branches
- [x] `bun run build:dev-portal` + `bun run build` — clean

## Acceptance Criteria mapping

- [x] `GeoIpSchema` in `features.ts` (provider enum, optional licenseKey, dbPath default).
- [x] Catalog entry in `feature-catalog.ts`.
- [x] Core folder with `geoip.service.ts`, `geoip.module.ts`, `download-planner.ts`, `download-runner.ts` + companion `resolver.ts` + `refresh-schedule.ts`.
- [x] `scripts/download-geoip.ts` reads env, calls planner+runner.
- [x] Auto-update via `GeoIpRefreshCron` (`OnModuleInit`, daily tick + cadence-aware refresh decision).
- [x] Docker-Compose oneshot `geoip-init` (gated by the `geoip` profile so default `up` stays unchanged).
- [x] Story tests for planner (URL build per provider, missing-license-key check), runner (gz + tar.gz extraction), service (cold-boot null, reader caching, error tolerance).
- [x] `.env.example` (regenerated via `buildDefaultEnvExample()`) and `CLAUDE.md` documentation.
- [x] CC-BY-4.0 + MaxMind EULA attribution in `README.md`.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)