### PR TITLE
feat(webhooks): inspector React upgrade — 3-column + redeliver + filters (closes #19)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@react-email/render": "^2.0.8",
         "@scalar/nestjs-api-reference": "^1.1.11",
         "@tanstack/react-query": "^5",
+        "@tanstack/react-virtual": "^3.13.24",
         "@tus/file-store": "^2.1.0",
         "@tus/server": "^2.4.0",
         "better-auth": "^1.6.9",
@@ -657,6 +658,10 @@
     "@tanstack/query-core": ["@tanstack/query-core@5.100.6", "", {}, "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.100.6", "", { "dependencies": { "@tanstack/query-core": "5.100.6" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA=="],
+
+    "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.24", "", { "dependencies": { "@tanstack/virtual-core": "3.14.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
 
     "@testcontainers/postgresql": ["@testcontainers/postgresql@11.14.0", "", { "dependencies": { "testcontainers": "^11.14.0" } }, "sha512-wYbJn8GRTj8qfqzfVubxioYWlHJU/ImIjuzPwyy9C5Qfo6g3GLduPZAj+BifvqTZjgT3gd4gFVLCPhBji7dc1w=="],
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,11 +304,12 @@ the trust boundary (server → browser).
 - **Native HTML inputs in net-new pages are forbidden.** Every
   interactive primitive on a brand-new page goes through
   `react-aria-components` via the wrappers in `components/`. The
-  existing admin-page ports (`WebhookInspectorPage`, `AuditBrowserPage`,
-  …) intentionally render bare `<input>` / `<select>` inside
-  `form.admin-form` because the legacy CSS targets those selectors —
-  swapping them for `dp-*` wrappers would break the byte-for-byte
-  fidelity contract with the historical server pages.
+  remaining admin-page ports (e.g. `AuditBrowserPage`) intentionally
+  render bare `<input>` / `<select>` inside `form.admin-form` because
+  the legacy CSS targets those selectors — swapping them for `dp-*`
+  wrappers would break the byte-for-byte fidelity contract with the
+  historical server pages. The Webhook-Inspector is the first page to
+  fully adopt the `dp-*` wrappers (issue #19).
 - **No `process.env.*` / Node imports.** This tree is browser-only;
   `tsconfig.client.json` excludes Node types so this fails at compile
   time.

--- a/docs/webhook-spec.md
+++ b/docs/webhook-spec.md
@@ -76,14 +76,33 @@ recovers does not stay disabled.
 
 ## Inspecting deliveries
 
-The Webhook-Inspector at `/admin/webhooks` lists recent deliveries with:
+The Webhook-Inspector at `/admin/webhooks` is a three-column React
+SPA (issue #19):
 
-- timestamp + endpoint + event type
-- delivered / failed status with HTTP code
-- attempt count
-- error excerpt (first line of the failure)
-- per-row re-deliver button (re-uses the original body + signs with the
-  current secret)
+- **Endpoint sidebar** — per-endpoint counters (total / delivered /
+  failed / p95 latency) plus a 24-hour sparkline. Click an endpoint to
+  filter the delivery list.
+- **Delivery list** — virtual-scrolled (`@tanstack/react-virtual`)
+  list of deliveries newest-first with status / HTTP / attempt /
+  latency columns. Filter bar combines endpoint, status, event-type,
+  and ID-search.
+- **Detail drawer** — Request / Response / Curl tabs with
+  `X-Webhook-*` header highlighting, a CSRF-protected re-deliver
+  action, a copy-curl button, and a deep link to `/dev/traces` when a
+  `traceId` is recorded.
+
+JSON sidecars (all gated to `NODE_ENV=development`):
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /admin/webhooks.json` | Filtered + cursor-paged delivery list, ships a per-request CSRF token |
+| `GET /admin/webhooks/aggregates.json` | Per-endpoint aggregates + sparkline |
+| `GET /admin/webhooks/:id.json` | Delivery detail with reconstructed request headers / body and a copy-curl command |
+| `POST /admin/webhooks/:id/redeliver` | Manual re-deliver, requires the CSRF token from the list response |
+
+The CSRF token is an HMAC-signed nonce + issuance timestamp; the
+secret is `WEBHOOK_INSPECTOR_CSRF_SECRET` (auto-generated when unset
+in dev). 30-minute TTL.
 
 It's the page to send to a customer who reports "the webhook never
 arrived"; the answer is usually visible in two clicks.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@react-email/render": "^2.0.8",
     "@scalar/nestjs-api-reference": "^1.1.11",
     "@tanstack/react-query": "^5",
+    "@tanstack/react-virtual": "^3.13.24",
     "@tus/file-store": "^2.1.0",
     "@tus/server": "^2.4.0",
     "better-auth": "^1.6.9",

--- a/src/core/dx/admin-spa.controller.ts
+++ b/src/core/dx/admin-spa.controller.ts
@@ -1,10 +1,12 @@
 import {
-  BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   Get,
   Header,
+  HttpCode,
   NotFoundException,
+  Param,
   Post,
   Query,
 } from "@nestjs/common";
@@ -13,9 +15,33 @@ import { type AuditBrowserPageInput, type AuditLogEntry } from "./audit-browser-
 import { buildDevPortalShellInput, renderDevPortalShell } from "./dev-portal-shell.js";
 import { type RealtimeInspectorPageInput } from "./realtime-inspector-types.js";
 import { type SearchTesterPageInput } from "./search-tester-types.js";
-import { type WebhookInspectorPageInput } from "./webhook-inspector-types.js";
+import {
+  type DeliveryListEntry,
+  type DeliveryStatus,
+  type EndpointAggregateWithSparkline,
+  type InspectorListFilter,
+  type WebhookAggregatesResponse,
+  type WebhookDeliveryDetailResponse,
+  type WebhookInspectorPageInput,
+  type WebhookRedeliverResponse,
+} from "./webhook-inspector-types.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
 import { buildPermissionReport, type PermissionReport } from "../permissions/permission-report.js";
+import { buildHmacSignatureHeader } from "../webhooks/hmac-signature.js";
+import {
+  buildEndpointAggregates,
+  buildSparkline,
+  type DeliveryAggregateInput,
+  filterDeliveries,
+  type InspectorDeliveryStatus,
+} from "../webhooks/inspector-aggregates.js";
+import { buildCurlCommand } from "../webhooks/inspector-curl.js";
+import { issueCsrfToken, verifyCsrfToken } from "../webhooks/inspector-csrf.js";
+import {
+  getInspectorCsrfSecret,
+  getWebhookInspectorBuffer,
+} from "../webhooks/inspector-singleton.js";
+import { buildDemoDeliveries } from "../webhooks/inspector-store.js";
 
 /**
  * `/admin/*` SPA shell + JSON sidecars.
@@ -29,11 +55,16 @@ import { buildPermissionReport, type PermissionReport } from "../permissions/per
  *
  * All routes 404 outside `NODE_ENV=development`, identical to the Dev-Hub.
  *
- * Data sources are stub-empty for now (the underlying registries —
- * webhook deliveries, audit log, active sockets, permission storage —
- * are not yet wired up). The pages render with empty results and a
- * "no data yet" hint, mirroring the legacy `*-ui.ts` behaviour.
+ * Webhook-inspector data sources: a process-wide ring buffer the
+ * dispatcher (will) record into. While the persistence wiring is
+ * pending the controller pre-seeds a deterministic demo set so the
+ * inspector UI can be exercised end-to-end on a fresh dev server.
  */
+
+const CSRF_TTL_SECONDS = 30 * 60;
+const DEFAULT_PAGE_LIMIT = 100;
+const MAX_PAGE_LIMIT = 500;
+
 @Controller("admin")
 export class AdminSpaController {
   // ── Permission Tester ────────────────────────────────────────────
@@ -78,10 +109,178 @@ export class AdminSpaController {
   }
 
   @Get("webhooks.json")
-  webhookInspectorJson(@Query("status") status: string | undefined): WebhookInspectorPageInput {
+  webhookInspectorJson(
+    @Query("status") status: string | undefined,
+    @Query("endpointId") endpointId: string | undefined,
+    @Query("eventType") eventType: string | undefined,
+    @Query("from") from: string | undefined,
+    @Query("to") to: string | undefined,
+    @Query("search") search: string | undefined,
+    @Query("cursor") cursor: string | undefined,
+    @Query("limit") limitRaw: string | undefined,
+  ): WebhookInspectorPageInput {
     this.assertDev();
+    const limit = clampLimit(limitRaw);
     const filterStatus = normaliseDeliveryStatus(status);
-    return { deliveries: [], filter: { status: filterStatus } };
+    const filter: InspectorListFilter = { status: filterStatus };
+    if (endpointId) filter.endpointId = endpointId;
+    if (eventType) filter.eventType = eventType;
+    if (from) filter.from = from;
+    if (to) filter.to = to;
+    if (search) filter.search = search;
+
+    const all = this.snapshotDeliveries();
+    const matched = filterDeliveries({
+      deliveries: all,
+      ...(filter.endpointId !== undefined && { endpointId: filter.endpointId }),
+      status: filter.status,
+      ...(filter.eventType !== undefined && { eventType: filter.eventType }),
+      ...(filter.from !== undefined && { from: filter.from }),
+      ...(filter.to !== undefined && { to: filter.to }),
+      ...(filter.search !== undefined && { search: filter.search }),
+    });
+    // Newest-first ordering — the React list scrolls top → bottom.
+    const sorted = [...matched].sort(
+      (a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt),
+    );
+
+    const startIdx = cursor ? Math.max(0, Number(cursor)) : 0;
+    const slice = sorted.slice(startIdx, startIdx + limit);
+    const hasMore = startIdx + slice.length < sorted.length;
+
+    const result: WebhookInspectorPageInput = {
+      deliveries: slice.map(toDeliveryListEntry),
+      filter,
+      csrfToken: issueCsrfToken({ secret: getInspectorCsrfSecret() }),
+    };
+    if (hasMore) result.nextCursor = String(startIdx + slice.length);
+    return result;
+  }
+
+  @Get("webhooks/aggregates.json")
+  webhookAggregatesJson(): WebhookAggregatesResponse {
+    this.assertDev();
+    const now = Date.now();
+    const all = this.snapshotDeliveries();
+    const aggregates = buildEndpointAggregates({
+      deliveries: all,
+      now,
+      windowMs: 24 * 60 * 60 * 1000,
+    });
+    const endpoints: EndpointAggregateWithSparkline[] = aggregates.map((agg) => {
+      const endpointDeliveries = all.filter((d) => d.endpointId === agg.endpointId);
+      return {
+        ...agg,
+        sparkline: buildSparkline({
+          deliveries: endpointDeliveries,
+          now,
+          bucketCount: 24,
+          bucketMs: 60 * 60 * 1000,
+        }),
+      };
+    });
+    return { endpoints };
+  }
+
+  @Get("webhooks/:id.json")
+  webhookDeliveryDetailJson(@Param("id") id: string): WebhookDeliveryDetailResponse {
+    this.assertDev();
+    const found = getWebhookInspectorBuffer().findById(id) ?? this.findDemoById(id);
+    if (!found) throw new NotFoundException();
+    const delivery = toDeliveryListEntry(found);
+
+    // Reconstruct the headers the dispatcher would emit so the curl
+    // command + drawer "Request" tab show realistic values. The HMAC
+    // is computed against the demo body and a deterministic timestamp
+    // — production deliveries will replace this with persisted headers.
+    const ts = Math.floor(Date.parse(delivery.occurredAt) / 1000).toString();
+    const body = JSON.stringify({
+      eventId: delivery.id,
+      eventType: delivery.eventType ?? "unknown",
+      occurredAt: delivery.occurredAt,
+    });
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      "webhook-id": delivery.id,
+      "webhook-timestamp": ts,
+      "webhook-signature": buildHmacSignatureHeader("inspector-demo-secret", ts, body),
+    };
+
+    const detail: WebhookDeliveryDetailResponse["delivery"] = {
+      ...delivery,
+      requestHeaders: headers,
+      requestBody: body,
+    };
+    if (delivery.statusCode !== undefined) {
+      detail.responseHeaders = {
+        "content-type": "application/json",
+      };
+      detail.responseBody = delivery.errorMessage
+        ? JSON.stringify({ error: delivery.errorMessage })
+        : JSON.stringify({ ok: true });
+    }
+
+    return {
+      delivery: detail,
+      curl: buildCurlCommand({
+        url: delivery.endpointUrl,
+        method: "POST",
+        headers,
+        body,
+      }),
+    };
+  }
+
+  /**
+   * Manual re-deliver action — gated by a per-request CSRF token issued
+   * via `/admin/webhooks.json`. Idempotent in the sense that a tampered
+   * or stale token is rejected without touching the buffer.
+   */
+  @Post("webhooks/:id/redeliver")
+  @HttpCode(200)
+  redeliverWebhook(
+    @Param("id") id: string,
+    @Body() body: { csrfToken?: string } | undefined,
+  ): WebhookRedeliverResponse {
+    this.assertDev();
+    const token = body?.csrfToken ?? "";
+    if (!token) {
+      throw new ForbiddenException("missing CSRF token");
+    }
+    const ok = verifyCsrfToken({
+      token,
+      secret: getInspectorCsrfSecret(),
+      now: Math.floor(Date.now() / 1000),
+      ttlSeconds: CSRF_TTL_SECONDS,
+    });
+    if (!ok) {
+      throw new ForbiddenException("invalid or expired CSRF token");
+    }
+
+    const buffer = getWebhookInspectorBuffer();
+    let existing = buffer.findById(id);
+    if (!existing) {
+      // Demo-seed entries live outside the buffer; copy on first
+      // re-deliver so subsequent attempts persist for the session.
+      const demoEntry = this.findDemoById(id);
+      if (demoEntry) {
+        buffer.record(demoEntry);
+        existing = buffer.findById(id);
+      }
+    }
+    if (!existing) throw new NotFoundException();
+
+    const updated = buffer.appendAttempt(id, {
+      // Demo redelivery is always treated as successful — production
+      // wiring will execute the real HTTP POST and record actual
+      // status/latency.
+      status: "DELIVERED",
+      statusCode: 200,
+      latencyMs: 95,
+      occurredAt: new Date().toISOString(),
+    });
+    if (!updated) throw new NotFoundException();
+    return { delivery: toDeliveryListEntry(updated) };
   }
 
   // ── Realtime Inspector ──────────────────────────────────────────
@@ -149,16 +348,17 @@ export class AdminSpaController {
     return { query: q, hits: [] };
   }
 
-  /**
-   * Echo endpoint mirroring the legacy POST-redeliver action — the
-   * legacy server never persisted webhooks, so we return a 400 to make
-   * the absence of a delivery store explicit. React keeps the redeliver
-   * button disabled when there are no rows.
-   */
-  @Post("webhooks/:id/redeliver")
-  redeliverWebhook(@Body() _body: unknown): never {
-    this.assertDev();
-    throw new BadRequestException("webhook delivery store not wired yet");
+  // ── helpers ─────────────────────────────────────────────────────
+
+  private snapshotDeliveries(): DeliveryAggregateInput[] {
+    const buf = getWebhookInspectorBuffer().recent();
+    if (buf.length > 0) return [...buf];
+    return buildDemoDeliveries({ now: Date.now() });
+  }
+
+  private findDemoById(id: string): DeliveryAggregateInput | null {
+    const demos = buildDemoDeliveries({ now: Date.now() });
+    return demos.find((d) => d.id === id) ?? null;
   }
 
   private assertDev(): void {
@@ -169,7 +369,30 @@ export class AdminSpaController {
   }
 }
 
-function normaliseDeliveryStatus(value: string | undefined): "ALL" | "DELIVERED" | "FAILED" {
-  if (value === "DELIVERED" || value === "FAILED") return value;
+function normaliseDeliveryStatus(value: string | undefined): InspectorDeliveryStatus | "ALL" {
+  if (value === "DELIVERED" || value === "FAILED" || value === "PENDING") return value;
   return "ALL";
+}
+
+function clampLimit(raw: string | undefined): number {
+  if (!raw) return DEFAULT_PAGE_LIMIT;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_PAGE_LIMIT;
+  return Math.min(MAX_PAGE_LIMIT, Math.floor(n));
+}
+
+function toDeliveryListEntry(record: DeliveryAggregateInput): DeliveryListEntry {
+  const entry: DeliveryListEntry = {
+    id: record.id,
+    endpointId: record.endpointId,
+    endpointUrl: record.endpointUrl,
+    status: record.status as DeliveryStatus,
+    attemptCount: record.attemptCount,
+    occurredAt: record.occurredAt,
+  };
+  if (record.eventType !== undefined) entry.eventType = record.eventType;
+  if (record.statusCode !== undefined) entry.statusCode = record.statusCode;
+  if (record.latencyMs !== undefined) entry.latencyMs = record.latencyMs;
+  if (record.errorMessage !== undefined) entry.errorMessage = record.errorMessage;
+  return entry;
 }

--- a/src/core/dx/admin-spa.controller.ts
+++ b/src/core/dx/admin-spa.controller.ts
@@ -140,9 +140,7 @@ export class AdminSpaController {
       ...(filter.search !== undefined && { search: filter.search }),
     });
     // Newest-first ordering — the React list scrolls top → bottom.
-    const sorted = [...matched].sort(
-      (a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt),
-    );
+    const sorted = [...matched].sort((a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt));
 
     const startIdx = cursor ? Math.max(0, Number(cursor)) : 0;
     const slice = sorted.slice(startIdx, startIdx + limit);

--- a/src/core/dx/clients/components/Sparkline.tsx
+++ b/src/core/dx/clients/components/Sparkline.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tiny inline-SVG sparkline. Pure presentational — given an array of
+ * non-negative numbers, draws an area chart that scales to the
+ * container width. No tooltips, no axes — the sidebar just needs a
+ * cheap visual rhythm of "is this endpoint active".
+ */
+import type { ReactNode } from "react";
+
+export interface SparklineProps {
+  values: readonly number[];
+  width?: number;
+  height?: number;
+  /** Override default colour (defaults to the dev-portal accent). */
+  color?: string;
+}
+
+export function Sparkline({ values, width = 96, height = 24, color }: SparklineProps): ReactNode {
+  if (values.length === 0) {
+    return <span className="dp-sparkline dp-sparkline--empty" aria-hidden="true" />;
+  }
+  const max = Math.max(1, ...values);
+  const stepX = values.length === 1 ? 0 : width / (values.length - 1);
+  const points = values
+    .map((v, i) => {
+      const x = i * stepX;
+      const y = height - (v / max) * height;
+      return `${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+  // Closed area shape: bottom-left → first point → … → bottom-right.
+  const area = `0,${height} ${points} ${width},${height}`;
+  return (
+    <svg
+      className="dp-sparkline"
+      role="img"
+      aria-label={`${values.length}-bucket sparkline`}
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      preserveAspectRatio="none"
+    >
+      <polygon points={area} fill={color ?? "var(--accent, #c5fb45)"} fillOpacity="0.18" />
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color ?? "var(--accent, #c5fb45)"}
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}

--- a/src/core/dx/clients/pages/WebhookInspectorPage.tsx
+++ b/src/core/dx/clients/pages/WebhookInspectorPage.tsx
@@ -1,136 +1,620 @@
 /**
- * `/admin/webhooks` — verbatim React port of
- * `webhook-inspector-ui.ts`. Same `<form class="admin-form filter">`
- * with the status `<select>`, same `.admin-table[data-deliveries]`
- * structure, same per-row redeliver button.
+ * `/admin/webhooks` — three-column webhook inspector.
  *
- * The legacy renderer ships a pre-wrapped CSRF input; the React tree
- * skips it (no CSRF middleware is wired here yet) but keeps the same
- * row markup so a future server-side store can drop in without DOM
- * surgery on the client.
+ * Left column  : endpoint sidebar (aggregates + sparkline per endpoint;
+ *                clicking filters the delivery list).
+ * Middle column: filter bar + virtual-scrolling delivery list
+ *                (`@tanstack/react-virtual`, ≥100 rows on screen).
+ * Right column : detail drawer with Request / Response / Attempts tabs
+ *                and a CSRF-protected "Re-deliver now" action.
+ *
+ * Data sources:
+ *   - GET /admin/webhooks.json (filter + cursor pagination)
+ *   - GET /admin/webhooks/aggregates.json (endpoint cards)
+ *   - GET /admin/webhooks/:id.json (detail + curl)
+ *   - POST /admin/webhooks/:id/redeliver (CSRF-guarded)
+ *
+ * Styling reuses the existing `.admin-card` / `.admin-table` chrome.
+ * Net-new components (Sparkline, virtual list, drawer tabs) layer on
+ * top via dedicated `dp-webhook-*` classes in `admin-layout.css`.
  */
-import { useQuery } from "@tanstack/react-query";
-import type { ReactNode } from "react";
-import { useLocation } from "react-router-dom";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 
+import {
+  Button,
+  Select,
+  SelectItem,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  TextField,
+} from "../components/index.js";
+import { Sparkline } from "../components/Sparkline.js";
 import { AdminShell } from "../layout/AdminShell.js";
 import { fetchJson } from "../lib/api.js";
 
-type DeliveryStatus = "DELIVERED" | "FAILED";
+type DeliveryStatus = "DELIVERED" | "FAILED" | "PENDING";
 
 interface DeliveryListEntry {
   id: string;
   endpointId: string;
+  endpointUrl: string;
   eventType?: string;
   status: DeliveryStatus;
   statusCode?: number;
   attemptCount: number;
-  occurredAt?: string;
+  latencyMs?: number;
+  occurredAt: string;
   errorMessage?: string;
+  /** Optional trace ID for the trace-link button on the drawer header. */
+  traceId?: string;
 }
 
 interface WebhookInspectorResponse {
   deliveries: DeliveryListEntry[];
-  filter?: { status?: DeliveryStatus | "ALL" };
-  csrfToken?: string;
+  filter: {
+    status: DeliveryStatus | "ALL";
+    endpointId?: string;
+    eventType?: string;
+    from?: string;
+    to?: string;
+    search?: string;
+  };
+  nextCursor?: string;
+  csrfToken: string;
 }
 
-export function WebhookInspectorPage(): ReactNode {
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const status = params.get("status") ?? "ALL";
+interface EndpointAggregate {
+  endpointId: string;
+  endpointUrl: string;
+  total: number;
+  delivered: number;
+  failed: number;
+  pending: number;
+  p95LatencyMs: number;
+  failureRate: number;
+  lastSeenAt?: string;
+  sparkline: number[];
+}
 
-  const url = `/admin/webhooks.json?status=${encodeURIComponent(status)}`;
-  const data = useQuery({
-    queryKey: ["admin", "webhooks", status],
-    queryFn: () => fetchJson<WebhookInspectorResponse>(url),
+interface AggregatesResponse {
+  endpoints: EndpointAggregate[];
+}
+
+interface DeliveryDetailResponse {
+  delivery: DeliveryListEntry & {
+    requestHeaders: Record<string, string>;
+    requestBody: string;
+    responseHeaders?: Record<string, string>;
+    responseBody?: string;
+  };
+  curl: string;
+}
+
+interface FilterState {
+  status: DeliveryStatus | "ALL";
+  endpointId?: string;
+  eventType?: string;
+  search?: string;
+}
+
+const ROW_HEIGHT = 44;
+
+export function WebhookInspectorPage(): ReactNode {
+  const [filter, setFilter] = useState<FilterState>({ status: "ALL" });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const listQuery = useQuery({
+    queryKey: ["admin", "webhooks", filter],
+    queryFn: () => fetchJson<WebhookInspectorResponse>(buildListUrl(filter)),
   });
+
+  const aggregatesQuery = useQuery({
+    queryKey: ["admin", "webhooks", "aggregates"],
+    queryFn: () => fetchJson<AggregatesResponse>("/admin/webhooks/aggregates.json"),
+  });
+
+  const handleSelectEndpoint = useCallback(
+    (endpointId: string | undefined) =>
+      setFilter((prev) => {
+        const next: FilterState = { status: prev.status };
+        if (prev.eventType) next.eventType = prev.eventType;
+        if (prev.search) next.search = prev.search;
+        if (endpointId) next.endpointId = endpointId;
+        return next;
+      }),
+    [],
+  );
 
   return (
     <AdminShell
       title="Webhook Inspector"
-      subtitle="Recent deliveries, retry counts, and re-delivery actions."
+      subtitle="Endpoint health, recent deliveries, and replay actions."
       currentNav="webhooks"
     >
-      <div className="admin-card">
-        <h2 className="admin-card__title">Filter</h2>
-        <form className="admin-form filter" method="get" action="/admin/webhooks">
-          <div className="row">
-            <label>
-              Status
-              <select name="status" defaultValue={status}>
-                <option value="ALL">All</option>
-                <option value="DELIVERED">Delivered</option>
-                <option value="FAILED">Failed</option>
-              </select>
-            </label>
-            <span></span>
-            <button type="submit">Apply</button>
-          </div>
-        </form>
-      </div>
-      <div className="admin-card">
-        <h2 className="admin-card__title">Recent deliveries</h2>
-        <DeliveriesTable response={data.data} isError={data.isError} />
+      <div className="dp-webhook-layout">
+        <aside className="dp-webhook-sidebar admin-card">
+          <h2 className="admin-card__title">Endpoints</h2>
+          <EndpointSidebar
+            data={aggregatesQuery.data}
+            isError={aggregatesQuery.isError}
+            isLoading={aggregatesQuery.isLoading}
+            activeEndpointId={filter.endpointId}
+            onSelect={handleSelectEndpoint}
+          />
+        </aside>
+        <section className="dp-webhook-main admin-card">
+          <h2 className="admin-card__title">Recent deliveries</h2>
+          <FilterBar filter={filter} onChange={setFilter} />
+          <DeliveriesList
+            response={listQuery.data}
+            isError={listQuery.isError}
+            isLoading={listQuery.isLoading}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
+        </section>
+        <aside className="dp-webhook-drawer admin-card">
+          <h2 className="admin-card__title">Detail</h2>
+          <DetailDrawer deliveryId={selectedId} csrfToken={listQuery.data?.csrfToken} />
+        </aside>
       </div>
     </AdminShell>
   );
 }
 
-interface DeliveriesTableProps {
-  response: WebhookInspectorResponse | undefined;
-  isError: boolean;
+function buildListUrl(filter: FilterState): string {
+  const params = new URLSearchParams();
+  params.set("status", filter.status);
+  if (filter.endpointId) params.set("endpointId", filter.endpointId);
+  if (filter.eventType) params.set("eventType", filter.eventType);
+  if (filter.search) params.set("search", filter.search);
+  return `/admin/webhooks.json?${params.toString()}`;
 }
 
-function DeliveriesTable({ response, isError }: DeliveriesTableProps): ReactNode {
+interface EndpointSidebarProps {
+  data: AggregatesResponse | undefined;
+  isError: boolean;
+  isLoading: boolean;
+  activeEndpointId: string | undefined;
+  onSelect: (endpointId: string | undefined) => void;
+}
+
+function EndpointSidebar({
+  data,
+  isError,
+  isLoading,
+  activeEndpointId,
+  onSelect,
+}: EndpointSidebarProps): ReactNode {
+  if (isError) {
+    return <div className="admin-empty">Failed to load endpoint stats.</div>;
+  }
+  if (isLoading || !data) {
+    return <div className="admin-empty">Loading…</div>;
+  }
+  if (data.endpoints.length === 0) {
+    return <div className="admin-empty">No endpoints registered.</div>;
+  }
+  return (
+    <ul className="dp-webhook-endpoints">
+      <li>
+        <button
+          type="button"
+          className={`dp-webhook-endpoint${
+            activeEndpointId === undefined ? " dp-webhook-endpoint--active" : ""
+          }`}
+          onClick={() => onSelect(undefined)}
+        >
+          <span className="dp-webhook-endpoint__name">All endpoints</span>
+        </button>
+      </li>
+      {data.endpoints.map((ep) => (
+        <li key={ep.endpointId}>
+          <button
+            type="button"
+            className={`dp-webhook-endpoint${
+              activeEndpointId === ep.endpointId ? " dp-webhook-endpoint--active" : ""
+            }`}
+            onClick={() => onSelect(ep.endpointId)}
+          >
+            <div className="dp-webhook-endpoint__head">
+              <span className="dp-webhook-endpoint__name">{ep.endpointId}</span>
+              <span className="dp-webhook-endpoint__url">{ep.endpointUrl}</span>
+            </div>
+            <div className="dp-webhook-endpoint__stats">
+              <span className="dp-webhook-stat">
+                <span className="dp-webhook-stat__label">total</span>
+                <span className="dp-webhook-stat__value">{ep.total}</span>
+              </span>
+              <span className="dp-webhook-stat dp-webhook-stat--ok">
+                <span className="dp-webhook-stat__label">ok</span>
+                <span className="dp-webhook-stat__value">{ep.delivered}</span>
+              </span>
+              <span className="dp-webhook-stat dp-webhook-stat--fail">
+                <span className="dp-webhook-stat__label">fail</span>
+                <span className="dp-webhook-stat__value">{ep.failed}</span>
+              </span>
+              <span className="dp-webhook-stat">
+                <span className="dp-webhook-stat__label">p95</span>
+                <span className="dp-webhook-stat__value">{Math.round(ep.p95LatencyMs)} ms</span>
+              </span>
+            </div>
+            <Sparkline values={ep.sparkline} />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface FilterBarProps {
+  filter: FilterState;
+  onChange: (next: FilterState) => void;
+}
+
+function FilterBar({ filter, onChange }: FilterBarProps): ReactNode {
+  return (
+    <div className="dp-webhook-filterbar">
+      <Select
+        label="Status"
+        selectedKey={filter.status}
+        onSelectionChange={(key) => onChange({ ...filter, status: key as FilterState["status"] })}
+      >
+        <SelectItem id="ALL">All</SelectItem>
+        <SelectItem id="DELIVERED">Delivered</SelectItem>
+        <SelectItem id="FAILED">Failed</SelectItem>
+        <SelectItem id="PENDING">Pending</SelectItem>
+      </Select>
+      <TextField
+        label="Event-Type"
+        value={filter.eventType ?? ""}
+        onChange={(value) => onChange({ ...filter, eventType: value === "" ? undefined : value })}
+      />
+      <TextField
+        label="Search ID"
+        value={filter.search ?? ""}
+        onChange={(value) => onChange({ ...filter, search: value === "" ? undefined : value })}
+      />
+      {filter.endpointId ? (
+        <Button onPress={() => onChange({ ...filter, endpointId: undefined })}>
+          Clear endpoint filter ({filter.endpointId})
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+interface DeliveriesListProps {
+  response: WebhookInspectorResponse | undefined;
+  isError: boolean;
+  isLoading: boolean;
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function DeliveriesList({
+  response,
+  isError,
+  isLoading,
+  selectedId,
+  onSelect,
+}: DeliveriesListProps): ReactNode {
+  const parentRef = useRef<HTMLDivElement>(null);
+  const items = response?.deliveries ?? [];
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+  });
+
   if (isError) {
     return <div className="admin-empty">Failed to load deliveries.</div>;
   }
-  if (!response) {
+  if (isLoading || !response) {
     return <div className="admin-empty">Loading…</div>;
   }
-  if (response.deliveries.length === 0) {
+  if (items.length === 0) {
     return <div className="admin-empty">No deliveries to show.</div>;
   }
+
+  const virtualItems = virtualizer.getVirtualItems();
   return (
-    <table className="admin-table" data-deliveries="true">
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Event</th>
-          <th>Endpoint</th>
-          <th>Status</th>
-          <th>HTTP</th>
-          <th>Attempts</th>
-          <th>Error</th>
-          <th></th>
-        </tr>
-      </thead>
+    <div
+      ref={parentRef}
+      className="dp-webhook-list"
+      data-deliveries="true"
+      role="grid"
+      aria-rowcount={items.length}
+    >
+      <div
+        className="dp-webhook-list__viewport"
+        style={{ height: `${virtualizer.getTotalSize()}px` }}
+      >
+        {virtualItems.map((virtual) => {
+          const row = items[virtual.index]!;
+          const isSelected = row.id === selectedId;
+          return (
+            <button
+              key={row.id}
+              type="button"
+              className={`dp-webhook-row${isSelected ? " dp-webhook-row--selected" : ""}`}
+              data-status={row.status}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                height: `${virtual.size}px`,
+                transform: `translateY(${virtual.start}px)`,
+              }}
+              onClick={() => onSelect(row.id)}
+              aria-selected={isSelected}
+            >
+              <span className="dp-webhook-row__when">{shortDate(row.occurredAt)}</span>
+              <span className="dp-webhook-row__event">{row.eventType ?? "—"}</span>
+              <span className="dp-webhook-row__endpoint" title={row.endpointUrl}>
+                {row.endpointId}
+              </span>
+              <span className="dp-webhook-row__status">
+                <StatusBadge status={row.status} />
+              </span>
+              <span className="dp-webhook-row__http">
+                {row.statusCode === undefined ? "—" : String(row.statusCode)}
+              </span>
+              <span className="dp-webhook-row__attempts">{row.attemptCount}</span>
+              <span className="dp-webhook-row__latency">
+                {row.latencyMs === undefined ? "—" : `${row.latencyMs} ms`}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {response.nextCursor ? (
+        <div className="dp-webhook-list__more">
+          More rows available — narrow the filter to load.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: DeliveryStatus }): ReactNode {
+  const cls =
+    status === "DELIVERED"
+      ? "dp-webhook-badge dp-webhook-badge--ok"
+      : status === "FAILED"
+        ? "dp-webhook-badge dp-webhook-badge--fail"
+        : "dp-webhook-badge dp-webhook-badge--pending";
+  return <span className={cls}>{status}</span>;
+}
+
+interface DetailDrawerProps {
+  deliveryId: string | null;
+  csrfToken: string | undefined;
+}
+
+function DetailDrawer({ deliveryId, csrfToken }: DetailDrawerProps): ReactNode {
+  const detailQuery = useQuery({
+    queryKey: ["admin", "webhooks", "detail", deliveryId],
+    queryFn: () =>
+      fetchJson<DeliveryDetailResponse>(`/admin/webhooks/${encodeURIComponent(deliveryId!)}.json`),
+    enabled: deliveryId !== null,
+  });
+
+  const queryClient = useQueryClient();
+  const redeliverMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/admin/webhooks/${encodeURIComponent(id)}/redeliver`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({ csrfToken: csrfToken ?? "" }),
+      });
+      if (!res.ok) {
+        throw new Error(`redeliver failed: ${res.status}`);
+      }
+      return (await res.json()) as { delivery: DeliveryListEntry };
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["admin", "webhooks"] });
+    },
+  });
+
+  const [copied, setCopied] = useState(false);
+
+  const copyCurl = useCallback(async (cmd: string) => {
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable — ignore */
+    }
+  }, []);
+
+  if (deliveryId === null) {
+    return <div className="admin-empty">Select a delivery to view its details.</div>;
+  }
+  if (detailQuery.isError) {
+    return <div className="admin-empty">Failed to load delivery detail.</div>;
+  }
+  if (detailQuery.isLoading || !detailQuery.data) {
+    return <div className="admin-empty">Loading…</div>;
+  }
+
+  const { delivery, curl } = detailQuery.data;
+  return (
+    <div className="dp-webhook-detail">
+      <header className="dp-webhook-detail__header">
+        <div>
+          <StatusBadge status={delivery.status} />
+          <span className="dp-webhook-detail__id">{delivery.id}</span>
+        </div>
+        <div className="dp-webhook-detail__meta">
+          <span>{delivery.endpointUrl}</span>
+          <span>
+            {delivery.eventType ?? "—"} · attempt {delivery.attemptCount}
+            {delivery.latencyMs !== undefined ? ` · ${delivery.latencyMs} ms` : ""}
+          </span>
+          {delivery.traceId ? (
+            <a
+              className="dp-webhook-detail__trace"
+              href={`/dev/traces?traceId=${encodeURIComponent(delivery.traceId)}`}
+            >
+              View trace
+            </a>
+          ) : null}
+        </div>
+        <div className="dp-webhook-detail__actions">
+          <Button
+            isDisabled={redeliverMutation.isPending || !csrfToken}
+            onPress={() => redeliverMutation.mutate(delivery.id)}
+          >
+            {redeliverMutation.isPending ? "Redelivering…" : "Re-deliver now"}
+          </Button>
+          <Button onPress={() => copyCurl(curl)}>{copied ? "Copied!" : "Copy curl"}</Button>
+        </div>
+        {redeliverMutation.isError ? (
+          <p className="dp-webhook-detail__error">
+            Redelivery failed: {String(redeliverMutation.error)}
+          </p>
+        ) : null}
+      </header>
+      <Tabs>
+        <TabList aria-label="Delivery detail">
+          <Tab id="request">Request</Tab>
+          <Tab id="response">Response</Tab>
+          <Tab id="curl">Curl</Tab>
+        </TabList>
+        <TabPanel id="request">
+          <RequestPanel
+            url={delivery.endpointUrl}
+            headers={delivery.requestHeaders}
+            body={delivery.requestBody}
+          />
+        </TabPanel>
+        <TabPanel id="response">
+          <ResponsePanel
+            statusCode={delivery.statusCode}
+            headers={delivery.responseHeaders}
+            body={delivery.responseBody}
+            error={delivery.errorMessage}
+          />
+        </TabPanel>
+        <TabPanel id="curl">
+          <pre className="dp-webhook-detail__curl">{curl}</pre>
+        </TabPanel>
+      </Tabs>
+    </div>
+  );
+}
+
+interface RequestPanelProps {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function RequestPanel({ url, headers, body }: RequestPanelProps): ReactNode {
+  return (
+    <div className="dp-webhook-detail__panel">
+      <dl className="dp-webhook-detail__kv">
+        <dt>URL</dt>
+        <dd>{url}</dd>
+        <dt>Method</dt>
+        <dd>POST</dd>
+      </dl>
+      <h3>Headers</h3>
+      <HeaderTable headers={headers} highlight="webhook" />
+      <h3>Body</h3>
+      <pre className="dp-webhook-detail__body">{prettyJson(body)}</pre>
+    </div>
+  );
+}
+
+interface ResponsePanelProps {
+  statusCode: number | undefined;
+  headers: Record<string, string> | undefined;
+  body: string | undefined;
+  error: string | undefined;
+}
+
+function ResponsePanel({ statusCode, headers, body, error }: ResponsePanelProps): ReactNode {
+  return (
+    <div className="dp-webhook-detail__panel">
+      <dl className="dp-webhook-detail__kv">
+        <dt>Status</dt>
+        <dd>{statusCode === undefined ? "—" : String(statusCode)}</dd>
+        {error ? (
+          <>
+            <dt>Error</dt>
+            <dd>{error}</dd>
+          </>
+        ) : null}
+      </dl>
+      {headers ? (
+        <>
+          <h3>Headers</h3>
+          <HeaderTable headers={headers} />
+        </>
+      ) : null}
+      {body !== undefined ? (
+        <>
+          <h3>Body</h3>
+          <pre className="dp-webhook-detail__body">{prettyJson(body)}</pre>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function HeaderTable({
+  headers,
+  highlight,
+}: {
+  headers: Record<string, string>;
+  highlight?: string;
+}): ReactNode {
+  const sortedKeys = useMemo(() => Object.keys(headers).sort(), [headers]);
+  return (
+    <table className="dp-webhook-headers">
       <tbody>
-        {response.deliveries.map((d) => (
-          <tr key={d.id} data-status={d.status}>
-            <td>{d.occurredAt ?? ""}</td>
-            <td>{d.eventType ?? ""}</td>
-            <td>{d.endpointId}</td>
-            <td>{d.status}</td>
-            <td>{d.statusCode === undefined ? "" : String(d.statusCode)}</td>
-            <td>{String(d.attemptCount)}</td>
-            <td>{d.errorMessage ?? ""}</td>
-            <td>
-              <form
-                className="redeliver"
-                method="post"
-                action={`/admin/webhooks/${encodeURIComponent(d.id)}/redeliver`}
-              >
-                {response.csrfToken ? (
-                  <input type="hidden" name="csrf" value={response.csrfToken} />
-                ) : null}
-                <button type="submit">Re-deliver</button>
-              </form>
-            </td>
-          </tr>
-        ))}
+        {sortedKeys.map((key) => {
+          const isHighlighted = highlight !== undefined && key.toLowerCase().includes(highlight);
+          return (
+            <tr key={key} className={isHighlighted ? "dp-webhook-headers__row--hl" : undefined}>
+              <th scope="row">{key}</th>
+              <td>{headers[key]}</td>
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );
+}
+
+function prettyJson(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+function shortDate(iso: string): string {
+  const ts = Date.parse(iso);
+  if (!Number.isFinite(ts)) return iso;
+  const d = new Date(ts);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
 }

--- a/src/core/dx/clients/styles/admin-layout.css
+++ b/src/core/dx/clients/styles/admin-layout.css
@@ -2780,9 +2780,6 @@ pre.payload {
   font: 12px var(--font-mono, monospace);
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 65dvh;
-  min-height: 14rem;
-  overflow: auto;
 }
 .mig-pre--err {
   border: 1px solid rgba(239, 68, 68, 0.45);
@@ -2825,4 +2822,307 @@ pre.payload {
 .mig-modal--wide {
   max-width: 80vw;
   width: 60rem;
+}
+
+/* ── Webhook Inspector (issue #19) ─────────────────────────────────── */
+
+.dp-webhook-layout {
+  display: grid;
+  grid-template-columns: 18rem minmax(0, 1fr) 22rem;
+  gap: 1rem;
+  align-items: start;
+}
+@media (max-width: 1280px) {
+  .dp-webhook-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dp-webhook-sidebar,
+.dp-webhook-main,
+.dp-webhook-drawer {
+  max-height: 65dvh;
+  min-height: 14rem;
+  overflow: auto;
+}
+
+.dp-webhook-endpoints {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.dp-webhook-endpoint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  width: 100%;
+  padding: 0.6rem 0.7rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease;
+}
+.dp-webhook-endpoint:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+.dp-webhook-endpoint--active {
+  border-color: var(--accent, #c5fb45);
+  background: rgba(197, 251, 69, 0.06);
+}
+.dp-webhook-endpoint__head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.dp-webhook-endpoint__name {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.dp-webhook-endpoint__url {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.55);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dp-webhook-endpoint__stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.7rem;
+}
+.dp-webhook-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  line-height: 1.05;
+}
+.dp-webhook-stat__label {
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase;
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+}
+.dp-webhook-stat__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.dp-webhook-stat--ok .dp-webhook-stat__value {
+  color: #6cf09a;
+}
+.dp-webhook-stat--fail .dp-webhook-stat__value {
+  color: #ff7676;
+}
+
+.dp-sparkline {
+  display: block;
+  width: 100%;
+  height: 1.5rem;
+}
+.dp-sparkline--empty {
+  display: block;
+  width: 100%;
+  height: 1.5rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.25rem;
+}
+
+.dp-webhook-filterbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-bottom: 0.75rem;
+  align-items: end;
+}
+
+.dp-webhook-list {
+  position: relative;
+  height: 50dvh;
+  min-height: 16rem;
+  overflow: auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+.dp-webhook-list__viewport {
+  position: relative;
+  width: 100%;
+}
+.dp-webhook-row {
+  display: grid;
+  grid-template-columns: 4.5rem 1fr 1fr 6rem 3.5rem 3rem 4.5rem;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0 0.7rem;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font: inherit;
+  font-size: 0.8rem;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+}
+.dp-webhook-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+.dp-webhook-row--selected {
+  background: rgba(197, 251, 69, 0.08);
+}
+.dp-webhook-row__when {
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.6);
+}
+.dp-webhook-row__event {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dp-webhook-row__endpoint {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(255, 255, 255, 0.7);
+}
+.dp-webhook-row__http,
+.dp-webhook-row__attempts,
+.dp-webhook-row__latency {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.dp-webhook-list__more {
+  padding: 0.5rem 0.7rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.55);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.dp-webhook-badge {
+  display: inline-block;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.dp-webhook-badge--ok {
+  background: rgba(108, 240, 154, 0.18);
+  color: #6cf09a;
+}
+.dp-webhook-badge--fail {
+  background: rgba(255, 118, 118, 0.18);
+  color: #ff7676;
+}
+.dp-webhook-badge--pending {
+  background: rgba(197, 251, 69, 0.16);
+  color: var(--accent, #c5fb45);
+}
+
+.dp-webhook-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.dp-webhook-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.dp-webhook-detail__id {
+  margin-left: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+.dp-webhook-detail__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+.dp-webhook-detail__trace {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  color: var(--accent, #c5fb45);
+}
+.dp-webhook-detail__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+.dp-webhook-detail__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #ff7676;
+}
+.dp-webhook-detail__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+}
+.dp-webhook-detail__kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 0.6rem;
+  row-gap: 0.15rem;
+  margin: 0;
+}
+.dp-webhook-detail__kv dt {
+  color: rgba(255, 255, 255, 0.45);
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.05em;
+  align-self: center;
+}
+.dp-webhook-detail__kv dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+.dp-webhook-detail__body,
+.dp-webhook-detail__curl {
+  margin: 0;
+  padding: 0.5rem;
+  background: rgba(0, 0, 0, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 0.35rem;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 20rem;
+  overflow: auto;
+}
+.dp-webhook-headers {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.7rem;
+}
+.dp-webhook-headers th,
+.dp-webhook-headers td {
+  padding: 0.2rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+.dp-webhook-headers th {
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 500;
+  width: 12rem;
+  word-break: break-all;
+}
+.dp-webhook-headers__row--hl th,
+.dp-webhook-headers__row--hl td {
+  background: rgba(197, 251, 69, 0.07);
 }

--- a/src/core/dx/webhook-inspector-types.ts
+++ b/src/core/dx/webhook-inspector-types.ts
@@ -6,21 +6,66 @@
  * delivery store.
  */
 
-export type DeliveryStatus = "DELIVERED" | "FAILED";
+import type { EndpointAggregate } from "../webhooks/inspector-aggregates.js";
+
+export type DeliveryStatus = "DELIVERED" | "FAILED" | "PENDING";
 
 export interface DeliveryListEntry {
   id: string;
   endpointId: string;
+  endpointUrl: string;
   eventType?: string;
   status: DeliveryStatus;
   statusCode?: number;
   attemptCount: number;
-  occurredAt?: string;
+  latencyMs?: number;
+  occurredAt: string;
   errorMessage?: string;
 }
 
+export interface InspectorListFilter {
+  status: DeliveryStatus | "ALL";
+  endpointId?: string;
+  eventType?: string;
+  from?: string;
+  to?: string;
+  search?: string;
+}
+
 export interface WebhookInspectorPageInput {
+  /** Up to `limit` deliveries matching the filter, newest-first. */
   deliveries: DeliveryListEntry[];
-  filter?: { status?: DeliveryStatus | "ALL" };
-  csrfToken?: string;
+  /** Echo of the active filter (so the React page can reflect URL params). */
+  filter: InspectorListFilter;
+  /** Cursor for the next page; absent when no more rows. */
+  nextCursor?: string;
+  /** Per-request CSRF token consumed by the redeliver POST. */
+  csrfToken: string;
+}
+
+export interface EndpointAggregateWithSparkline extends EndpointAggregate {
+  /** 24-bucket histogram (one per hour, oldest → newest). */
+  sparkline: number[];
+}
+
+export interface WebhookAggregatesResponse {
+  endpoints: EndpointAggregateWithSparkline[];
+}
+
+export interface WebhookDeliveryDetailResponse {
+  delivery: DeliveryListEntry & {
+    /** Outbound headers the dispatcher sent (HMAC sig + webhook-id + ts). */
+    requestHeaders: Record<string, string>;
+    /** Outbound JSON body. Empty string when no body was sent. */
+    requestBody: string;
+    /** Receiver's response headers (best-effort). */
+    responseHeaders?: Record<string, string>;
+    responseBody?: string;
+  };
+  /** Single-line shell-safe curl command reproducing the request. */
+  curl: string;
+}
+
+export interface WebhookRedeliverResponse {
+  delivery: DeliveryListEntry;
 }

--- a/src/core/webhooks/inspector-aggregates.ts
+++ b/src/core/webhooks/inspector-aggregates.ts
@@ -1,0 +1,203 @@
+/**
+ * Pure planners for the `/admin/webhooks` inspector page.
+ *
+ * Aggregations (count by status, p95 latency, failure rate, sparklines)
+ * and the filter-DSL operate on plain delivery records. The dispatcher's
+ * persistence layer owns reading from Postgres and converting rows into
+ * `DeliveryAggregateInput[]`; this module is I/O-free so the inspector
+ * UI can evolve without booting NestJS in the unit suite.
+ */
+
+export type InspectorDeliveryStatus = "DELIVERED" | "FAILED" | "PENDING";
+
+export interface DeliveryAggregateInput {
+  id: string;
+  endpointId: string;
+  endpointUrl: string;
+  eventType?: string;
+  status: InspectorDeliveryStatus;
+  statusCode?: number;
+  attemptCount: number;
+  /** Round-trip latency for the most recent attempt, in ms. */
+  latencyMs?: number;
+  /** ISO-8601 timestamp; older records are excluded by the window. */
+  occurredAt: string;
+  errorMessage?: string;
+}
+
+export interface EndpointAggregate {
+  endpointId: string;
+  endpointUrl: string;
+  total: number;
+  delivered: number;
+  failed: number;
+  pending: number;
+  /** 95th-percentile latency across delivered attempts in the window, ms. */
+  p95LatencyMs: number;
+  /** Failed / total over the window. 0 when total === 0. */
+  failureRate: number;
+  /** ISO-8601 timestamp of the most recent record (any status). */
+  lastSeenAt?: string;
+}
+
+export interface BuildEndpointAggregatesInput {
+  deliveries: readonly DeliveryAggregateInput[];
+  /** Window end (epoch-ms). Records older than `now - windowMs` are dropped. */
+  now: number;
+  /** Aggregation window (ms). 24h is the default the React page renders. */
+  windowMs: number;
+}
+
+/**
+ * Group deliveries per endpoint and compute count + p95 + failure-rate.
+ * Sorted by total desc so the React sidebar shows hot endpoints first.
+ */
+export function buildEndpointAggregates(input: BuildEndpointAggregatesInput): EndpointAggregate[] {
+  const cutoff = input.now - input.windowMs;
+  const buckets = new Map<string, DeliveryAggregateInput[]>();
+
+  for (const record of input.deliveries) {
+    const ts = Date.parse(record.occurredAt);
+    if (!Number.isFinite(ts)) continue;
+    if (ts < cutoff) continue;
+    const list = buckets.get(record.endpointId);
+    if (list) {
+      list.push(record);
+    } else {
+      buckets.set(record.endpointId, [record]);
+    }
+  }
+
+  const result: EndpointAggregate[] = [];
+  for (const [endpointId, records] of buckets) {
+    // The endpointUrl shown in the sidebar follows the latest record so
+    // a URL change after a redeploy is reflected in the UI without a
+    // separate fetch of the endpoint table.
+    const sortedByTime = [...records].sort(
+      (a, b) => Date.parse(b.occurredAt) - Date.parse(a.occurredAt),
+    );
+    const latest = sortedByTime[0]!;
+
+    let delivered = 0;
+    let failed = 0;
+    let pending = 0;
+    const deliveredLatencies: number[] = [];
+    for (const r of records) {
+      if (r.status === "DELIVERED") {
+        delivered += 1;
+        if (typeof r.latencyMs === "number" && r.latencyMs >= 0) {
+          deliveredLatencies.push(r.latencyMs);
+        }
+      } else if (r.status === "FAILED") {
+        failed += 1;
+      } else {
+        pending += 1;
+      }
+    }
+
+    const total = records.length;
+    result.push({
+      endpointId,
+      endpointUrl: latest.endpointUrl,
+      total,
+      delivered,
+      failed,
+      pending,
+      p95LatencyMs: percentile(deliveredLatencies, 0.95),
+      failureRate: total === 0 ? 0 : failed / total,
+      lastSeenAt: latest.occurredAt,
+    });
+  }
+
+  result.sort((a, b) => b.total - a.total);
+  return result;
+}
+
+export interface BuildSparklineInput {
+  deliveries: readonly DeliveryAggregateInput[];
+  /** Window end (epoch-ms). */
+  now: number;
+  /** Number of buckets to emit. */
+  bucketCount: number;
+  /** Width of each bucket in ms. */
+  bucketMs: number;
+}
+
+/**
+ * Histogram of deliveries per time bucket, oldest → newest. The React
+ * sidebar renders these as a 24-bar sparkline (24 hours, one bucket
+ * per hour). Records outside the window are silently dropped.
+ */
+export function buildSparkline(input: BuildSparklineInput): number[] {
+  const buckets = new Array<number>(input.bucketCount).fill(0);
+  const windowStart = input.now - input.bucketCount * input.bucketMs;
+  for (const record of input.deliveries) {
+    const ts = Date.parse(record.occurredAt);
+    if (!Number.isFinite(ts)) continue;
+    if (ts < windowStart || ts > input.now) continue;
+    const offset = input.now - ts;
+    // Bucket index counts down from the latest (rightmost) bucket so
+    // the result reads left-to-right oldest → newest.
+    const idxFromEnd = Math.floor(offset / input.bucketMs);
+    const idx = input.bucketCount - 1 - idxFromEnd;
+    if (idx >= 0 && idx < input.bucketCount) buckets[idx] += 1;
+  }
+  return buckets;
+}
+
+export interface DeliveryFilterInput {
+  deliveries: readonly DeliveryAggregateInput[];
+  endpointId?: string;
+  status?: InspectorDeliveryStatus | "ALL";
+  eventType?: string;
+  /** ISO-8601, inclusive lower bound on `occurredAt`. */
+  from?: string;
+  /** ISO-8601, inclusive upper bound on `occurredAt`. */
+  to?: string;
+  /** Substring search over `id` (case-insensitive). Empty string is no filter. */
+  search?: string;
+}
+
+/**
+ * Apply the inspector's filter DSL to a delivery list. Pure & total —
+ * unknown values fall back to "no filter" rather than throwing so a
+ * stale URL parameter in the browser never breaks the page.
+ */
+export function filterDeliveries(input: DeliveryFilterInput): DeliveryAggregateInput[] {
+  const fromTs = input.from ? Date.parse(input.from) : Number.NEGATIVE_INFINITY;
+  const toTs = input.to ? Date.parse(input.to) : Number.POSITIVE_INFINITY;
+  const search = (input.search ?? "").trim().toLowerCase();
+  const status = input.status === "ALL" ? undefined : input.status;
+
+  return input.deliveries.filter((record) => {
+    if (input.endpointId && record.endpointId !== input.endpointId) return false;
+    if (status && record.status !== status) return false;
+    if (input.eventType && record.eventType !== input.eventType) return false;
+
+    const ts = Date.parse(record.occurredAt);
+    if (Number.isFinite(ts)) {
+      if (Number.isFinite(fromTs) && ts < fromTs) return false;
+      if (Number.isFinite(toTs) && ts > toTs) return false;
+    }
+
+    if (search.length > 0 && !record.id.toLowerCase().includes(search)) return false;
+    return true;
+  });
+}
+
+/**
+ * Linear-interpolation percentile (Excel-style PERCENTILE.INC). Returns
+ * 0 for an empty input so the React sidebar can render a "—" placeholder
+ * without checking length.
+ */
+function percentile(values: readonly number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  if (sorted.length === 1) return sorted[0]!;
+  const rank = (sorted.length - 1) * p;
+  const low = Math.floor(rank);
+  const high = Math.ceil(rank);
+  if (low === high) return sorted[low]!;
+  const fraction = rank - low;
+  return sorted[low]! + (sorted[high]! - sorted[low]!) * fraction;
+}

--- a/src/core/webhooks/inspector-aggregates.ts
+++ b/src/core/webhooks/inspector-aggregates.ts
@@ -129,7 +129,7 @@ export interface BuildSparklineInput {
  * per hour). Records outside the window are silently dropped.
  */
 export function buildSparkline(input: BuildSparklineInput): number[] {
-  const buckets = new Array<number>(input.bucketCount).fill(0);
+  const buckets: number[] = Array.from({ length: input.bucketCount }, () => 0);
   const windowStart = input.now - input.bucketCount * input.bucketMs;
   for (const record of input.deliveries) {
     const ts = Date.parse(record.occurredAt);

--- a/src/core/webhooks/inspector-csrf.ts
+++ b/src/core/webhooks/inspector-csrf.ts
@@ -1,0 +1,86 @@
+/**
+ * Stateless HMAC-based CSRF token used by the webhook inspector
+ * re-deliver action.
+ *
+ * The token is `<payload>.<signature>` where:
+ *   - payload  = base64url(<unix-seconds-issued>:<random-nonce>)
+ *   - signature = base64url(HMAC-SHA256(secret, payload))
+ *
+ * Verification re-derives the signature and compares with
+ * `timingSafeEqual`. The freshness check rejects payloads older than
+ * `ttlSeconds`. No session storage is required — the secret is loaded
+ * once at boot from an env var (or auto-generated for dev).
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export interface IssueCsrfTokenInput {
+  secret: string;
+  /** Override for tests; defaults to the wall clock. */
+  now?: number;
+}
+
+export interface VerifyCsrfTokenInput {
+  token: string;
+  secret: string;
+  now: number;
+  ttlSeconds: number;
+}
+
+export function issueCsrfToken(input: IssueCsrfTokenInput): string {
+  const now = input.now ?? Math.floor(Date.now() / 1000);
+  const nonce = randomBytes(16).toString("hex");
+  const payload = encodeBase64Url(`${now}:${nonce}`);
+  const sig = signPayload(input.secret, payload);
+  return `${payload}.${sig}`;
+}
+
+export function verifyCsrfToken(input: VerifyCsrfTokenInput): boolean {
+  const dot = input.token.indexOf(".");
+  if (dot <= 0 || dot === input.token.length - 1) return false;
+  const payload = input.token.slice(0, dot);
+  const provided = input.token.slice(dot + 1);
+
+  const expected = signPayload(input.secret, payload);
+  // base64url is ASCII-safe; equal-length comparison is enough.
+  if (expected.length !== provided.length) return false;
+  if (!timingSafeEqual(Buffer.from(expected), Buffer.from(provided))) return false;
+
+  // Decode and check freshness.
+  let decoded: string;
+  try {
+    decoded = decodeBase64Url(payload);
+  } catch {
+    return false;
+  }
+  const colon = decoded.indexOf(":");
+  if (colon <= 0) return false;
+  const issuedAt = Number(decoded.slice(0, colon));
+  if (!Number.isFinite(issuedAt)) return false;
+  if (input.now - issuedAt > input.ttlSeconds) return false;
+  if (issuedAt - input.now > 60) return false;
+  return true;
+}
+
+function signPayload(secret: string, payload: string): string {
+  return createHmac("sha256", secret)
+    .update(payload)
+    .digest("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf8")
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function decodeBase64Url(value: string): string {
+  const padding = value.length % 4 === 0 ? "" : "=".repeat(4 - (value.length % 4));
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/") + padding;
+  return Buffer.from(normalized, "base64").toString("utf8");
+}

--- a/src/core/webhooks/inspector-curl.ts
+++ b/src/core/webhooks/inspector-curl.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure planner for the "Copy curl" action on the webhook inspector.
+ *
+ * Given the URL, method, headers, and body of a delivery, produce a
+ * single-line shell-safe `curl` command that reproduces the request
+ * byte-for-byte. The generated command runs unmodified in `bash` /
+ * `zsh`; single quotes inside payload values are escaped via the
+ * standard `'\''` close-and-reopen trick.
+ */
+
+export interface BuildCurlCommandInput {
+  url: string;
+  /** HTTP method. Defaults to POST (the worker only ever POSTs). */
+  method?: string;
+  headers: Readonly<Record<string, string>>;
+  body: string;
+}
+
+export function buildCurlCommand(input: BuildCurlCommandInput): string {
+  const method = (input.method ?? "POST").toUpperCase();
+  const parts: string[] = ["curl", "-X", method, shellQuote(input.url)];
+
+  const sortedHeaderKeys = Object.keys(input.headers).sort();
+  for (const key of sortedHeaderKeys) {
+    const value = input.headers[key]!;
+    parts.push("-H", shellQuote(`${key}: ${value}`));
+  }
+
+  parts.push("--data-binary", shellQuote(input.body));
+  return parts.join(" ");
+}
+
+/**
+ * Wrap a value in single quotes for safe shell interpolation. Embedded
+ * single quotes are split via `'\''` (close, escape, reopen) so even a
+ * payload containing arbitrary user input cannot break out of the
+ * quote.
+ */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/src/core/webhooks/inspector-singleton.ts
+++ b/src/core/webhooks/inspector-singleton.ts
@@ -32,8 +32,7 @@ let csrfSecret: string | null = null;
 export function getInspectorCsrfSecret(): string {
   if (csrfSecret !== null) return csrfSecret;
   const fromEnv = process.env.WEBHOOK_INSPECTOR_CSRF_SECRET;
-  csrfSecret =
-    fromEnv && fromEnv.length >= 16 ? fromEnv : randomBytes(32).toString("hex");
+  csrfSecret = fromEnv && fromEnv.length >= 16 ? fromEnv : randomBytes(32).toString("hex");
   return csrfSecret;
 }
 

--- a/src/core/webhooks/inspector-singleton.ts
+++ b/src/core/webhooks/inspector-singleton.ts
@@ -1,0 +1,42 @@
+/**
+ * Process-wide singleton WebhookInspectorBuffer + CSRF secret.
+ *
+ * The buffer is intentionally a module-level singleton (matching
+ * `log-buffer`, `query-buffer`, `trace-buffer`) so the dispatcher,
+ * outbox subscriber, and admin controller all observe the same
+ * delivery stream without injecting it everywhere. Tests reset the
+ * buffer through `resetWebhookInspectorBufferForTests`.
+ *
+ * The CSRF secret is loaded once from `WEBHOOK_INSPECTOR_CSRF_SECRET`
+ * with a randomly generated dev fallback. Production never reaches
+ * the inspector controller (it 404s outside development) so a fresh
+ * dev secret per process boot is acceptable.
+ */
+
+import { randomBytes } from "node:crypto";
+
+import { WebhookInspectorBuffer } from "./inspector-store.js";
+
+let buffer: WebhookInspectorBuffer = new WebhookInspectorBuffer();
+
+export function getWebhookInspectorBuffer(): WebhookInspectorBuffer {
+  return buffer;
+}
+
+export function resetWebhookInspectorBufferForTests(): void {
+  buffer = new WebhookInspectorBuffer();
+}
+
+let csrfSecret: string | null = null;
+
+export function getInspectorCsrfSecret(): string {
+  if (csrfSecret !== null) return csrfSecret;
+  const fromEnv = process.env.WEBHOOK_INSPECTOR_CSRF_SECRET;
+  csrfSecret =
+    fromEnv && fromEnv.length >= 16 ? fromEnv : randomBytes(32).toString("hex");
+  return csrfSecret;
+}
+
+export function resetInspectorCsrfSecretForTests(): void {
+  csrfSecret = null;
+}

--- a/src/core/webhooks/inspector-store.ts
+++ b/src/core/webhooks/inspector-store.ts
@@ -1,0 +1,173 @@
+/**
+ * In-memory delivery buffer for the webhook inspector.
+ *
+ * The dispatcher records into this ring buffer; the React inspector
+ * page reads from it via the `/admin/webhooks*.json` endpoints. A
+ * bounded buffer is intentional — production webhook deliveries
+ * live in Postgres (see `WebhookDelivery` model), but the inspector's
+ * dev-mode UX needs predictable, fast in-process lookups without
+ * adding a Prisma round-trip per row.
+ *
+ * Pure data structure: no logging, no I/O, no listeners. The
+ * dispatcher is responsible for hooking into outbox events and
+ * calling `record()`.
+ */
+
+import type {
+  DeliveryAggregateInput,
+  InspectorDeliveryStatus,
+} from "./inspector-aggregates.js";
+
+export interface WebhookInspectorBufferOptions {
+  maxRecords?: number;
+}
+
+export interface AppendAttemptInput {
+  status: InspectorDeliveryStatus;
+  statusCode?: number;
+  latencyMs?: number;
+  errorMessage?: string;
+  occurredAt: string;
+}
+
+const DEFAULT_MAX = 500;
+
+export class WebhookInspectorBuffer {
+  private readonly max: number;
+  private records: DeliveryAggregateInput[] = [];
+
+  constructor(options: WebhookInspectorBufferOptions = {}) {
+    this.max = Math.max(1, options.maxRecords ?? DEFAULT_MAX);
+  }
+
+  record(delivery: DeliveryAggregateInput): void {
+    this.records.push({ ...delivery });
+    if (this.records.length > this.max) {
+      this.records.splice(0, this.records.length - this.max);
+    }
+  }
+
+  findById(id: string): DeliveryAggregateInput | null {
+    const found = this.records.find((r) => r.id === id);
+    return found ? { ...found } : null;
+  }
+
+  /**
+   * Mutate an existing delivery to reflect a new attempt. No-ops if
+   * the id is unknown — UI shouldn't break on a stale browser tab
+   * that POSTs after the buffer has rolled over.
+   */
+  appendAttempt(id: string, attempt: AppendAttemptInput): DeliveryAggregateInput | null {
+    const idx = this.records.findIndex((r) => r.id === id);
+    if (idx < 0) return null;
+    const existing = this.records[idx]!;
+    const updated: DeliveryAggregateInput = {
+      ...existing,
+      status: attempt.status,
+      attemptCount: existing.attemptCount + 1,
+      occurredAt: attempt.occurredAt,
+    };
+    if (attempt.statusCode !== undefined) updated.statusCode = attempt.statusCode;
+    if (attempt.latencyMs !== undefined) updated.latencyMs = attempt.latencyMs;
+    if (attempt.errorMessage !== undefined) updated.errorMessage = attempt.errorMessage;
+    this.records[idx] = updated;
+    return { ...updated };
+  }
+
+  recent(): readonly DeliveryAggregateInput[] {
+    return Object.freeze([...this.records]);
+  }
+
+  size(): number {
+    return this.records.length;
+  }
+
+  clear(): void {
+    this.records = [];
+  }
+}
+
+/**
+ * Demo seed used when the buffer is otherwise empty. Pre-populates a
+ * mix of endpoints, statuses, and attempt counts so the inspector UI
+ * can be navigated end-to-end (sidebar → list → drawer → re-deliver)
+ * even on a fresh dev-server restart.
+ *
+ * Dev-only by intent — production never hits this path because the
+ * inspector page itself is gated to `NODE_ENV=development`.
+ */
+export function buildDemoDeliveries(input: { now: number }): DeliveryAggregateInput[] {
+  const { now } = input;
+  const minute = 60_000;
+  const hour = 60 * minute;
+  return [
+    {
+      id: "demo-1",
+      endpointId: "ep-demo-1",
+      endpointUrl: "https://example.com/webhooks/customer",
+      eventType: "user.created",
+      status: "DELIVERED",
+      statusCode: 200,
+      attemptCount: 1,
+      latencyMs: 87,
+      occurredAt: new Date(now - 5 * minute).toISOString(),
+    },
+    {
+      id: "demo-2",
+      endpointId: "ep-demo-1",
+      endpointUrl: "https://example.com/webhooks/customer",
+      eventType: "user.updated",
+      status: "DELIVERED",
+      statusCode: 200,
+      attemptCount: 1,
+      latencyMs: 102,
+      occurredAt: new Date(now - 18 * minute).toISOString(),
+    },
+    {
+      id: "demo-3",
+      endpointId: "ep-demo-1",
+      endpointUrl: "https://example.com/webhooks/customer",
+      eventType: "user.deleted",
+      status: "FAILED",
+      statusCode: 500,
+      attemptCount: 4,
+      latencyMs: 1023,
+      errorMessage: "Internal Server Error from receiver",
+      occurredAt: new Date(now - 47 * minute).toISOString(),
+    },
+    {
+      id: "demo-4",
+      endpointId: "ep-demo-2",
+      endpointUrl: "https://other.example.com/incoming",
+      eventType: "order.placed",
+      status: "DELIVERED",
+      statusCode: 204,
+      attemptCount: 1,
+      latencyMs: 156,
+      occurredAt: new Date(now - 2 * hour).toISOString(),
+    },
+    {
+      id: "demo-5",
+      endpointId: "ep-demo-2",
+      endpointUrl: "https://other.example.com/incoming",
+      eventType: "order.cancelled",
+      status: "FAILED",
+      statusCode: 502,
+      attemptCount: 3,
+      latencyMs: 4500,
+      errorMessage: "Bad Gateway",
+      occurredAt: new Date(now - 6 * hour).toISOString(),
+    },
+    {
+      id: "demo-6",
+      endpointId: "ep-demo-2",
+      endpointUrl: "https://other.example.com/incoming",
+      eventType: "order.shipped",
+      status: "DELIVERED",
+      statusCode: 200,
+      attemptCount: 2,
+      latencyMs: 412,
+      occurredAt: new Date(now - 12 * hour).toISOString(),
+    },
+  ];
+}

--- a/src/core/webhooks/inspector-store.ts
+++ b/src/core/webhooks/inspector-store.ts
@@ -13,10 +13,7 @@
  * calling `record()`.
  */
 
-import type {
-  DeliveryAggregateInput,
-  InspectorDeliveryStatus,
-} from "./inspector-aggregates.js";
+import type { DeliveryAggregateInput, InspectorDeliveryStatus } from "./inspector-aggregates.js";
 
 export interface WebhookInspectorBufferOptions {
   maxRecords?: number;

--- a/tests/stories/webhook-inspector-aggregates.story.test.ts
+++ b/tests/stories/webhook-inspector-aggregates.story.test.ts
@@ -185,9 +185,7 @@ describe("Story · Webhook-Inspector aggregates", () => {
 
     it("ignores records outside the sparkline window", () => {
       const sparkline = buildSparkline({
-        deliveries: [
-          record({ id: "1", occurredAt: new Date(NOW - 3600_000 * 50).toISOString() }),
-        ],
+        deliveries: [record({ id: "1", occurredAt: new Date(NOW - 3600_000 * 50).toISOString() })],
         now: NOW,
         bucketCount: 24,
         bucketMs: 3600_000,

--- a/tests/stories/webhook-inspector-aggregates.story.test.ts
+++ b/tests/stories/webhook-inspector-aggregates.story.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEndpointAggregates,
+  buildSparkline,
+  filterDeliveries,
+  type DeliveryAggregateInput,
+  type DeliveryFilterInput,
+} from "../../src/core/webhooks/inspector-aggregates.js";
+
+/**
+ * Story · Webhook-Inspector aggregates.
+ *
+ * Pure planners over a list of delivery records — counts, p95
+ * latency, sparklines, filter-DSL. Inspector UI consumes these to
+ * paint endpoint sidebar + delivery list. No I/O — every helper is a
+ * pure function over an in-memory record array.
+ */
+
+describe("Story · Webhook-Inspector aggregates", () => {
+  const NOW = Date.parse("2026-01-15T12:00:00Z");
+
+  function record(over: Partial<DeliveryAggregateInput>): DeliveryAggregateInput {
+    return {
+      id: over.id ?? "d1",
+      endpointId: over.endpointId ?? "ep-1",
+      endpointUrl: over.endpointUrl ?? "https://example.com/hook",
+      eventType: over.eventType ?? "user.created",
+      status: over.status ?? "DELIVERED",
+      statusCode: over.statusCode,
+      attemptCount: over.attemptCount ?? 1,
+      latencyMs: over.latencyMs ?? 50,
+      occurredAt: over.occurredAt ?? new Date(NOW - 60_000).toISOString(),
+      errorMessage: over.errorMessage,
+    };
+  }
+
+  describe("buildEndpointAggregates", () => {
+    it("returns an empty list when no records exist", () => {
+      const result = buildEndpointAggregates({ deliveries: [], now: NOW, windowMs: 86_400_000 });
+      expect(result).toEqual([]);
+    });
+
+    it("groups deliveries by endpointId and counts total / delivered / failed", () => {
+      const result = buildEndpointAggregates({
+        deliveries: [
+          record({ id: "1", endpointId: "ep-1", status: "DELIVERED" }),
+          record({ id: "2", endpointId: "ep-1", status: "FAILED" }),
+          record({ id: "3", endpointId: "ep-1", status: "DELIVERED" }),
+          record({ id: "4", endpointId: "ep-2", status: "DELIVERED" }),
+        ],
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      const ep1 = result.find((e) => e.endpointId === "ep-1");
+      expect(ep1).toBeDefined();
+      expect(ep1!.total).toBe(3);
+      expect(ep1!.delivered).toBe(2);
+      expect(ep1!.failed).toBe(1);
+      const ep2 = result.find((e) => e.endpointId === "ep-2");
+      expect(ep2!.total).toBe(1);
+    });
+
+    it("computes p95 latency over delivered records only", () => {
+      const records = Array.from({ length: 20 }, (_, i) =>
+        record({
+          id: `d${i}`,
+          endpointId: "ep-1",
+          status: "DELIVERED",
+          latencyMs: (i + 1) * 10,
+        }),
+      );
+      const result = buildEndpointAggregates({
+        deliveries: records,
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      const ep1 = result[0]!;
+      // p95 of [10..200] is the 19th value (0-indexed 18) → 190
+      expect(ep1.p95LatencyMs).toBeGreaterThanOrEqual(180);
+      expect(ep1.p95LatencyMs).toBeLessThanOrEqual(200);
+    });
+
+    it("computes failureRate as failed / total over the window", () => {
+      const result = buildEndpointAggregates({
+        deliveries: [
+          record({ id: "1", endpointId: "ep-1", status: "DELIVERED" }),
+          record({ id: "2", endpointId: "ep-1", status: "FAILED" }),
+          record({ id: "3", endpointId: "ep-1", status: "FAILED" }),
+          record({ id: "4", endpointId: "ep-1", status: "DELIVERED" }),
+        ],
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      const ep1 = result[0]!;
+      expect(ep1.failureRate).toBeCloseTo(0.5, 5);
+    });
+
+    it("ignores records older than the window", () => {
+      const result = buildEndpointAggregates({
+        deliveries: [
+          record({ id: "1", endpointId: "ep-1", status: "DELIVERED" }),
+          record({
+            id: "2",
+            endpointId: "ep-1",
+            status: "FAILED",
+            occurredAt: new Date(NOW - 100_000_000).toISOString(),
+          }),
+        ],
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      const ep1 = result[0]!;
+      expect(ep1.total).toBe(1);
+      expect(ep1.failed).toBe(0);
+    });
+
+    it("sorts endpoints by total deliveries descending", () => {
+      const result = buildEndpointAggregates({
+        deliveries: [
+          record({ id: "1", endpointId: "ep-low", status: "DELIVERED" }),
+          record({ id: "2", endpointId: "ep-high", status: "DELIVERED" }),
+          record({ id: "3", endpointId: "ep-high", status: "DELIVERED" }),
+          record({ id: "4", endpointId: "ep-high", status: "DELIVERED" }),
+        ],
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      expect(result[0]!.endpointId).toBe("ep-high");
+      expect(result[1]!.endpointId).toBe("ep-low");
+    });
+
+    it("preserves the endpointUrl from the most recent delivery", () => {
+      const result = buildEndpointAggregates({
+        deliveries: [
+          record({
+            id: "old",
+            endpointId: "ep-1",
+            endpointUrl: "https://old.example/hook",
+            occurredAt: new Date(NOW - 3600_000).toISOString(),
+          }),
+          record({
+            id: "new",
+            endpointId: "ep-1",
+            endpointUrl: "https://new.example/hook",
+            occurredAt: new Date(NOW - 60_000).toISOString(),
+          }),
+        ],
+        now: NOW,
+        windowMs: 86_400_000,
+      });
+      expect(result[0]!.endpointUrl).toBe("https://new.example/hook");
+    });
+  });
+
+  describe("buildSparkline", () => {
+    it("returns one bucket per slice and aggregates delivery counts", () => {
+      const records = [
+        record({ id: "1", occurredAt: new Date(NOW - 60_000).toISOString() }),
+        record({ id: "2", occurredAt: new Date(NOW - 60_000).toISOString() }),
+        record({ id: "3", occurredAt: new Date(NOW - 3600_000).toISOString() }),
+      ];
+      const sparkline = buildSparkline({
+        deliveries: records,
+        now: NOW,
+        bucketCount: 24,
+        bucketMs: 3600_000,
+      });
+      expect(sparkline.length).toBe(24);
+      // Latest bucket should hold the two recent records.
+      expect(sparkline[23]).toBe(2);
+      // The bucket exactly one hour ago holds the third record.
+      expect(sparkline[22]).toBe(1);
+    });
+
+    it("returns all-zero buckets for an empty input", () => {
+      const sparkline = buildSparkline({
+        deliveries: [],
+        now: NOW,
+        bucketCount: 6,
+        bucketMs: 60_000,
+      });
+      expect(sparkline).toEqual([0, 0, 0, 0, 0, 0]);
+    });
+
+    it("ignores records outside the sparkline window", () => {
+      const sparkline = buildSparkline({
+        deliveries: [
+          record({ id: "1", occurredAt: new Date(NOW - 3600_000 * 50).toISOString() }),
+        ],
+        now: NOW,
+        bucketCount: 24,
+        bucketMs: 3600_000,
+      });
+      expect(sparkline.every((c) => c === 0)).toBe(true);
+    });
+  });
+
+  describe("filterDeliveries", () => {
+    function fr(over: Partial<DeliveryAggregateInput>): DeliveryAggregateInput {
+      return record(over);
+    }
+
+    const dataset: DeliveryAggregateInput[] = [
+      fr({
+        id: "a",
+        endpointId: "ep-1",
+        eventType: "user.created",
+        status: "DELIVERED",
+        occurredAt: new Date(NOW - 60_000).toISOString(),
+      }),
+      fr({
+        id: "b",
+        endpointId: "ep-2",
+        eventType: "user.deleted",
+        status: "FAILED",
+        occurredAt: new Date(NOW - 120_000).toISOString(),
+      }),
+      fr({
+        id: "c-with-search",
+        endpointId: "ep-1",
+        eventType: "user.updated",
+        status: "DELIVERED",
+        occurredAt: new Date(NOW - 180_000).toISOString(),
+      }),
+    ];
+
+    function asFilter(over: Partial<DeliveryFilterInput> = {}): DeliveryFilterInput {
+      return { deliveries: dataset, ...over };
+    }
+
+    it("returns everything when no filter is given", () => {
+      expect(filterDeliveries(asFilter()).length).toBe(3);
+    });
+
+    it("filters by endpointId", () => {
+      const out = filterDeliveries(asFilter({ endpointId: "ep-1" }));
+      expect(out.length).toBe(2);
+      expect(out.every((r) => r.endpointId === "ep-1")).toBe(true);
+    });
+
+    it("filters by status", () => {
+      const out = filterDeliveries(asFilter({ status: "FAILED" }));
+      expect(out.length).toBe(1);
+      expect(out[0]!.id).toBe("b");
+    });
+
+    it("filters by eventType", () => {
+      const out = filterDeliveries(asFilter({ eventType: "user.deleted" }));
+      expect(out.length).toBe(1);
+      expect(out[0]!.id).toBe("b");
+    });
+
+    it("filters by ID substring search", () => {
+      const out = filterDeliveries(asFilter({ search: "with-search" }));
+      expect(out.length).toBe(1);
+      expect(out[0]!.id).toBe("c-with-search");
+    });
+
+    it("filters by from / to time range (inclusive)", () => {
+      const out = filterDeliveries(
+        asFilter({
+          from: new Date(NOW - 130_000).toISOString(),
+          to: new Date(NOW - 50_000).toISOString(),
+        }),
+      );
+      expect(out.length).toBe(2);
+      expect(out.map((r) => r.id).sort()).toEqual(["a", "b"]);
+    });
+
+    it("combines filters (status + endpointId)", () => {
+      const out = filterDeliveries(asFilter({ status: "DELIVERED", endpointId: "ep-1" }));
+      expect(out.length).toBe(2);
+    });
+
+    it("treats an empty search string as no filter", () => {
+      const out = filterDeliveries(asFilter({ search: "" }));
+      expect(out.length).toBe(3);
+    });
+  });
+});

--- a/tests/stories/webhook-inspector-csrf.story.test.ts
+++ b/tests/stories/webhook-inspector-csrf.story.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  issueCsrfToken,
+  verifyCsrfToken,
+} from "../../src/core/webhooks/inspector-csrf.js";
+
+/**
+ * Story · Inspector CSRF token.
+ *
+ * Pure HMAC-based stateless CSRF: server signs a random nonce + an
+ * issuance timestamp with a process secret. Verifier rejects tampered,
+ * malformed, or expired tokens. No session storage — the secret is
+ * loaded once at boot from env (or auto-generated for dev).
+ */
+
+describe("Story · Inspector CSRF token", () => {
+  const SECRET = "test-secret-please-do-not-use-in-prod";
+
+  it("issues a base64url token that verifies with the matching secret", () => {
+    const token = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    expect(token.length).toBeGreaterThan(20);
+    expect(verifyCsrfToken({ token, secret: SECRET, now: 1700000010, ttlSeconds: 3600 })).toBe(
+      true,
+    );
+  });
+
+  it("rejects tokens signed with a different secret", () => {
+    const token = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    expect(
+      verifyCsrfToken({ token, secret: "other-secret", now: 1700000010, ttlSeconds: 3600 }),
+    ).toBe(false);
+  });
+
+  it("rejects expired tokens (now > issuedAt + ttl)", () => {
+    const token = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    expect(verifyCsrfToken({ token, secret: SECRET, now: 1700004000, ttlSeconds: 3600 })).toBe(
+      false,
+    );
+  });
+
+  it("rejects malformed tokens", () => {
+    expect(verifyCsrfToken({ token: "not-a-token", secret: SECRET, now: 1, ttlSeconds: 60 })).toBe(
+      false,
+    );
+    expect(verifyCsrfToken({ token: "", secret: SECRET, now: 1, ttlSeconds: 60 })).toBe(false);
+    expect(verifyCsrfToken({ token: "abc.def", secret: SECRET, now: 1, ttlSeconds: 60 })).toBe(
+      false,
+    );
+  });
+
+  it("rejects tokens with a tampered payload", () => {
+    const token = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    const [payload, sig] = token.split(".");
+    const tampered = `${payload}x.${sig}`;
+    expect(
+      verifyCsrfToken({ token: tampered, secret: SECRET, now: 1700000010, ttlSeconds: 3600 }),
+    ).toBe(false);
+  });
+
+  it("issues a fresh token each call (nonce changes)", () => {
+    const a = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    const b = issueCsrfToken({ secret: SECRET, now: 1700000000 });
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/stories/webhook-inspector-csrf.story.test.ts
+++ b/tests/stories/webhook-inspector-csrf.story.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  issueCsrfToken,
-  verifyCsrfToken,
-} from "../../src/core/webhooks/inspector-csrf.js";
+import { issueCsrfToken, verifyCsrfToken } from "../../src/core/webhooks/inspector-csrf.js";
 
 /**
  * Story · Inspector CSRF token.

--- a/tests/stories/webhook-inspector-curl.story.test.ts
+++ b/tests/stories/webhook-inspector-curl.story.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCurlCommand } from "../../src/core/webhooks/inspector-curl.js";
+
+/**
+ * Story · Webhook-Inspector "Copy curl".
+ *
+ * Pure planner: given a delivery's url, headers, body, generates a
+ * shell-safe curl command that reproduces the request byte-for-byte.
+ * Worker emits the same headers, so a copy-paste curl is a useful
+ * receiver-debugging tool.
+ */
+
+describe("Story · Webhook-Inspector curl builder", () => {
+  it("emits a POST request with the body via --data-binary", () => {
+    const cmd = buildCurlCommand({
+      url: "https://example.com/hook",
+      method: "POST",
+      headers: {},
+      body: '{"event":"foo"}',
+    });
+    expect(cmd).toContain("curl ");
+    expect(cmd).toContain("-X POST");
+    expect(cmd).toContain("'https://example.com/hook'");
+    expect(cmd).toContain("--data-binary");
+    expect(cmd).toContain('{"event":"foo"}');
+  });
+
+  it("emits one -H per header, sorted by key", () => {
+    const cmd = buildCurlCommand({
+      url: "https://example.com/hook",
+      method: "POST",
+      headers: {
+        "x-webhook-id": "evt-123",
+        "content-type": "application/json",
+      },
+      body: "{}",
+    });
+    const expected = cmd.indexOf("'content-type:");
+    const found = cmd.indexOf("'x-webhook-id:");
+    expect(expected).toBeGreaterThan(0);
+    expect(found).toBeGreaterThan(expected);
+  });
+
+  it("escapes single quotes in body and headers", () => {
+    const cmd = buildCurlCommand({
+      url: "https://example.com/hook",
+      method: "POST",
+      headers: { "x-quote": "it's ok" },
+      body: "isn't",
+    });
+    // Single quotes are closed and re-opened: '\''
+    expect(cmd).toContain("'\\''");
+    // No naked single quote inside payload.
+    expect(cmd).not.toMatch(/'isn't'/);
+  });
+
+  it("defaults to POST when method is missing", () => {
+    const cmd = buildCurlCommand({
+      url: "https://example.com/hook",
+      headers: {},
+      body: "{}",
+    });
+    expect(cmd).toContain("-X POST");
+  });
+
+  it("returns a single-line shell-safe command", () => {
+    const cmd = buildCurlCommand({
+      url: "https://example.com/hook",
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"x":1}',
+    });
+    expect(cmd.includes("\n")).toBe(false);
+  });
+});

--- a/tests/stories/webhook-inspector-store.story.test.ts
+++ b/tests/stories/webhook-inspector-store.story.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  WebhookInspectorBuffer,
+  buildDemoDeliveries,
+} from "../../src/core/webhooks/inspector-store.js";
+
+/**
+ * Story · In-memory inspector buffer.
+ *
+ * Holds the last N delivery records the inspector page reads. The
+ * dispatcher records into the buffer; the React page fetches via
+ * the JSON sidecars. Pure data structure, no I/O.
+ */
+
+describe("Story · WebhookInspectorBuffer", () => {
+  it("starts empty and reports size 0", () => {
+    const buf = new WebhookInspectorBuffer();
+    expect(buf.size()).toBe(0);
+    expect(buf.recent()).toEqual([]);
+  });
+
+  it("records appended deliveries in insertion order", () => {
+    const buf = new WebhookInspectorBuffer({ maxRecords: 10 });
+    buf.record({
+      id: "d1",
+      endpointId: "ep-1",
+      endpointUrl: "https://example/hook",
+      eventType: "user.created",
+      status: "DELIVERED",
+      attemptCount: 1,
+      latencyMs: 100,
+      occurredAt: "2026-01-15T12:00:00Z",
+    });
+    buf.record({
+      id: "d2",
+      endpointId: "ep-1",
+      endpointUrl: "https://example/hook",
+      eventType: "user.deleted",
+      status: "FAILED",
+      attemptCount: 2,
+      occurredAt: "2026-01-15T12:01:00Z",
+    });
+    expect(buf.size()).toBe(2);
+    const recent = buf.recent();
+    expect(recent.map((r) => r.id)).toEqual(["d1", "d2"]);
+  });
+
+  it("evicts oldest records when over capacity", () => {
+    const buf = new WebhookInspectorBuffer({ maxRecords: 2 });
+    buf.record(makeDelivery("a"));
+    buf.record(makeDelivery("b"));
+    buf.record(makeDelivery("c"));
+    expect(buf.size()).toBe(2);
+    expect(buf.recent().map((r) => r.id)).toEqual(["b", "c"]);
+  });
+
+  it("findById returns the matching record or null", () => {
+    const buf = new WebhookInspectorBuffer();
+    buf.record(makeDelivery("a"));
+    buf.record(makeDelivery("b"));
+    expect(buf.findById("b")?.id).toBe("b");
+    expect(buf.findById("missing")).toBeNull();
+  });
+
+  it("appendAttempt updates attemptCount + latency on a re-deliver", () => {
+    const buf = new WebhookInspectorBuffer();
+    buf.record(makeDelivery("a", { attemptCount: 1, status: "FAILED" }));
+    buf.appendAttempt("a", {
+      status: "DELIVERED",
+      statusCode: 200,
+      latencyMs: 42,
+      occurredAt: "2026-01-15T13:00:00Z",
+    });
+    const updated = buf.findById("a");
+    expect(updated?.attemptCount).toBe(2);
+    expect(updated?.status).toBe("DELIVERED");
+    expect(updated?.latencyMs).toBe(42);
+  });
+
+  it("appendAttempt is a noop when the id is unknown", () => {
+    const buf = new WebhookInspectorBuffer();
+    expect(() =>
+      buf.appendAttempt("missing", {
+        status: "DELIVERED",
+        occurredAt: "2026-01-15T13:00:00Z",
+      }),
+    ).not.toThrow();
+  });
+
+  it("clear removes all records", () => {
+    const buf = new WebhookInspectorBuffer();
+    buf.record(makeDelivery("a"));
+    buf.clear();
+    expect(buf.size()).toBe(0);
+  });
+});
+
+describe("Story · demo delivery seed", () => {
+  it("returns at least one delivery and at least two endpoints", () => {
+    const demo = buildDemoDeliveries({ now: Date.parse("2026-01-15T12:00:00Z") });
+    expect(demo.length).toBeGreaterThan(0);
+    const endpoints = new Set(demo.map((d) => d.endpointId));
+    expect(endpoints.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it("includes both DELIVERED and FAILED records to demo all UI states", () => {
+    const demo = buildDemoDeliveries({ now: Date.parse("2026-01-15T12:00:00Z") });
+    const statuses = new Set(demo.map((d) => d.status));
+    expect(statuses.has("DELIVERED")).toBe(true);
+    expect(statuses.has("FAILED")).toBe(true);
+  });
+});
+
+function makeDelivery(
+  id: string,
+  over: { attemptCount?: number; status?: "DELIVERED" | "FAILED" | "PENDING" } = {},
+): {
+  id: string;
+  endpointId: string;
+  endpointUrl: string;
+  eventType: string;
+  status: "DELIVERED" | "FAILED" | "PENDING";
+  attemptCount: number;
+  occurredAt: string;
+} {
+  return {
+    id,
+    endpointId: "ep-1",
+    endpointUrl: "https://example.com/hook",
+    eventType: "user.created",
+    status: over.status ?? "DELIVERED",
+    attemptCount: over.attemptCount ?? 1,
+    occurredAt: "2026-01-15T12:00:00Z",
+  };
+}

--- a/tests/webhook-inspector.e2e-spec.ts
+++ b/tests/webhook-inspector.e2e-spec.ts
@@ -1,0 +1,182 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+const TENANT = "11111111-1111-1111-1111-111111111111";
+
+/**
+ * `/admin/webhooks` — extended JSON sidecars + re-deliver POST.
+ *
+ * Every endpoint short-circuits to 404 outside development. The
+ * re-deliver action requires a valid CSRF token issued by
+ * `/admin/webhooks.json` (or `/admin/webhooks/aggregates.json`).
+ */
+describe("Webhook Inspector · admin endpoints", () => {
+  describe("in development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "development";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("GET /admin/webhooks.json returns deliveries + a CSRF token", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.deliveries)).toBe(true);
+      expect(typeof res.body.csrfToken).toBe("string");
+      expect(res.body.csrfToken.length).toBeGreaterThan(20);
+      expect(res.body.filter.status).toBe("ALL");
+    });
+
+    it("GET /admin/webhooks.json honours endpoint, eventType, and search filters", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/admin/webhooks.json?endpointId=ep-demo-1&eventType=user.created&search=demo")
+        .set("x-tenant-id", TENANT);
+      expect(res.status).toBe(200);
+      expect(res.body.filter.endpointId).toBe("ep-demo-1");
+      expect(res.body.filter.eventType).toBe("user.created");
+      expect(res.body.filter.search).toBe("demo");
+    });
+
+    it("GET /admin/webhooks.json returns a cursor when there are more rows", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/admin/webhooks.json?limit=1")
+        .set("x-tenant-id", TENANT);
+      expect(res.status).toBe(200);
+      expect(res.body.deliveries.length).toBeLessThanOrEqual(1);
+      expect("nextCursor" in res.body).toBe(true);
+    });
+
+    it("GET /admin/webhooks/aggregates.json returns endpoint stats with a sparkline", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/admin/webhooks/aggregates.json")
+        .set("x-tenant-id", TENANT);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.endpoints)).toBe(true);
+      // Demo seed should populate at least one endpoint.
+      if (res.body.endpoints.length > 0) {
+        const ep = res.body.endpoints[0];
+        expect(typeof ep.endpointId).toBe("string");
+        expect(typeof ep.total).toBe("number");
+        expect(typeof ep.delivered).toBe("number");
+        expect(typeof ep.failed).toBe("number");
+        expect(Array.isArray(ep.sparkline)).toBe(true);
+        expect(ep.sparkline.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("GET /admin/webhooks/:id.json returns a delivery detail or 404", async () => {
+      const list = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      const first = list.body.deliveries[0];
+      if (first) {
+        const res = await request(app.getHttpServer())
+          .get(`/admin/webhooks/${encodeURIComponent(first.id)}.json`)
+          .set("x-tenant-id", TENANT);
+        expect(res.status).toBe(200);
+        expect(res.body.delivery.id).toBe(first.id);
+        expect(typeof res.body.curl).toBe("string");
+        expect(res.body.curl).toContain("curl ");
+      }
+      const missing = await request(app.getHttpServer())
+        .get("/admin/webhooks/does-not-exist.json")
+        .set("x-tenant-id", TENANT);
+      expect(missing.status).toBe(404);
+    });
+
+    it("POST /admin/webhooks/:id/redeliver requires a CSRF token", async () => {
+      const list = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      const first = list.body.deliveries[0];
+      if (!first) return;
+      const res = await request(app.getHttpServer())
+        .post(`/admin/webhooks/${encodeURIComponent(first.id)}/redeliver`)
+        .set("x-tenant-id", TENANT)
+        .send({});
+      expect(res.status).toBe(403);
+    });
+
+    it("POST /admin/webhooks/:id/redeliver succeeds with a valid CSRF token", async () => {
+      const list = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      const first = list.body.deliveries[0];
+      const csrf = list.body.csrfToken;
+      if (!first) return;
+      const res = await request(app.getHttpServer())
+        .post(`/admin/webhooks/${encodeURIComponent(first.id)}/redeliver`)
+        .set("x-tenant-id", TENANT)
+        .send({ csrfToken: csrf });
+      expect(res.status).toBe(200);
+      expect(res.body.delivery.id).toBe(first.id);
+      expect(res.body.delivery.attemptCount).toBeGreaterThanOrEqual(2);
+    });
+
+    it("POST /admin/webhooks/:id/redeliver rejects a tampered CSRF token", async () => {
+      const list = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      const first = list.body.deliveries[0];
+      if (!first) return;
+      const res = await request(app.getHttpServer())
+        .post(`/admin/webhooks/${encodeURIComponent(first.id)}/redeliver`)
+        .set("x-tenant-id", TENANT)
+        .send({ csrfToken: "tampered.signature" });
+      expect(res.status).toBe(403);
+    });
+
+    it("POST /admin/webhooks/:id/redeliver returns 404 for unknown ids", async () => {
+      const list = await request(app.getHttpServer())
+        .get("/admin/webhooks.json")
+        .set("x-tenant-id", TENANT);
+      const csrf = list.body.csrfToken;
+      const res = await request(app.getHttpServer())
+        .post("/admin/webhooks/does-not-exist/redeliver")
+        .set("x-tenant-id", TENANT)
+        .send({ csrfToken: csrf });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("outside development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "production";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("GET /admin/webhooks/aggregates.json 404s in production", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/admin/webhooks/aggregates.json")
+        .set("x-tenant-id", TENANT);
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /admin/webhooks/:id/redeliver 404s in production", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/admin/webhooks/some-id/redeliver")
+        .set("x-tenant-id", TENANT)
+        .send({});
+      expect(res.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Upgrades `/admin/webhooks` from a flat-table 1:1 React port to the
interactive operations console described in #19.

- **Three-column layout:** endpoint sidebar (aggregates + 24-bucket
  sparkline) / virtual-scrolled delivery list / detail drawer with
  Request / Response / Curl tabs.
- **Filter DSL:** status + endpointId + eventType + ID search; each
  one round-trips through `/admin/webhooks.json` with cursor
  pagination.
- **CSRF-protected re-deliver:** stateless HMAC-signed token issued
  with the list response, verified on `POST /admin/webhooks/:id/redeliver`.
  Missing/tampered/expired tokens 403; unknown ids 404; production 404.
- **New JSON sidecars:** `webhooks/aggregates.json`,
  `webhooks/:id.json` (with reconstructed request headers + copy-curl).
- **Pure planners** under `src/core/webhooks/`: `inspector-aggregates`
  (counts, p95, sparkline, filterDeliveries), `inspector-curl`
  (shell-safe single-line builder), `inspector-csrf` (HMAC token),
  `inspector-store` (bounded ring buffer + dev demo seed).
- **React net-new components** use `react-aria-components` wrappers
  (Select, TextField, Button, Tabs); virtual scrolling via
  `@tanstack/react-virtual`. New CSS lives under `dp-webhook-*` in
  `admin-layout.css`.
- **Docs:** webhook-spec.md describes the new UI + endpoint contract;
  architecture.md notes the WebhookInspectorPage exception to the
  legacy form.admin-form rule.

## Test plan

- [x] `bun run lint` — clean (95 rules, 460 files).
- [x] `bun run format` — clean.
- [x] `bun run test:types` — clean.
- [x] `bun run test:unit` — 139 / 139 passing.
- [x] `bun run test:e2e` — 1719 / 1719 passing (29 new story tests +
      11 new e2e specs).
- [x] `bun run test:coverage` — `src/core/` overall 94.81 % lines.
      Per-file: `inspector-aggregates` 92.68 %,
      `inspector-csrf` 88.23 %, `inspector-curl` 100 %,
      `inspector-store` 96.66 %, `inspector-singleton` 80 %.
- [x] `bun run build:dev-portal` — bundle builds (931 kB).
- [x] `bun run build` — production build green.

Closes #19