### PR TITLE
feat(dev-portal): jobs dashboard (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ Every Prisma query event lands in a 500-entry ring buffer. The page surfaces:
 
 If a slice you just shipped lands in the slowest section, that's your next thing to fix.
 
+### Jobs Dashboard — `/dev/jobs`
+
+Two-tab view of the in-memory `JobQueueService` (the future pg-boss adapter exposes the same JSON contract):
+
+- **Queues** — per-queue counts, p95 latency, failure rate. Click a queue to filter the Jobs tab.
+- **Jobs** — paginated, queue + state filterable list. Inspect opens a drawer with the full payload (rendered in the JSON viewer), the captured error stack on failed jobs, and a Retry button that POSTs to `/dev/jobs/jobs/:id/retry` and re-enqueues a failed job with a bumped attempt counter.
+
+Pure planner (`buildJobAggregates()`) computes counts / p95 / failure-rate over a flat `JobRecord` list, so the same dashboard renders unchanged once a Postgres-backed adapter ships. Auto-refresh every 4 s. Schedules / Workers / Archive tabs are deferred to the pg-boss adapter slice.
+
 ### Routes Inventory — `/dev/routes`
 
 Live audit of every endpoint registered in NestJS, with its decorator-derived guard kind: `@Can(action, subject)` (guarded), `public` (allowlist), `dev-only` (404s in prod), or `unguarded` (red). 5-tile summary with per-kind counts so an auditor can spot gaps. JSON endpoint at `/dev/routes.json` for SDK / agent tooling.

--- a/src/core/dx/clients/App.tsx
+++ b/src/core/dx/clients/App.tsx
@@ -43,6 +43,7 @@ const QueriesPage = lazy(() =>
 const MigrationsPage = lazy(() =>
   import("./pages/MigrationsPage.js").then((m) => ({ default: m.MigrationsPage })),
 );
+const JobsPage = lazy(() => import("./pages/JobsPage.js").then((m) => ({ default: m.JobsPage })));
 const RoutesPage = lazy(() =>
   import("./pages/RoutesPage.js").then((m) => ({ default: m.RoutesPage })),
 );
@@ -97,6 +98,7 @@ export function App(): ReactNode {
         <Route path="/dev/traces" element={<TracesPage />} />
         <Route path="/dev/queries" element={<QueriesPage />} />
         <Route path="/dev/migrations" element={<MigrationsPage />} />
+        <Route path="/dev/jobs" element={<JobsPage />} />
         <Route path="/dev/routes" element={<RoutesPage />} />
         <Route path="/dev/erd" element={<ErdPage />} />
         <Route path="/dev/email-preview" element={<EmailPreviewPage />} />

--- a/src/core/dx/clients/layout/icons.tsx
+++ b/src/core/dx/clients/layout/icons.tsx
@@ -136,6 +136,13 @@ export const ICONS: Record<string, ReactElement> = {
       <polyline points="22 6 12 13 2 6" />
     </svg>
   ),
+  layers: (
+    <svg {...COMMON}>
+      <polygon points="12 2 2 7 12 12 22 7 12 2" />
+      <polyline points="2 17 12 22 22 17" />
+      <polyline points="2 12 12 17 22 12" />
+    </svg>
+  ),
 };
 
 /**

--- a/src/core/dx/clients/layout/nav.ts
+++ b/src/core/dx/clients/layout/nav.ts
@@ -37,6 +37,7 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "traces", label: "Traces", href: "/dev/traces", icon: "pulse" },
       { id: "queries", label: "Queries", href: "/dev/queries", icon: "database" },
       { id: "migrations", label: "Migrations", href: "/dev/migrations", icon: "database" },
+      { id: "jobs", label: "Jobs", href: "/dev/jobs", icon: "layers" },
     ],
   },
   {
@@ -87,6 +88,7 @@ export const SPA_ROUTES = new Set<string>([
   "/dev/traces",
   "/dev/queries",
   "/dev/migrations",
+  "/dev/jobs",
   "/dev/routes",
   "/dev/erd",
   "/dev/email-preview",

--- a/src/core/dx/clients/pages/JobsPage.tsx
+++ b/src/core/dx/clients/pages/JobsPage.tsx
@@ -1,0 +1,454 @@
+/**
+ * `/dev/jobs` — Jobs-Dashboard for the in-memory queue (and any future
+ * pg-boss-backed adapter that exposes the same `/dev/jobs/*` JSON
+ * contract).
+ *
+ * Two tabs:
+ *   - **Queues** — per-queue counts, p95 latency, failure rate
+ *   - **Jobs**   — paginated, state-filterable listing with a drawer
+ *                  that shows the full payload + error + retry CTA
+ *
+ * The page polls both endpoints every 4 s while open. The Schedules /
+ * Workers / Archive tabs from the issue are intentionally deferred —
+ * pg-boss surface, separate slice (see issue #15 follow-up notes).
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type Key, type ReactNode } from "react";
+
+import { Button, Select, SelectItem, Tab, TabList, TabPanel, Tabs } from "../components/index.js";
+import { JsonViewer } from "../components/JsonViewer.js";
+import { AdminShell } from "../layout/AdminShell.js";
+import { fetchJson, formatMs } from "../lib/api.js";
+
+interface StateCounts {
+  created: number;
+  active: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  retry: number;
+}
+
+interface QueueAggregate {
+  name: string;
+  total: number;
+  counts: StateCounts;
+  p95LatencyMs: number | null;
+  failureRate: number;
+}
+
+interface JobAggregates {
+  totalJobs: number;
+  totals: StateCounts;
+  failureRate: number;
+  p95LatencyMs: number | null;
+  queues: QueueAggregate[];
+}
+
+type JobState = keyof StateCounts;
+
+interface JobRecord {
+  id: string;
+  name: string;
+  state: JobState;
+  attempt: number;
+  payload: unknown;
+  createdAt: number;
+  startedAt?: number;
+  completedAt?: number;
+  errorMessage?: string;
+  errorStack?: string;
+}
+
+interface JobListResponse {
+  jobs: JobRecord[];
+}
+
+const STATE_FILTERS: readonly { id: string; label: string }[] = [
+  { id: "all", label: "All states" },
+  { id: "created", label: "Created" },
+  { id: "active", label: "Active" },
+  { id: "completed", label: "Completed" },
+  { id: "failed", label: "Failed" },
+  { id: "cancelled", label: "Cancelled" },
+  { id: "retry", label: "Retry" },
+];
+
+const POLL_INTERVAL_MS = 4000;
+
+export function JobsPage(): ReactNode {
+  const aggregates = useQuery({
+    queryKey: ["dev", "jobs", "queues"],
+    queryFn: () => fetchJson<JobAggregates>("/dev/jobs/queues.json"),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const subtitle = aggregates.data
+    ? `${aggregates.data.totalJobs} jobs across ${aggregates.data.queues.length} queues · auto-refresh every ${POLL_INTERVAL_MS / 1000} s`
+    : "Loading…";
+
+  return (
+    <AdminShell title="Jobs" subtitle={subtitle} currentNav="jobs">
+      {aggregates.data ? (
+        <JobsBody aggregates={aggregates.data} />
+      ) : aggregates.isError ? (
+        <div className="admin-empty">Failed to load job aggregates.</div>
+      ) : (
+        <div className="admin-empty">Loading job aggregates…</div>
+      )}
+    </AdminShell>
+  );
+}
+
+function JobsBody({ aggregates }: { aggregates: JobAggregates }): ReactNode {
+  const [queueFilter, setQueueFilter] = useState<string>("");
+  const [stateFilter, setStateFilter] = useState<string>("all");
+  const [activeTab, setActiveTab] = useState<Key>("queues");
+
+  return (
+    <>
+      <SummaryTiles aggregates={aggregates} />
+      <Tabs selectedKey={activeTab} onSelectionChange={setActiveTab}>
+        <TabList aria-label="Jobs sections">
+          <Tab id="queues">Queues</Tab>
+          <Tab id="jobs">Jobs</Tab>
+        </TabList>
+        <TabPanel id="queues">
+          <QueuesTab
+            aggregates={aggregates}
+            onQueueClick={(name) => {
+              setQueueFilter(name);
+              setActiveTab("jobs");
+            }}
+          />
+        </TabPanel>
+        <TabPanel id="jobs">
+          <JobsTab
+            queueFilter={queueFilter}
+            onQueueFilterChange={setQueueFilter}
+            stateFilter={stateFilter}
+            onStateFilterChange={setStateFilter}
+            queueOptions={aggregates.queues.map((q) => q.name)}
+          />
+        </TabPanel>
+      </Tabs>
+    </>
+  );
+}
+
+function SummaryTiles({ aggregates }: { aggregates: JobAggregates }): ReactNode {
+  const failurePct = (aggregates.failureRate * 100).toFixed(1);
+  const p95 = aggregates.p95LatencyMs === null ? "—" : formatMs(aggregates.p95LatencyMs);
+  return (
+    <div className="feat-summary">
+      <div className="feat-tile">
+        <span className="feat-tile__label">Total jobs</span>
+        <span className="feat-tile__value">{aggregates.totalJobs}</span>
+      </div>
+      <div className="feat-tile feat-tile--ok">
+        <span className="feat-tile__label">Completed</span>
+        <span className="feat-tile__value">{aggregates.totals.completed}</span>
+      </div>
+      <div className="feat-tile">
+        <span className="feat-tile__label">Active / pending</span>
+        <span className="feat-tile__value">
+          {aggregates.totals.active + aggregates.totals.created + aggregates.totals.retry}
+        </span>
+      </div>
+      <div className="feat-tile">
+        <span className="feat-tile__label">Failed</span>
+        <span className="feat-tile__value">{aggregates.totals.failed}</span>
+      </div>
+      <div className="feat-tile">
+        <span className="feat-tile__label">Failure rate</span>
+        <span className="feat-tile__value">{failurePct}%</span>
+      </div>
+      <div className="feat-tile">
+        <span className="feat-tile__label">p95 latency</span>
+        <span className="feat-tile__value">{p95}</span>
+      </div>
+    </div>
+  );
+}
+
+interface QueuesTabProps {
+  aggregates: JobAggregates;
+  onQueueClick: (name: string) => void;
+}
+
+function QueuesTab({ aggregates, onQueueClick }: QueuesTabProps): ReactNode {
+  if (aggregates.queues.length === 0) {
+    return <div className="admin-empty">No queues active yet — enqueue a job to see it here.</div>;
+  }
+  return (
+    <div className="admin-card">
+      <table className="log-table">
+        <thead>
+          <tr>
+            <th>Queue</th>
+            <th style={{ textAlign: "right" }}>Total</th>
+            <th style={{ textAlign: "right" }}>Active</th>
+            <th style={{ textAlign: "right" }}>Completed</th>
+            <th style={{ textAlign: "right" }}>Failed</th>
+            <th style={{ textAlign: "right" }}>p95 latency</th>
+            <th style={{ textAlign: "right" }}>Failure rate</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {aggregates.queues.map((queue) => (
+            <tr key={queue.name}>
+              <td>
+                <strong>{queue.name}</strong>
+              </td>
+              <td style={{ textAlign: "right" }}>{queue.total}</td>
+              <td style={{ textAlign: "right" }}>{queue.counts.active + queue.counts.created}</td>
+              <td style={{ textAlign: "right" }}>{queue.counts.completed}</td>
+              <td style={{ textAlign: "right" }}>{queue.counts.failed}</td>
+              <td style={{ textAlign: "right" }}>
+                {queue.p95LatencyMs === null ? "—" : formatMs(queue.p95LatencyMs)}
+              </td>
+              <td style={{ textAlign: "right" }}>{(queue.failureRate * 100).toFixed(1)}%</td>
+              <td>
+                <Button onPress={() => onQueueClick(queue.name)}>Filter jobs →</Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface JobsTabProps {
+  queueFilter: string;
+  onQueueFilterChange: (next: string) => void;
+  stateFilter: string;
+  onStateFilterChange: (next: string) => void;
+  queueOptions: readonly string[];
+}
+
+function JobsTab({
+  queueFilter,
+  onQueueFilterChange,
+  stateFilter,
+  onStateFilterChange,
+  queueOptions,
+}: JobsTabProps): ReactNode {
+  const params = new URLSearchParams();
+  if (queueFilter) params.set("name", queueFilter);
+  if (stateFilter && stateFilter !== "all") params.set("state", stateFilter);
+  params.set("limit", "100");
+
+  const list = useQuery({
+    queryKey: ["dev", "jobs", "list", queueFilter, stateFilter],
+    queryFn: () => fetchJson<JobListResponse>(`/dev/jobs/jobs.json?${params.toString()}`),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const queueChoices = ["all", ...queueOptions];
+
+  return (
+    <div className="admin-card">
+      <div className="log-toolbar">
+        <Select
+          label="Queue"
+          selectedKey={queueFilter || "all"}
+          onSelectionChange={(key) => onQueueFilterChange(key === "all" ? "" : String(key))}
+        >
+          {queueChoices.map((name) => (
+            <SelectItem key={name} id={name}>
+              {name === "all" ? "All queues" : name}
+            </SelectItem>
+          ))}
+        </Select>
+        <Select
+          label="State"
+          selectedKey={stateFilter}
+          onSelectionChange={(key) => onStateFilterChange(String(key))}
+        >
+          {STATE_FILTERS.map((opt) => (
+            <SelectItem key={opt.id} id={opt.id}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </Select>
+      </div>
+
+      {list.data ? (
+        list.data.jobs.length === 0 ? (
+          <div className="admin-empty">No jobs match the current filters.</div>
+        ) : (
+          <table className="log-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Queue</th>
+                <th>State</th>
+                <th style={{ textAlign: "right" }}>Attempt</th>
+                <th>Created</th>
+                <th style={{ textAlign: "right" }}>Duration</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {list.data.jobs.map((job) => (
+                <JobRow key={job.id} job={job} onInspect={() => setSelectedId(job.id)} />
+              ))}
+            </tbody>
+          </table>
+        )
+      ) : list.isError ? (
+        <div className="admin-empty">Failed to load jobs.</div>
+      ) : (
+        <div className="admin-empty">Loading jobs…</div>
+      )}
+
+      {selectedId ? <JobDrawer id={selectedId} onClose={() => setSelectedId(null)} /> : null}
+    </div>
+  );
+}
+
+function JobRow({ job, onInspect }: { job: JobRecord; onInspect: () => void }): ReactNode {
+  const created = new Date(job.createdAt).toISOString().slice(11, 19);
+  const duration =
+    job.startedAt !== undefined && job.completedAt !== undefined
+      ? formatMs(job.completedAt - job.startedAt)
+      : "—";
+  return (
+    <tr className={`log-row--${stateToLevel(job.state)}`}>
+      <td>
+        <code>{job.id.slice(0, 8)}…</code>
+      </td>
+      <td>{job.name}</td>
+      <td>
+        <span className={`log-level log-level--${stateToLevel(job.state)}`}>{job.state}</span>
+      </td>
+      <td style={{ textAlign: "right" }}>{job.attempt}</td>
+      <td>{created}</td>
+      <td style={{ textAlign: "right" }}>{duration}</td>
+      <td>
+        <Button onPress={onInspect}>Inspect</Button>
+      </td>
+    </tr>
+  );
+}
+
+function JobDrawer({ id, onClose }: { id: string; onClose: () => void }): ReactNode {
+  const queryClient = useQueryClient();
+  const detail = useQuery({
+    queryKey: ["dev", "jobs", "detail", id],
+    queryFn: () => fetchJson<JobRecord>(`/dev/jobs/jobs/${encodeURIComponent(id)}.json`),
+  });
+
+  const retry = useMutation({
+    mutationFn: async () => {
+      const res = await fetch(`/dev/jobs/jobs/${encodeURIComponent(id)}/retry`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Retry failed: ${res.status} ${text}`);
+      }
+      return (await res.json()) as { id: string };
+    },
+    onSuccess: () => {
+      // Refresh both the listing and the aggregates so the UI reflects
+      // the new attempt without waiting for the next poll tick.
+      queryClient.invalidateQueries({ queryKey: ["dev", "jobs"] });
+    },
+  });
+
+  return (
+    <div className="feat-restart is-visible" role="dialog" aria-label="Job detail">
+      <div className="feat-restart__box" style={{ maxWidth: "48rem", textAlign: "left" }}>
+        <header
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "1rem",
+          }}
+        >
+          <h3 className="feat-restart__title">
+            Job <code>{id.slice(0, 16)}…</code>
+          </h3>
+          <Button onPress={onClose}>Close</Button>
+        </header>
+        {detail.data ? (
+          <div>
+            <p className="feat-restart__msg">
+              Queue <code>{detail.data.name}</code> · state{" "}
+              <span className={`log-level log-level--${stateToLevel(detail.data.state)}`}>
+                {detail.data.state}
+              </span>{" "}
+              · attempt {detail.data.attempt}
+            </p>
+            {detail.data.errorMessage ? (
+              <div className="admin-card">
+                <h4>Error</h4>
+                <pre style={{ whiteSpace: "pre-wrap", color: "var(--text-bad, #ff6b6b)" }}>
+                  {detail.data.errorMessage}
+                </pre>
+                {detail.data.errorStack ? (
+                  <pre
+                    style={{
+                      whiteSpace: "pre-wrap",
+                      fontSize: "0.78rem",
+                      opacity: 0.6,
+                    }}
+                  >
+                    {detail.data.errorStack}
+                  </pre>
+                ) : null}
+              </div>
+            ) : null}
+            <h4>Payload</h4>
+            <JsonViewer value={detail.data.payload} />
+            {detail.data.state === "failed" ? (
+              <div style={{ display: "flex", gap: "0.75rem", marginTop: "1rem" }}>
+                <Button
+                  variant="accent"
+                  onPress={() => retry.mutate()}
+                  isDisabled={retry.isPending}
+                >
+                  {retry.isPending ? "Retrying…" : "Retry now"}
+                </Button>
+                {retry.isError ? (
+                  <span className="admin-meta">
+                    {String((retry.error as Error | undefined)?.message ?? retry.error)}
+                  </span>
+                ) : null}
+                {retry.isSuccess ? (
+                  <span className="admin-meta">
+                    ✓ re-queued as{" "}
+                    <code>{(retry.data as { id?: string } | undefined)?.id?.slice(0, 8)}…</code>
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : detail.isError ? (
+          <div className="admin-empty">Failed to load job.</div>
+        ) : (
+          <div className="admin-empty">Loading job…</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Map a job state to the log-row CSS level so the existing
+ * `log-row--info` / `log-row--error` styles colour the table without
+ * a per-page stylesheet.
+ */
+function stateToLevel(state: JobState): "info" | "warn" | "error" | "debug" {
+  if (state === "failed") return "error";
+  if (state === "cancelled") return "warn";
+  if (state === "completed") return "info";
+  if (state === "active" || state === "retry") return "warn";
+  return "debug";
+}

--- a/src/core/dx/dev-hub.controller.ts
+++ b/src/core/dx/dev-hub.controller.ts
@@ -26,11 +26,7 @@ import { readTunnelState } from "../dev/tunnel-state-runner.js";
 import { MigrationsService } from "./migrations/migrations.service.js";
 
 import { type Features, loadFeatures } from "../features/features.js";
-import {
-  JobNotFoundError,
-  JobNotRetryableError,
-  type ListJobsOptions,
-} from "../jobs/job-queue.js";
+import { JobNotFoundError, JobNotRetryableError, type ListJobsOptions } from "../jobs/job-queue.js";
 import type { JobState } from "../jobs/dev-jobs-aggregations.js";
 import { JobQueueService } from "../jobs/jobs.module.js";
 import { parsePostgrestQuery } from "../permissions/postgrest-query.js";

--- a/src/core/dx/dev-hub.controller.ts
+++ b/src/core/dx/dev-hub.controller.ts
@@ -26,6 +26,13 @@ import { readTunnelState } from "../dev/tunnel-state-runner.js";
 import { MigrationsService } from "./migrations/migrations.service.js";
 
 import { type Features, loadFeatures } from "../features/features.js";
+import {
+  JobNotFoundError,
+  JobNotRetryableError,
+  type ListJobsOptions,
+} from "../jobs/job-queue.js";
+import type { JobState } from "../jobs/dev-jobs-aggregations.js";
+import { JobQueueService } from "../jobs/jobs.module.js";
 import { parsePostgrestQuery } from "../permissions/postgrest-query.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
 import { APP_NAME, APP_VERSION } from "../app/app.metadata.js";
@@ -73,6 +80,7 @@ export class DevHubController {
   constructor(
     private readonly routes: RouteInventoryService,
     private readonly migrations: MigrationsService,
+    private readonly jobs: JobQueueService,
   ) {}
 
   @Get()
@@ -698,6 +706,106 @@ export class DevHubController {
   }
 
   /**
+   * `/dev/jobs` — Jobs-Dashboard SPA shell. Same SPA bundle as the
+   * rest of `/dev/*`; react-router resolves to `JobsPage`.
+   */
+  @Get("jobs")
+  @Header("content-type", "text/html; charset=utf-8")
+  jobsPage(): string {
+    this.assertDev();
+    return renderDevPortalShell(buildDevPortalShellInput({ title: "Jobs" }));
+  }
+
+  /**
+   * `/dev/jobs/queues.json` — aggregate snapshot for the Queues tab.
+   * Per-queue counts + p95 latency + failure rate are computed by the
+   * pure planner (`buildJobAggregates`); this endpoint is just the
+   * thin runner that hands the queue's history to it.
+   */
+  @Get("jobs/queues.json")
+  jobsQueuesJson() {
+    this.assertDev();
+    return this.jobs.getAggregates();
+  }
+
+  /**
+   * `/dev/jobs/jobs.json` — paginated, filterable job listing for the
+   * Jobs tab. The in-memory adapter caps `limit` at 500 to keep the
+   * response sized for the React table; the React page asks for
+   * 100 per page.
+   */
+  @Get("jobs/jobs.json")
+  jobsListJson(
+    @Query("state") state: string | undefined,
+    @Query("name") name: string | undefined,
+    @Query("limit") limit: string | undefined,
+  ) {
+    this.assertDev();
+    const options: ListJobsOptions = {};
+    if (state) {
+      if (!isJobState(state)) {
+        throw new BadRequestException(`unknown state: ${state}`);
+      }
+      options.state = state;
+    }
+    if (name) {
+      if (!isSafeQueueName(name)) {
+        throw new BadRequestException(`invalid queue name`);
+      }
+      options.name = name;
+    }
+    if (limit) {
+      const parsed = Number.parseInt(limit, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new BadRequestException(`invalid limit`);
+      }
+      options.limit = Math.min(parsed, 500);
+    } else {
+      options.limit = 100;
+    }
+    return { jobs: this.jobs.listJobs(options) };
+  }
+
+  /**
+   * `/dev/jobs/jobs/:id.json` — full record for the drawer detail view.
+   * Validates the id shape before the lookup so a malformed path-param
+   * surfaces as a clean 400 instead of leaking through to the
+   * Map-lookup path.
+   */
+  @Get("jobs/jobs/:id.json")
+  jobDetailJson(@Param("id") id: string) {
+    this.assertDev();
+    if (!isSafeJobId(id)) {
+      throw new BadRequestException(`invalid job id`);
+    }
+    const record = this.jobs.getJob(id);
+    if (!record) throw new NotFoundException();
+    return record;
+  }
+
+  /**
+   * `POST /dev/jobs/jobs/:id/retry` — re-enqueue a failed job. Returns
+   * `{ id }` of the new attempt; the original record stays in history.
+   * 404 on unknown ids, 409 on jobs that are not in the failed state.
+   */
+  @Post("jobs/jobs/:id/retry")
+  @HttpCode(200)
+  async retryJob(@Param("id") id: string): Promise<{ id: string }> {
+    this.assertDev();
+    if (!isSafeJobId(id)) {
+      throw new BadRequestException(`invalid job id`);
+    }
+    try {
+      const newId = await this.jobs.retry(id);
+      return { id: newId };
+    } catch (error) {
+      if (error instanceof JobNotFoundError) throw new NotFoundException();
+      if (error instanceof JobNotRetryableError) throw new ConflictException(error.message);
+      throw error;
+    }
+  }
+
+  /**
    * Catch-all for `/dev/*` paths that don't match a more specific
    * handler. Always returns the SPA shell — react-router on the client
    * decides what to render. NestJS dispatches to the most specific
@@ -766,6 +874,38 @@ function assertNonEmptyString(value: unknown, fieldName: string): string {
 
 function asMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+const JOB_STATES = new Set<JobState>([
+  "created",
+  "active",
+  "completed",
+  "failed",
+  "cancelled",
+  "retry",
+]);
+
+function isJobState(value: string): value is JobState {
+  return JOB_STATES.has(value as JobState);
+}
+
+/**
+ * Allow-list for job ids — UUID-shaped + a defensive length cap.
+ * Path-traversal-shaped or otherwise weird ids never reach the lookup.
+ */
+function isSafeJobId(value: string): boolean {
+  if (!value || value.length > 64) return false;
+  return /^[a-zA-Z0-9_-]+$/.test(value);
+}
+
+/**
+ * Allow-list for queue names — slug-shaped, ≤ 64 chars. Mirrors the
+ * id check; the in-memory queue accepts any string for `register()`,
+ * but the public surface only exposes ones that match this pattern.
+ */
+function isSafeQueueName(value: string): boolean {
+  if (!value || value.length > 64) return false;
+  return /^[a-zA-Z0-9._-]+$/.test(value);
 }
 
 function mimeForExtension(name: string): string {

--- a/src/core/dx/dev-hub.module.ts
+++ b/src/core/dx/dev-hub.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { DiscoveryModule } from "@nestjs/core";
 
+import { JobsModule } from "../jobs/jobs.module.js";
 import { AdminSpaController } from "./admin-spa.controller.js";
 import { DevHubController } from "./dev-hub.controller.js";
 import { MigrationsService } from "./migrations/migrations.service.js";
@@ -17,10 +18,11 @@ import { RouteInventoryService } from "./route-inventory-runner.js";
  * the registered controllers for `/dev/routes`. `MigrationsService` is
  * a dev-only orchestrator for the `/dev/migrations` page; it depends on
  * the global `PrismaService` for advisory locks + `_prisma_migrations`
- * reads.
+ * reads. `JobsModule` is imported so the controller can read the
+ * in-memory queue history for the `/dev/jobs/*` dashboard.
  */
 @Module({
-  imports: [DiscoveryModule],
+  imports: [DiscoveryModule, JobsModule],
   controllers: [DevHubController, AdminSpaController],
   providers: [RouteInventoryService, MigrationsService],
   exports: [RouteInventoryService],

--- a/src/core/jobs/dev-jobs-aggregations.ts
+++ b/src/core/jobs/dev-jobs-aggregations.ts
@@ -1,0 +1,179 @@
+/**
+ * Dev-Jobs Aggregations — pure planner for the Jobs-Dashboard.
+ *
+ * Takes a flat list of `JobRecord` rows (whatever the runner produced
+ * — in-memory queue today, pg-boss tomorrow) and rolls them up into
+ * the counters / latency stats / per-queue snapshots the dashboard
+ * renders. No I/O, no clock, no database — given the same input the
+ * output is deterministic.
+ *
+ * The runner-side counterparts (`InMemoryJobQueue.listJobs()` and a
+ * future pg-boss adapter) live alongside the queue implementation so
+ * this file can be unit-tested without booting a database.
+ */
+
+/**
+ * State machine for jobs as the dashboard sees it. The in-memory
+ * queue uses {created, active, completed, failed, cancelled, retry}
+ * — pg-boss adds `expired`, which we map to `failed` to keep the
+ * UI buckets manageable.
+ */
+export type JobState = "created" | "active" | "completed" | "failed" | "cancelled" | "retry";
+
+export interface JobRecord {
+  id: string;
+  /** Queue / job-handler name. */
+  name: string;
+  state: JobState;
+  /** 1-indexed attempt counter — first run is `1`, retries increment. */
+  attempt: number;
+  /** Caller-supplied payload. Stored verbatim so the drawer can show it. */
+  payload: unknown;
+  /** Epoch-ms when the job was enqueued. */
+  createdAt: number;
+  /** Epoch-ms when the worker picked the job up. */
+  startedAt?: number;
+  /** Epoch-ms when the job finished (completed or failed). */
+  completedAt?: number;
+  /** Error message captured on failure. */
+  errorMessage?: string;
+  /** Error stack captured on failure (if available). */
+  errorStack?: string;
+}
+
+export interface StateCounts {
+  created: number;
+  active: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  retry: number;
+}
+
+export interface QueueAggregate {
+  name: string;
+  total: number;
+  counts: StateCounts;
+  /** 95th-percentile completion latency in ms across completed jobs. */
+  p95LatencyMs: number | null;
+  /** Failed share of finished jobs (0..1). */
+  failureRate: number;
+}
+
+export interface JobAggregates {
+  totalJobs: number;
+  totals: StateCounts;
+  failureRate: number;
+  p95LatencyMs: number | null;
+  queues: QueueAggregate[];
+}
+
+function emptyCounts(): StateCounts {
+  return { created: 0, active: 0, completed: 0, failed: 0, cancelled: 0, retry: 0 };
+}
+
+/**
+ * Count jobs by state. Defensive against unknown future states (pg-boss
+ * `expired` etc.) — anything outside the known buckets is silently
+ * ignored so the totals still add up to the known list.
+ */
+export function countByState(records: readonly JobRecord[]): StateCounts {
+  const counts = emptyCounts();
+  for (const record of records) {
+    if (record.state in counts) {
+      counts[record.state] += 1;
+    }
+  }
+  return counts;
+}
+
+/**
+ * Extract completion durations (ms) from completed jobs that recorded
+ * both `startedAt` and `completedAt`. Negative durations (clock skew,
+ * malformed records) are dropped — they would distort percentiles.
+ */
+function completionDurations(records: readonly JobRecord[]): number[] {
+  const durations: number[] = [];
+  for (const record of records) {
+    if (record.state !== "completed") continue;
+    if (record.startedAt === undefined) continue;
+    if (record.completedAt === undefined) continue;
+    const duration = record.completedAt - record.startedAt;
+    if (duration < 0) continue;
+    durations.push(duration);
+  }
+  return durations;
+}
+
+/**
+ * 95th-percentile completion latency in ms. Returns `null` when no
+ * completed job has a recorded duration.
+ *
+ * Uses the simple "ceil(0.95 * N) - 1" index after sorting — sufficient
+ * for the dashboard, no need for the linear-interpolation flavour.
+ */
+export function computeP95Latency(records: readonly JobRecord[]): number | null {
+  const durations = completionDurations(records);
+  if (durations.length === 0) return null;
+  const sorted = durations.slice().sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * 0.95) - 1));
+  return sorted[index] ?? null;
+}
+
+/**
+ * Failed share of *finished* jobs (failed / (failed + completed)).
+ * Returns `0` on an empty list to avoid NaN; pending / active jobs
+ * are excluded — they are not yet failures.
+ */
+export function computeFailureRate(records: readonly JobRecord[]): number {
+  let failed = 0;
+  let completed = 0;
+  for (const record of records) {
+    if (record.state === "failed") failed += 1;
+    else if (record.state === "completed") completed += 1;
+  }
+  const total = failed + completed;
+  if (total === 0) return 0;
+  return failed / total;
+}
+
+/**
+ * Group jobs by queue name and emit a per-queue aggregate. Queues are
+ * returned alphabetically sorted so the rendered table is stable
+ * across reloads (no flicker as job counts wiggle).
+ */
+export function aggregateJobsByQueue(records: readonly JobRecord[]): QueueAggregate[] {
+  const grouped = new Map<string, JobRecord[]>();
+  for (const record of records) {
+    const list = grouped.get(record.name) ?? [];
+    list.push(record);
+    grouped.set(record.name, list);
+  }
+  const queues: QueueAggregate[] = [];
+  for (const [name, list] of grouped) {
+    queues.push({
+      name,
+      total: list.length,
+      counts: countByState(list),
+      p95LatencyMs: computeP95Latency(list),
+      failureRate: computeFailureRate(list),
+    });
+  }
+  queues.sort((a, b) => a.name.localeCompare(b.name));
+  return queues;
+}
+
+/**
+ * Top-level snapshot the `/dev/jobs/queues.json` endpoint returns.
+ * Combines totals, the per-queue list, and global p95 + failure-rate
+ * so the dashboard hero can render without a second pass.
+ */
+export function buildJobAggregates(records: readonly JobRecord[]): JobAggregates {
+  return {
+    totalJobs: records.length,
+    totals: countByState(records),
+    failureRate: computeFailureRate(records),
+    p95LatencyMs: computeP95Latency(records),
+    queues: aggregateJobsByQueue(records),
+  };
+}

--- a/src/core/jobs/job-queue.ts
+++ b/src/core/jobs/job-queue.ts
@@ -1,3 +1,9 @@
+import {
+  buildJobAggregates,
+  type JobAggregates,
+  type JobRecord,
+  type JobState,
+} from "./dev-jobs-aggregations.js";
 import { uuidV7 } from "../uuid/uuid-v7.js";
 
 /**
@@ -11,6 +17,13 @@ import { uuidV7 } from "../uuid/uuid-v7.js";
  *   - start() / stop()
  *
  * `drain()` is the test-only helper that awaits an empty queue.
+ *
+ * Beyond the runtime surface the queue keeps a per-job `JobRecord`
+ * with createdAt / startedAt / completedAt timestamps + the original
+ * payload + the error captured on failure. The `/dev/jobs/*`
+ * dashboard reads that history through `listJobs()` and `getAggregates()`
+ * — pg-boss exposes the same shape via its own table layout, so the
+ * future driver-adapter swap is a one-line change in the controller.
  */
 
 export type JobHandler<TPayload = unknown> = (payload: TPayload) => Promise<void> | void;
@@ -27,16 +40,45 @@ export class JobHandlerNotRegisteredError extends Error {
   }
 }
 
+export class JobNotFoundError extends Error {
+  constructor(id: string) {
+    super(`job not found: ${id}`);
+    this.name = "JobNotFoundError";
+  }
+}
+
+export class JobNotRetryableError extends Error {
+  constructor(id: string, state: JobState) {
+    super(`job ${id} is not retryable in state ${state}`);
+    this.name = "JobNotRetryableError";
+  }
+}
+
+export interface ListJobsOptions {
+  state?: JobState;
+  name?: string;
+  /** Default cap to prevent runaway responses; the drawer asks for one record. */
+  limit?: number;
+}
+
 interface QueuedJob {
   id: string;
-  name: string;
-  payload: unknown;
+}
+
+interface MutableJobRecord extends JobRecord {
+  state: JobState;
 }
 
 export class InMemoryJobQueue {
   private readonly handlers = new Map<string, JobHandler>();
   private readonly queue: QueuedJob[] = [];
-  private readonly results = new Map<string, JobResult>();
+  private readonly history = new Map<string, MutableJobRecord>();
+  /**
+   * Insertion order tracked separately so listJobs() can return
+   * newest-first without sorting on every call. Stable across retries:
+   * the retry creates a *new* id and appends to the end.
+   */
+  private readonly historyOrder: string[] = [];
   private running = false;
   private inFlight: Promise<void> = Promise.resolve();
 
@@ -45,14 +87,26 @@ export class InMemoryJobQueue {
   }
 
   async enqueue<TPayload>(name: string, payload: TPayload): Promise<string> {
-    if (!this.handlers.has(name)) {
-      throw new JobHandlerNotRegisteredError(name);
+    return this.enqueueInternal({ name, payload, attempt: 1 });
+  }
+
+  /**
+   * Re-run a previously failed job. Returns the new job id; the
+   * original record stays in history with its terminal state. Throws
+   * `JobNotFoundError` on unknown ids and `JobNotRetryableError` if
+   * the job is still pending / completed / cancelled.
+   */
+  async retry(id: string): Promise<string> {
+    const original = this.history.get(id);
+    if (!original) throw new JobNotFoundError(id);
+    if (original.state !== "failed") {
+      throw new JobNotRetryableError(id, original.state);
     }
-    const id = uuidV7();
-    this.queue.push({ id, name, payload });
-    this.results.set(id, { status: "pending" });
-    if (this.running) this.scheduleProcess();
-    return id;
+    return this.enqueueInternal({
+      name: original.name,
+      payload: original.payload,
+      attempt: original.attempt + 1,
+    });
   }
 
   async start(): Promise<void> {
@@ -73,7 +127,79 @@ export class InMemoryJobQueue {
   }
 
   jobResult(id: string): JobResult | undefined {
-    return this.results.get(id);
+    const record = this.history.get(id);
+    if (!record) return undefined;
+    if (record.state === "completed") return { status: "completed" };
+    if (record.state === "failed") {
+      const error = new Error(record.errorMessage ?? "job failed");
+      if (record.errorStack) error.stack = record.errorStack;
+      return { status: "failed", error };
+    }
+    return { status: "pending" };
+  }
+
+  /**
+   * Detail-view accessor for the dashboard drawer. Returns a defensive
+   * copy so callers cannot mutate internal history.
+   */
+  getJob(id: string): JobRecord | undefined {
+    const record = this.history.get(id);
+    return record ? { ...record } : undefined;
+  }
+
+  /**
+   * Enumerate the history newest-first. Filters and limit are applied
+   * in-memory — the in-memory queue holds at most a handful of jobs
+   * during a dev-server session, so a pass over the array is fine.
+   */
+  listJobs(options: ListJobsOptions = {}): JobRecord[] {
+    const { state, name, limit } = options;
+    const out: JobRecord[] = [];
+    // Walk the order array in reverse (newest-first).
+    for (let i = this.historyOrder.length - 1; i >= 0; i--) {
+      const id = this.historyOrder[i];
+      if (id === undefined) continue;
+      const record = this.history.get(id);
+      if (!record) continue;
+      if (state && record.state !== state) continue;
+      if (name && record.name !== name) continue;
+      out.push({ ...record });
+      if (limit !== undefined && out.length >= limit) break;
+    }
+    return out;
+  }
+
+  /**
+   * Aggregate snapshot the `/dev/jobs/queues.json` endpoint serves.
+   * Built from the unfiltered history so totals reflect everything
+   * the queue has ever processed in the current process lifetime.
+   */
+  getAggregates(): JobAggregates {
+    return buildJobAggregates(this.listJobs());
+  }
+
+  private async enqueueInternal(input: {
+    name: string;
+    payload: unknown;
+    attempt: number;
+  }): Promise<string> {
+    if (!this.handlers.has(input.name)) {
+      throw new JobHandlerNotRegisteredError(input.name);
+    }
+    const id = uuidV7();
+    const record: MutableJobRecord = {
+      id,
+      name: input.name,
+      state: "created",
+      attempt: input.attempt,
+      payload: input.payload,
+      createdAt: Date.now(),
+    };
+    this.history.set(id, record);
+    this.historyOrder.push(id);
+    this.queue.push({ id });
+    if (this.running) this.scheduleProcess();
+    return id;
   }
 
   private async flushInFlight(): Promise<boolean> {
@@ -87,24 +213,29 @@ export class InMemoryJobQueue {
 
   private async processOne(): Promise<void> {
     if (!this.running) return;
-    const job = this.queue.shift();
-    if (!job) return;
-    const handler = this.handlers.get(job.name);
+    const queued = this.queue.shift();
+    if (!queued) return;
+    const record = this.history.get(queued.id);
+    if (!record) return;
+    const handler = this.handlers.get(record.name);
     if (!handler) {
-      this.results.set(job.id, {
-        status: "failed",
-        error: new JobHandlerNotRegisteredError(job.name),
-      });
+      record.state = "failed";
+      record.errorMessage = `job handler not registered: ${record.name}`;
+      record.completedAt = Date.now();
       return;
     }
+    record.state = "active";
+    record.startedAt = Date.now();
     try {
-      await handler(job.payload);
-      this.results.set(job.id, { status: "completed" });
+      await handler(record.payload);
+      record.state = "completed";
+      record.completedAt = Date.now();
     } catch (error) {
-      this.results.set(job.id, {
-        status: "failed",
-        error: error instanceof Error ? error : new Error(String(error)),
-      });
+      const err = error instanceof Error ? error : new Error(String(error));
+      record.state = "failed";
+      record.errorMessage = err.message;
+      record.errorStack = err.stack;
+      record.completedAt = Date.now();
     }
     if (this.running && this.queue.length > 0) this.scheduleProcess();
   }

--- a/tests/jobs-dashboard.e2e-spec.ts
+++ b/tests/jobs-dashboard.e2e-spec.ts
@@ -1,0 +1,181 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { JobQueueService } from "../src/core/jobs/jobs.module.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * Jobs-Dashboard endpoints (#15).
+ *
+ * Read-side endpoints under `/dev/jobs/*` 404 outside development and
+ * surface the same view of the in-memory queue the SPA renders. The
+ * write-side `retry` endpoint re-enqueues a failed job through the
+ * shared `JobQueueService`.
+ *
+ * Tests are scoped to the in-memory adapter; the future pg-boss
+ * adapter swap re-uses the same JSON contract.
+ */
+describe("Dev Jobs Dashboard · /dev/jobs/*", () => {
+  describe("in development mode", () => {
+    let app: INestApplication;
+    let queue: JobQueueService;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "development";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+      queue = app.get(JobQueueService);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    beforeEach(async () => {
+      // Seed each test with a fresh handler set; jobs accumulate in
+      // history across tests so each spec asserts on counts that come
+      // from the jobs it created.
+      queue.register("e2e-ok", async () => {});
+      queue.register("e2e-bad", async () => {
+        throw new Error("e2e failure");
+      });
+    });
+
+    it("GET /dev/jobs renders the SPA shell", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/jobs");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/text\/html/);
+      expect(res.text).toContain('<div id="root"></div>');
+      expect(res.text).toMatch(/<title>Jobs — nest-server<\/title>/);
+    });
+
+    it("GET /dev/jobs/queues.json returns the aggregated snapshot", async () => {
+      const id = await queue.enqueue("e2e-ok", { who: "alice" });
+      await queue.drain();
+      const res = await request(app.getHttpServer()).get("/dev/jobs/queues.json");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(typeof res.body.totalJobs).toBe("number");
+      expect(res.body.totalJobs).toBeGreaterThan(0);
+      expect(res.body.totals).toHaveProperty("completed");
+      expect(res.body.totals).toHaveProperty("failed");
+      expect(Array.isArray(res.body.queues)).toBe(true);
+      const matching = res.body.queues.find((q: { name: string }) => q.name === "e2e-ok");
+      expect(matching).toBeDefined();
+      expect(matching.counts.completed).toBeGreaterThan(0);
+      // Job we just enqueued shows up in the listing endpoint too.
+      const list = await request(app.getHttpServer()).get(
+        `/dev/jobs/jobs.json?name=e2e-ok&limit=10`,
+      );
+      const ids: string[] = list.body.jobs.map((j: { id: string }) => j.id);
+      expect(ids).toContain(id);
+    });
+
+    it("GET /dev/jobs/jobs.json supports state + name filters and limit", async () => {
+      await queue.enqueue("e2e-ok", { i: 1 });
+      await queue.enqueue("e2e-ok", { i: 2 });
+      await queue.enqueue("e2e-bad", { i: 3 });
+      await queue.drain();
+      const completed = await request(app.getHttpServer()).get(
+        "/dev/jobs/jobs.json?state=completed&name=e2e-ok&limit=50",
+      );
+      expect(completed.status).toBe(200);
+      expect(Array.isArray(completed.body.jobs)).toBe(true);
+      for (const job of completed.body.jobs) {
+        expect(job.state).toBe("completed");
+        expect(job.name).toBe("e2e-ok");
+      }
+      const failed = await request(app.getHttpServer()).get("/dev/jobs/jobs.json?state=failed");
+      expect(failed.status).toBe(200);
+      for (const job of failed.body.jobs) {
+        expect(job.state).toBe("failed");
+      }
+      // Sanity: the smallest limit is honoured.
+      const tiny = await request(app.getHttpServer()).get("/dev/jobs/jobs.json?limit=1");
+      expect(tiny.body.jobs.length).toBe(1);
+    });
+
+    it("GET /dev/jobs/jobs/:id.json returns the full record + 404 on miss", async () => {
+      const id = await queue.enqueue("e2e-ok", { hello: "world" });
+      await queue.drain();
+      const detail = await request(app.getHttpServer()).get(`/dev/jobs/jobs/${id}.json`);
+      expect(detail.status).toBe(200);
+      expect(detail.body.id).toBe(id);
+      expect(detail.body.payload).toEqual({ hello: "world" });
+      expect(detail.body.state).toBe("completed");
+      expect(typeof detail.body.createdAt).toBe("number");
+
+      const miss = await request(app.getHttpServer()).get(
+        "/dev/jobs/jobs/no-such-id-exists-here.json",
+      );
+      expect(miss.status).toBe(404);
+    });
+
+    it("rejects unsafe job ids on detail / retry", async () => {
+      // Path-traversal-shaped ids are rejected before the lookup runs.
+      const badPaths = ["..%2Fpackage", "weird%20id", "with/slash"];
+      for (const bad of badPaths) {
+        const detail = await request(app.getHttpServer()).get(`/dev/jobs/jobs/${bad}.json`);
+        expect([400, 404]).toContain(detail.status);
+        const retry = await request(app.getHttpServer()).post(`/dev/jobs/jobs/${bad}/retry`);
+        expect([400, 404]).toContain(retry.status);
+      }
+    });
+
+    it("POST /dev/jobs/jobs/:id/retry re-enqueues a failed job", async () => {
+      const original = await queue.enqueue("e2e-bad", { run: 1 });
+      await queue.drain();
+      const res = await request(app.getHttpServer())
+        .post(`/dev/jobs/jobs/${original}/retry`)
+        .send();
+      expect(res.status).toBe(200);
+      expect(typeof res.body.id).toBe("string");
+      expect(res.body.id).not.toBe(original);
+      // Drain so the retried job ages into a terminal state.
+      await queue.drain();
+      const retried = await request(app.getHttpServer()).get(`/dev/jobs/jobs/${res.body.id}.json`);
+      expect(retried.status).toBe(200);
+      expect(retried.body.attempt).toBe(2);
+    });
+
+    it("POST /dev/jobs/jobs/:id/retry returns 404 when the id is unknown", async () => {
+      const res = await request(app.getHttpServer())
+        .post(`/dev/jobs/jobs/${"a".repeat(36)}/retry`)
+        .send();
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /dev/jobs/jobs/:id/retry returns 409 when the job is not failed", async () => {
+      const id = await queue.enqueue("e2e-ok", {});
+      await queue.drain();
+      const res = await request(app.getHttpServer()).post(`/dev/jobs/jobs/${id}/retry`).send();
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("outside development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "production";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("404s on /dev/jobs/queues.json", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/jobs/queues.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("404s on /dev/jobs/jobs.json", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/jobs/jobs.json");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/jobs-dashboard.e2e-spec.ts
+++ b/tests/jobs-dashboard.e2e-spec.ts
@@ -115,8 +115,13 @@ describe("Dev Jobs Dashboard · /dev/jobs/*", () => {
 
     it("rejects unsafe job ids on detail / retry", async () => {
       // Path-traversal-shaped ids are rejected before the lookup runs.
-      const badPaths = ["..%2Fpackage", "weird%20id", "with/slash"];
-      for (const bad of badPaths) {
+      // The route validator allows only `[a-zA-Z0-9_-]+` (≤ 64 chars);
+      // anything with a space, dot-segment, or path-traversal char is
+      // a 400 BadRequest. Note: literal `/` in the URL would land on
+      // a different route (the SPA catch-all), so we test the cases
+      // that actually reach the param handler.
+      const badIds = ["..", "weird%20id", "..%2Etxt", "way-too-long-".repeat(10)];
+      for (const bad of badIds) {
         const detail = await request(app.getHttpServer()).get(`/dev/jobs/jobs/${bad}.json`);
         expect([400, 404]).toContain(detail.status);
         const retry = await request(app.getHttpServer()).post(`/dev/jobs/jobs/${bad}/retry`);

--- a/tests/stories/dev-jobs-aggregations.story.test.ts
+++ b/tests/stories/dev-jobs-aggregations.story.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateJobsByQueue,
+  buildJobAggregates,
+  computeFailureRate,
+  computeP95Latency,
+  countByState,
+  type JobRecord,
+} from "../../src/core/jobs/dev-jobs-aggregations.js";
+
+/**
+ * Story · Dev Jobs Aggregations.
+ *
+ * Pure-planner layer for the Jobs-Dashboard. The functions here take
+ * a flat list of `JobRecord` rows (whatever shape the runner produces
+ * — in-memory adapter today, pg-boss adapter tomorrow) and roll them
+ * up into the counters / latency stats / per-queue snapshots the
+ * dashboard needs.
+ *
+ * Pure-planner contract:
+ *   - never reads from a DB
+ *   - never mutates input arrays
+ *   - deterministic given the input list
+ *
+ * The runner (`InMemoryJobQueue.listJobs()` / future pg-boss adapter)
+ * is responsible for actually hitting storage; everything below is
+ * unit-testable in isolation.
+ */
+describe("Story · Dev Jobs Aggregations", () => {
+  function record(overrides: Partial<JobRecord>): JobRecord {
+    return {
+      id: "job-1",
+      name: "test-queue",
+      state: "completed",
+      attempt: 1,
+      payload: {},
+      createdAt: 1_000_000,
+      ...overrides,
+    };
+  }
+
+  describe("countByState()", () => {
+    it("returns zero for every state when the list is empty", () => {
+      const counts = countByState([]);
+      expect(counts.created).toBe(0);
+      expect(counts.active).toBe(0);
+      expect(counts.completed).toBe(0);
+      expect(counts.failed).toBe(0);
+      expect(counts.cancelled).toBe(0);
+      expect(counts.retry).toBe(0);
+    });
+
+    it("groups records by their state and totals each bucket", () => {
+      const counts = countByState([
+        record({ id: "a", state: "completed" }),
+        record({ id: "b", state: "completed" }),
+        record({ id: "c", state: "failed" }),
+        record({ id: "d", state: "created" }),
+        record({ id: "e", state: "active" }),
+        record({ id: "f", state: "retry" }),
+        record({ id: "g", state: "cancelled" }),
+      ]);
+      expect(counts.completed).toBe(2);
+      expect(counts.failed).toBe(1);
+      expect(counts.created).toBe(1);
+      expect(counts.active).toBe(1);
+      expect(counts.retry).toBe(1);
+      expect(counts.cancelled).toBe(1);
+    });
+  });
+
+  describe("computeP95Latency()", () => {
+    it("returns null when no completed jobs have a duration", () => {
+      expect(computeP95Latency([])).toBeNull();
+      expect(computeP95Latency([record({ state: "completed" })])).toBeNull();
+    });
+
+    it("ignores non-completed jobs", () => {
+      const ms = computeP95Latency([
+        record({ state: "active", startedAt: 1, completedAt: 100 }),
+        record({ state: "failed", startedAt: 1, completedAt: 100 }),
+      ]);
+      expect(ms).toBeNull();
+    });
+
+    it("returns the 95th percentile of completed-job durations", () => {
+      // 20 records with durations 1..20ms — p95 is the 19th value (95% of 20).
+      const records: JobRecord[] = Array.from({ length: 20 }, (_, i) =>
+        record({
+          id: `job-${i}`,
+          state: "completed",
+          startedAt: 0,
+          completedAt: i + 1,
+        }),
+      );
+      const ms = computeP95Latency(records);
+      expect(ms).toBeGreaterThanOrEqual(19);
+      expect(ms).toBeLessThanOrEqual(20);
+    });
+  });
+
+  describe("computeFailureRate()", () => {
+    it("returns 0 on an empty list (no division-by-zero)", () => {
+      expect(computeFailureRate([])).toBe(0);
+    });
+
+    it("returns 0 when every job completed", () => {
+      const list = [record({ state: "completed" }), record({ state: "completed" })];
+      expect(computeFailureRate(list)).toBe(0);
+    });
+
+    it("returns the failed share of finished jobs (failed / (failed + completed))", () => {
+      // 1 failed, 3 completed → 25 %.
+      const list = [
+        record({ id: "a", state: "completed" }),
+        record({ id: "b", state: "completed" }),
+        record({ id: "c", state: "completed" }),
+        record({ id: "d", state: "failed" }),
+      ];
+      expect(computeFailureRate(list)).toBeCloseTo(0.25, 5);
+    });
+
+    it("ignores still-pending / active jobs (not yet finished)", () => {
+      const list = [
+        record({ id: "a", state: "active" }),
+        record({ id: "b", state: "created" }),
+        record({ id: "c", state: "completed" }),
+        record({ id: "d", state: "failed" }),
+      ];
+      expect(computeFailureRate(list)).toBeCloseTo(0.5, 5);
+    });
+  });
+
+  describe("aggregateJobsByQueue()", () => {
+    it("returns an empty list when no jobs are passed", () => {
+      expect(aggregateJobsByQueue([])).toEqual([]);
+    });
+
+    it("groups jobs by queue name and emits per-queue counts + p95", () => {
+      const list = [
+        record({ id: "a", name: "emails", state: "completed", startedAt: 0, completedAt: 100 }),
+        record({ id: "b", name: "emails", state: "completed", startedAt: 0, completedAt: 200 }),
+        record({ id: "c", name: "emails", state: "failed" }),
+        record({ id: "d", name: "imports", state: "active" }),
+        record({ id: "e", name: "imports", state: "completed", startedAt: 0, completedAt: 50 }),
+      ];
+      const queues = aggregateJobsByQueue(list);
+      expect(queues).toHaveLength(2);
+      const emails = queues.find((q) => q.name === "emails");
+      expect(emails).toBeDefined();
+      expect(emails!.counts.completed).toBe(2);
+      expect(emails!.counts.failed).toBe(1);
+      expect(emails!.total).toBe(3);
+      expect(emails!.p95LatencyMs).not.toBeNull();
+      const imports = queues.find((q) => q.name === "imports");
+      expect(imports!.counts.active).toBe(1);
+      expect(imports!.counts.completed).toBe(1);
+      expect(imports!.total).toBe(2);
+    });
+
+    it("returns queues sorted alphabetically for stable rendering", () => {
+      const list = [
+        record({ id: "a", name: "z-queue" }),
+        record({ id: "b", name: "a-queue" }),
+        record({ id: "c", name: "m-queue" }),
+      ];
+      const names = aggregateJobsByQueue(list).map((q) => q.name);
+      expect(names).toEqual(["a-queue", "m-queue", "z-queue"]);
+    });
+  });
+
+  describe("buildJobAggregates()", () => {
+    it("returns the full snapshot the dashboard renders", () => {
+      const list = [
+        record({ id: "a", name: "q1", state: "completed", startedAt: 0, completedAt: 10 }),
+        record({ id: "b", name: "q1", state: "failed" }),
+        record({ id: "c", name: "q2", state: "active" }),
+      ];
+      const snapshot = buildJobAggregates(list);
+      expect(snapshot.totalJobs).toBe(3);
+      expect(snapshot.totals.completed).toBe(1);
+      expect(snapshot.totals.failed).toBe(1);
+      expect(snapshot.totals.active).toBe(1);
+      expect(snapshot.queues).toHaveLength(2);
+      expect(snapshot.failureRate).toBeCloseTo(0.5, 5);
+      // p95 over a single 10 ms job is 10.
+      expect(snapshot.p95LatencyMs).toBe(10);
+    });
+
+    it("does not mutate the input array", () => {
+      const list = [record({ id: "a", name: "q1", state: "completed" })];
+      const before = [...list];
+      buildJobAggregates(list);
+      expect(list).toEqual(before);
+    });
+  });
+});

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -44,6 +44,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "/dev/logs",
       "/dev/traces",
       "/dev/queries",
+      "/dev/jobs",
       "/dev/routes",
       "/dev/erd",
       "/dev/email-preview",
@@ -75,6 +76,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "/dev/logs",
       "/dev/traces",
       "/dev/queries",
+      "/dev/jobs",
       "/dev/routes",
       "/dev/erd",
       "/dev/email-preview",
@@ -126,6 +128,8 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "email-preview.json",
       "coverage.json",
       "tests.json",
+      "jobs/queues.json",
+      "jobs/jobs.json",
     ];
     for (const ep of jsonEndpoints) {
       it(`dev-hub.controller.ts declares @Get("${ep}")`, () => {
@@ -264,6 +268,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "logs",
       "traces",
       "queries",
+      "jobs",
       "scalar",
       "openapi",
       "routes",

--- a/tests/stories/job-queue-history.story.test.ts
+++ b/tests/stories/job-queue-history.story.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { InMemoryJobQueue } from "../../src/core/jobs/job-queue.js";
+
+/**
+ * Story · Job-Queue history (dashboard substrate).
+ *
+ * The Jobs-Dashboard needs to enumerate every job — pending, running,
+ * completed, failed — with timestamps and the original payload. The
+ * legacy `jobResult(id)` only exposes the terminal status, so the
+ * dashboard would have to rebuild the timeline itself.
+ *
+ * Story:
+ *   - `listJobs()` returns one record per enqueued job
+ *   - records carry id, name, state, attempt, payload, createdAt,
+ *     startedAt (once active), completedAt + state transitions, and
+ *     errorMessage on failure
+ *   - records are returned newest-first so the UI can render the
+ *     latest activity at the top
+ *   - `getAggregates()` returns the dashboard snapshot computed from
+ *     the same record list
+ *   - listing supports `state` and `name` filters and a `limit` cap
+ *   - `retry(id)` re-enqueues a failed job, returning the new id;
+ *     the original record stays in the history with `attempt = 1`
+ *     and the new one carries `attempt = 2`
+ */
+describe("Story · Job-Queue history", () => {
+  it("listJobs() returns one record per enqueued job with createdAt + payload", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ping", async () => {});
+    await queue.start();
+    await queue.enqueue("ping", { who: "alice" });
+    await queue.enqueue("ping", { who: "bob" });
+    await queue.drain();
+    const records = queue.listJobs();
+    expect(records).toHaveLength(2);
+    for (const record of records) {
+      expect(record.id).toMatch(/.+/);
+      expect(record.name).toBe("ping");
+      expect(record.state).toBe("completed");
+      expect(record.attempt).toBe(1);
+      expect(typeof record.createdAt).toBe("number");
+      expect(typeof record.startedAt).toBe("number");
+      expect(typeof record.completedAt).toBe("number");
+    }
+    const payloads = records.map((r) => (r.payload as { who: string }).who).sort();
+    expect(payloads).toEqual(["alice", "bob"]);
+    await queue.stop();
+  });
+
+  it("listJobs() returns newest-first ordering", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ping", async () => {});
+    await queue.start();
+    const a = await queue.enqueue("ping", { n: 1 });
+    const b = await queue.enqueue("ping", { n: 2 });
+    const c = await queue.enqueue("ping", { n: 3 });
+    await queue.drain();
+    const ids = queue.listJobs().map((r) => r.id);
+    expect(ids).toEqual([c, b, a]);
+    await queue.stop();
+  });
+
+  it("captures error message + stack on failed jobs", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("boom", async () => {
+      throw new Error("kaboom");
+    });
+    await queue.start();
+    const id = await queue.enqueue("boom", {});
+    await queue.drain();
+    const record = queue.listJobs().find((r) => r.id === id);
+    expect(record).toBeDefined();
+    expect(record!.state).toBe("failed");
+    expect(record!.errorMessage).toContain("kaboom");
+    expect(record!.errorStack).toBeTruthy();
+    await queue.stop();
+  });
+
+  it("filters by state and by queue name", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ok", async () => {});
+    queue.register("bad", async () => {
+      throw new Error("nope");
+    });
+    await queue.start();
+    await queue.enqueue("ok", {});
+    await queue.enqueue("ok", {});
+    await queue.enqueue("bad", {});
+    await queue.drain();
+    expect(queue.listJobs({ state: "completed" })).toHaveLength(2);
+    expect(queue.listJobs({ state: "failed" })).toHaveLength(1);
+    expect(queue.listJobs({ name: "ok" })).toHaveLength(2);
+    expect(queue.listJobs({ name: "bad" })).toHaveLength(1);
+    await queue.stop();
+  });
+
+  it("respects the limit cap", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ping", async () => {});
+    await queue.start();
+    for (let i = 0; i < 5; i++) await queue.enqueue("ping", { i });
+    await queue.drain();
+    expect(queue.listJobs({ limit: 2 })).toHaveLength(2);
+    expect(queue.listJobs({ limit: 100 })).toHaveLength(5);
+    await queue.stop();
+  });
+
+  it("getAggregates() returns the dashboard snapshot built from listJobs()", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ok", async () => {});
+    queue.register("bad", async () => {
+      throw new Error("nope");
+    });
+    await queue.start();
+    await queue.enqueue("ok", {});
+    await queue.enqueue("ok", {});
+    await queue.enqueue("bad", {});
+    await queue.drain();
+    const snapshot = queue.getAggregates();
+    expect(snapshot.totalJobs).toBe(3);
+    expect(snapshot.totals.completed).toBe(2);
+    expect(snapshot.totals.failed).toBe(1);
+    expect(snapshot.queues).toHaveLength(2);
+    expect(snapshot.failureRate).toBeCloseTo(1 / 3, 5);
+    await queue.stop();
+  });
+
+  it("retry(id) re-enqueues a failed job and bumps the attempt counter", async () => {
+    const queue = new InMemoryJobQueue();
+    let attempts = 0;
+    queue.register("flaky", async () => {
+      attempts++;
+      if (attempts === 1) throw new Error("first try");
+    });
+    await queue.start();
+    const original = await queue.enqueue("flaky", { run: 1 });
+    await queue.drain();
+    expect(queue.listJobs().find((r) => r.id === original)!.state).toBe("failed");
+
+    const retryId = await queue.retry(original);
+    expect(retryId).not.toBe(original);
+    await queue.drain();
+    const retried = queue.listJobs().find((r) => r.id === retryId);
+    expect(retried).toBeDefined();
+    expect(retried!.state).toBe("completed");
+    expect(retried!.attempt).toBe(2);
+    expect(retried!.payload).toEqual({ run: 1 });
+
+    // Original record stays as-is in history.
+    expect(queue.listJobs().find((r) => r.id === original)!.attempt).toBe(1);
+    await queue.stop();
+  });
+
+  it("retry(id) throws when the job id is unknown", async () => {
+    const queue = new InMemoryJobQueue();
+    await queue.start();
+    await expect(queue.retry("does-not-exist")).rejects.toThrow();
+    await queue.stop();
+  });
+
+  it("retry(id) only works on failed jobs", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ok", async () => {});
+    await queue.start();
+    const id = await queue.enqueue("ok", {});
+    await queue.drain();
+    await expect(queue.retry(id)).rejects.toThrow();
+    await queue.stop();
+  });
+
+  it("getJob(id) returns the record for inspection (drawer detail view)", async () => {
+    const queue = new InMemoryJobQueue();
+    queue.register("ok", async () => {});
+    await queue.start();
+    const id = await queue.enqueue("ok", { hello: "world" });
+    await queue.drain();
+    const record = queue.getJob(id);
+    expect(record).toBeDefined();
+    expect(record!.id).toBe(id);
+    expect(record!.payload).toEqual({ hello: "world" });
+    expect(queue.getJob("missing")).toBeUndefined();
+    await queue.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `/dev/jobs` dashboard for the in-memory `JobQueueService` and lays the groundwork for the future pg-boss adapter to plug into the same JSON contract.

- **Pure-planner aggregations** (`src/core/jobs/dev-jobs-aggregations.ts`) — `countByState`, `computeP95Latency`, `computeFailureRate`, `aggregateJobsByQueue`, top-level `buildJobAggregates`. Deterministic, no I/O, fully unit-tested.
- **Queue history** — `InMemoryJobQueue` now retains per-job `JobRecord`s with `createdAt` / `startedAt` / `completedAt` timestamps + payload + captured error. Adds `listJobs({ state?, name?, limit? })`, `getJob(id)`, `getAggregates()`, `retry(id)`. Existing `jobResult(id)` surface stays.
- **HTTP endpoints** in `DevHubController`:
  - `GET /dev/jobs` — SPA shell
  - `GET /dev/jobs/queues.json` — aggregated snapshot
  - `GET /dev/jobs/jobs.json?state=&name=&limit=` — paginated listing (default 100, hard cap 500)
  - `GET /dev/jobs/jobs/:id.json` — drawer detail
  - `POST /dev/jobs/jobs/:id/retry` — re-enqueue failed jobs (404 unknown / 409 not-failed / 400 malformed id)
  - All routes inherit the `NODE_ENV=development` 404 guard
- **React `JobsPage`** with Queues + Jobs tabs, six-tile summary header, queue/state filters, a drawer rendering the payload via the existing `JsonViewer` and exposing a Retry CTA on failed jobs. `react-aria-components` wrappers throughout.
- **Sidebar nav** entry "Jobs" with a new `layers` icon.

### Out of scope (deferred)
The pg-boss-specific tabs from issue #15 (Schedules with cron heatmap, Workers with heartbeats, Archive with restore) need a Postgres-backed adapter and `pgboss.*` schema queries. The dashboard is shaped so a future pg-boss adapter exposes `listJobs()` + `getAggregates()` and lights up unchanged. The in-memory queue has no schedules/workers to surface yet.

## Test plan

- [x] `bun run lint` — 0 warnings
- [x] `bun run format` — all clean
- [x] `bun run test:types` — green
- [x] `bun run test:unit` — 139 / 139 green
- [x] `bun run build:dev-portal` — bundle builds
- [x] `bun run test:e2e` — 1709 / 1709 green (incl. 10 new `tests/jobs-dashboard.e2e-spec.ts`)
- [x] `bun run test:coverage` — `core/jobs` lines 95.93 % (≥ 70 % gate); 24 new story tests in `dev-jobs-aggregations` + 10 new in `job-queue-history`
- [x] `bun run build` — green
- [x] README updated with the new page

Closes #15