### PR TITLE
feat(dev-portal): migration handler page (closes #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Live Mermaid `erDiagram` of the active Prisma schema (concat'd from `schema.pris
 
 Every registered email template rendered with a realistic sample payload. Subject + sandboxed HTML iframe + plain-text version side-by-side, plus the sample-payload JSON. Mailpit at `:8025` shows actually-sent emails; this page is for "did my edit to the welcome template break anything?".
 
+### Migrations — `/dev/migrations`
+
+Five-tab handler for Prisma schema evolution: **Status** (rows from `_prisma_migrations` with retry on failed), **Pending** (preview SQL · apply one · apply all · dry-run in a transaction), **Diff** (`prisma migrate diff` between live DB and `schema.prisma`), **History** (timeline of applied migrations), **Create New** (kebab-case validated → `prisma migrate dev --create-only` → SQL preview → apply or discard). Drift banner above all tabs. Every mutating endpoint is gated by a Postgres advisory lock (409 on contention) and 404s outside `NODE_ENV=development`.
+
 ### JSON Endpoints — `/errors`, `/api/openapi`, `/dev/postgrest-parse`
 
 Every JSON endpoint has a sister HTML page that mounts the React SPA's shared **JSON viewer** — syntax-highlighted, collapsible tree, copy button, key-filter search. Browser default → viewer; `Accept: application/json` or `?format=json` → raw JSON for SDKs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,7 +268,8 @@ in any environment because frontends + SDK generators read them.
 | Page chrome CSS | `src/core/dx/clients/styles/admin-layout.css` | Shell + every per-page CSS block; React JSX re-uses the same classnames the legacy renderers produced so the diff vs. the historical HTML is zero |
 | Component styles | `src/core/dx/clients/styles/components.css` | `.dp-*` selectors targeting `react-aria` `data-*` states (input primitives only) |
 | Build script | `scripts/build-dev-portal.ts` | `Bun.build({ target: "browser", splitting: true, minify: true })` → `dist/dev-portal/` |
-| `/dev/*` JSON sidecars | `dev-hub.controller.ts` | `dashboard.json`, `feature-catalog.json`, `coverage.json`, `tests.json`, `diagnostics.json`, `logs.json`, `traces.json`, `queries.json`, `routes.json`, `erd.json`, `email-preview.json` |
+| `/dev/*` JSON sidecars | `dev-hub.controller.ts` | `dashboard.json`, `feature-catalog.json`, `coverage.json`, `tests.json`, `diagnostics.json`, `logs.json`, `traces.json`, `queries.json`, `routes.json`, `erd.json`, `email-preview.json`, `migrations.json` |
+| `/dev/migrations/*` mutating endpoints | `dev-hub.controller.ts` + `migrations/migrations.service.ts` | `deploy`, `apply-one`, `dry-run`, `retry`, `create`, `apply-draft`, `draft/:name` (DELETE) — Postgres advisory-lock-gated, 404 outside development |
 | `/admin/*` JSON sidecars | `admin-spa.controller.ts` | `permissions/test.json`, `webhooks.json`, `realtime.json`, `audit.json`, `search.json` |
 | Static asset endpoint | `GET /dev/static/:filename` | 404 outside development; allow-list filename, MIME-detect, stream from `dist/dev-portal/` |
 | Catch-all | `GET /dev/*splat` | Returns the SPA shell so client-side routes work without a server change |

--- a/src/core/dx/clients/App.tsx
+++ b/src/core/dx/clients/App.tsx
@@ -40,6 +40,9 @@ const TracesPage = lazy(() =>
 const QueriesPage = lazy(() =>
   import("./pages/QueriesPage.js").then((m) => ({ default: m.QueriesPage })),
 );
+const MigrationsPage = lazy(() =>
+  import("./pages/MigrationsPage.js").then((m) => ({ default: m.MigrationsPage })),
+);
 const RoutesPage = lazy(() =>
   import("./pages/RoutesPage.js").then((m) => ({ default: m.RoutesPage })),
 );
@@ -93,6 +96,7 @@ export function App(): ReactNode {
         <Route path="/dev/logs" element={<LogsPage />} />
         <Route path="/dev/traces" element={<TracesPage />} />
         <Route path="/dev/queries" element={<QueriesPage />} />
+        <Route path="/dev/migrations" element={<MigrationsPage />} />
         <Route path="/dev/routes" element={<RoutesPage />} />
         <Route path="/dev/erd" element={<ErdPage />} />
         <Route path="/dev/email-preview" element={<EmailPreviewPage />} />

--- a/src/core/dx/clients/layout/nav.ts
+++ b/src/core/dx/clients/layout/nav.ts
@@ -36,6 +36,7 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "logs", label: "Logs", href: "/dev/logs", icon: "terminal" },
       { id: "traces", label: "Traces", href: "/dev/traces", icon: "pulse" },
       { id: "queries", label: "Queries", href: "/dev/queries", icon: "database" },
+      { id: "migrations", label: "Migrations", href: "/dev/migrations", icon: "database" },
     ],
   },
   {
@@ -85,6 +86,7 @@ export const SPA_ROUTES = new Set<string>([
   "/dev/logs",
   "/dev/traces",
   "/dev/queries",
+  "/dev/migrations",
   "/dev/routes",
   "/dev/erd",
   "/dev/email-preview",

--- a/src/core/dx/clients/pages/MigrationsPage.tsx
+++ b/src/core/dx/clients/pages/MigrationsPage.tsx
@@ -1,0 +1,619 @@
+/**
+ * `/dev/migrations` — Issue #10 dev-portal page.
+ *
+ * Five tabs (Status, Pending, Diff, History, Create New) over the same
+ * `<AdminShell>` chrome every other dev-portal page uses. Server data
+ * comes from `/dev/migrations.json`; mutations POST to the lock-gated
+ * `/dev/migrations/*` endpoints.
+ *
+ * No native `<button>` / `<input>` elements — every interactive
+ * primitive comes from `clients/components/` (Button, TextField, Tabs)
+ * or directly from `react-aria-components` (Dialog/Modal). The full
+ * ERD-diff visualisation tracked in the AC is out of scope for this
+ * slice and lands as a follow-up issue.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type ReactNode } from "react";
+import { Dialog, Heading, Modal, ModalOverlay } from "react-aria-components";
+
+import { Button, Tab, TabList, TabPanel, Tabs, TextField } from "../components/index.js";
+import { AdminShell } from "../layout/AdminShell.js";
+import { fetchJson } from "../lib/api.js";
+
+interface AppliedRow {
+  id: string;
+  migration_name: string;
+  started_at: string;
+  finished_at: string | null;
+  applied_steps_count: number;
+  logs: string | null;
+  rolled_back_at: string | null;
+}
+
+interface PendingRow {
+  name: string;
+}
+
+interface FailedRow extends AppliedRow {
+  failed: true;
+}
+
+interface MigrationsStatus {
+  applied: AppliedRow[];
+  pending: PendingRow[];
+  failed: FailedRow[];
+  driftDetected: boolean;
+  driftReasons: string[];
+  migrationsRoot: string;
+  generatedAt: string;
+}
+
+async function postJson<T>(url: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : {};
+  } catch {
+    parsed = { raw: text };
+  }
+  if (!res.ok) {
+    const msg =
+      (parsed && typeof parsed === "object" && "message" in parsed
+        ? (parsed as { message?: string }).message
+        : null) ?? `${res.status} ${res.statusText}`;
+    throw new Error(msg);
+  }
+  return parsed as T;
+}
+
+export function MigrationsPage(): ReactNode {
+  const status = useQuery({
+    queryKey: ["dev", "migrations", "status"],
+    queryFn: () => fetchJson<MigrationsStatus>("/dev/migrations.json"),
+    refetchInterval: 30_000,
+  });
+
+  const subtitle = status.data
+    ? `${status.data.applied.length} applied · ${status.data.pending.length} pending · ${status.data.failed.length} failed`
+    : "Loading migration status…";
+
+  return (
+    <AdminShell title="Migrations" subtitle={subtitle} currentNav="migrations">
+      {status.data ? (
+        <MigrationsBody data={status.data} />
+      ) : status.isError ? (
+        <div className="admin-empty">Failed to load migration status.</div>
+      ) : (
+        <div className="admin-empty">Loading migrations…</div>
+      )}
+    </AdminShell>
+  );
+}
+
+function MigrationsBody({ data }: { data: MigrationsStatus }): ReactNode {
+  return (
+    <>
+      <MigrationsTimeline data={data} />
+      {data.driftDetected ? <DriftBanner reasons={data.driftReasons} /> : null}
+      <Tabs defaultSelectedKey="status">
+        <TabList aria-label="Migration tabs">
+          <Tab id="status">Status</Tab>
+          <Tab id="pending">Pending ({data.pending.length})</Tab>
+          <Tab id="diff">Diff</Tab>
+          <Tab id="history">History</Tab>
+          <Tab id="create">Create New</Tab>
+        </TabList>
+        <TabPanel id="status">
+          <StatusTab data={data} />
+        </TabPanel>
+        <TabPanel id="pending">
+          <PendingTab data={data} />
+        </TabPanel>
+        <TabPanel id="diff">
+          <DiffTab />
+        </TabPanel>
+        <TabPanel id="history">
+          <HistoryTab data={data} />
+        </TabPanel>
+        <TabPanel id="create">
+          <CreateNewTab />
+        </TabPanel>
+      </Tabs>
+    </>
+  );
+}
+
+function MigrationsTimeline({ data }: { data: MigrationsStatus }): ReactNode {
+  const all = [
+    ...data.applied.map((m) => ({ name: m.migration_name, kind: "applied" as const })),
+    ...data.failed.map((m) => ({ name: m.migration_name, kind: "failed" as const })),
+    ...data.pending.map((m) => ({ name: m.name, kind: "pending" as const })),
+  ];
+  return (
+    <div className="admin-card">
+      <h3 className="feat-section__title">Timeline</h3>
+      <div className="mig-timeline" data-testid="mig-timeline">
+        {all.length === 0 ? (
+          <span className="admin-meta">No migrations.</span>
+        ) : (
+          all.map((m) => (
+            <span key={m.name} className={`mig-pill mig-pill--${m.kind}`} title={m.name}>
+              <span className="mig-pill__dot" />
+              {m.name}
+            </span>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DriftBanner({ reasons }: { reasons: string[] }): ReactNode {
+  return (
+    <div className="admin-card mig-drift" role="status">
+      <h3 className="feat-section__title">Drift detected</h3>
+      <ul className="mig-drift__list">
+        {reasons.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ul>
+      <p className="admin-meta">
+        Database schema diverges from migration history. Inspect <strong>Diff</strong> tab and
+        decide whether to write a corrective migration or reset the dev DB.
+      </p>
+    </div>
+  );
+}
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  primaryLabel: string;
+  onConfirm: () => void;
+  isPending?: boolean;
+  children?: ReactNode;
+}
+
+/**
+ * Controlled confirmation modal — react-aria-components `Modal` driven
+ * by a parent's `isOpen` prop instead of a `DialogTrigger` because the
+ * trigger lives on a different row from the modal in our layout.
+ */
+function ConfirmDialog({
+  isOpen,
+  onClose,
+  title,
+  primaryLabel,
+  onConfirm,
+  isPending,
+  children,
+}: ConfirmDialogProps): ReactNode {
+  return (
+    <ModalOverlay
+      isOpen={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      className="dp-modal-overlay"
+      isDismissable
+    >
+      <Modal className="dp-modal">
+        <Dialog>
+          <Heading slot="title" className="dp-modal__title">
+            {title}
+          </Heading>
+          <div className="mig-modal-body">{children}</div>
+          <div className="mig-modal-actions">
+            <Button onPress={onClose}>Cancel</Button>
+            <Button variant="accent" isDisabled={isPending} onPress={onConfirm}>
+              {isPending ? "Working…" : primaryLabel}
+            </Button>
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+function PreviewDialog({
+  preview,
+  onClose,
+}: {
+  preview: { name: string; sql: string } | null;
+  onClose: () => void;
+}): ReactNode {
+  return (
+    <ModalOverlay
+      isOpen={preview !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      className="dp-modal-overlay"
+      isDismissable
+    >
+      <Modal className="dp-modal mig-modal--wide">
+        <Dialog>
+          <Heading slot="title" className="dp-modal__title">
+            {preview?.name ?? ""} — SQL
+          </Heading>
+          <pre className="mig-pre">{preview?.sql ?? ""}</pre>
+          <div className="mig-modal-actions">
+            <Button variant="accent" onPress={onClose}>
+              Close
+            </Button>
+          </div>
+        </Dialog>
+      </Modal>
+    </ModalOverlay>
+  );
+}
+
+function StatusTab({ data }: { data: MigrationsStatus }): ReactNode {
+  const queryClient = useQueryClient();
+  const [confirm, setConfirm] = useState<{ name: string; logs: string | null } | null>(null);
+  const retry = useMutation({
+    mutationFn: (name: string) =>
+      postJson<{ success: boolean; stderr: string }>("/dev/migrations/retry", { name }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ["dev", "migrations", "status"] }),
+  });
+
+  return (
+    <div className="admin-card">
+      <h3 className="feat-section__title">Applied + failed migrations</h3>
+      {data.applied.length === 0 && data.failed.length === 0 ? (
+        <div className="admin-empty">No applied migrations yet.</div>
+      ) : (
+        <table className="mig-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Started</th>
+              <th>Finished</th>
+              <th>Steps</th>
+              <th>State</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {[...data.failed, ...data.applied].map((row) => (
+              <tr key={row.id} data-state={row.finished_at ? "applied" : "failed"}>
+                <td>
+                  <code>{row.migration_name}</code>
+                </td>
+                <td>{formatDate(row.started_at)}</td>
+                <td>{row.finished_at ? formatDate(row.finished_at) : "—"}</td>
+                <td>{row.applied_steps_count}</td>
+                <td>
+                  {row.finished_at ? (
+                    <span className="mig-badge mig-badge--ok">applied</span>
+                  ) : (
+                    <span className="mig-badge mig-badge--err">failed</span>
+                  )}
+                </td>
+                <td>
+                  {!row.finished_at ? (
+                    <Button
+                      variant="accent"
+                      onPress={() =>
+                        setConfirm({ name: row.migration_name, logs: row.logs ?? null })
+                      }
+                    >
+                      Retry…
+                    </Button>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <ConfirmDialog
+        isOpen={confirm !== null}
+        onClose={() => setConfirm(null)}
+        title={confirm ? `Retry ${confirm.name}?` : ""}
+        primaryLabel="Retry migration"
+        isPending={retry.isPending}
+        onConfirm={() => {
+          if (!confirm) return;
+          retry.mutate(confirm.name, { onSettled: () => setConfirm(null) });
+        }}
+      >
+        <p>
+          This will mark the migration as <em>rolled back</em> and re-apply it.
+        </p>
+        {confirm?.logs ? <pre className="mig-pre">{confirm.logs}</pre> : null}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function PendingTab({ data }: { data: MigrationsStatus }): ReactNode {
+  const queryClient = useQueryClient();
+  const [preview, setPreview] = useState<{ name: string; sql: string } | null>(null);
+  const [confirm, setConfirm] = useState<{ kind: "one" | "all" | "dry"; name?: string } | null>(
+    null,
+  );
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ["dev", "migrations", "status"] });
+
+  const deployAll = useMutation({
+    mutationFn: () => postJson<{ success: boolean; stderr: string }>("/dev/migrations/deploy"),
+    onSettled: refresh,
+  });
+  const applyOne = useMutation({
+    mutationFn: (name: string) =>
+      postJson<{ success: boolean; stderr: string }>("/dev/migrations/apply-one", { name }),
+    onSettled: refresh,
+  });
+  const dryRun = useMutation({
+    mutationFn: (name: string) =>
+      postJson<{ success: boolean; error?: string }>("/dev/migrations/dry-run", { name }),
+  });
+
+  const loadPreview = async (name: string) => {
+    const result = await fetchJson<{ name: string; sql: string }>(
+      `/dev/migrations/preview/${encodeURIComponent(name)}`,
+    );
+    setPreview(result);
+  };
+
+  return (
+    <div className="admin-card">
+      <div className="mig-actions">
+        <h3 className="feat-section__title">Pending migrations ({data.pending.length})</h3>
+        <Button
+          variant="accent"
+          isDisabled={data.pending.length === 0}
+          onPress={() => setConfirm({ kind: "all" })}
+        >
+          Apply All Pending
+        </Button>
+      </div>
+      {data.pending.length === 0 ? (
+        <div className="admin-empty">Schema is up to date.</div>
+      ) : (
+        <table className="mig-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.pending.map((row) => (
+              <tr key={row.name}>
+                <td>
+                  <code>{row.name}</code>
+                </td>
+                <td className="mig-actions-cell">
+                  <Button onPress={() => void loadPreview(row.name)}>Preview SQL</Button>
+                  <Button
+                    variant="accent"
+                    onPress={() => setConfirm({ kind: "one", name: row.name })}
+                  >
+                    Apply this one…
+                  </Button>
+                  <Button onPress={() => setConfirm({ kind: "dry", name: row.name })}>
+                    Dry-Run
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <PreviewDialog preview={preview} onClose={() => setPreview(null)} />
+
+      <ConfirmDialog
+        isOpen={confirm !== null}
+        onClose={() => setConfirm(null)}
+        title={
+          confirm?.kind === "all"
+            ? `Apply ${data.pending.length} pending migration(s)?`
+            : confirm?.kind === "one"
+              ? `Apply ${confirm.name}?`
+              : confirm?.kind === "dry"
+                ? `Dry-Run ${confirm.name}?`
+                : ""
+        }
+        primaryLabel={confirm?.kind === "dry" ? "Dry-Run" : "Apply migration(s)"}
+        isPending={deployAll.isPending || applyOne.isPending || dryRun.isPending}
+        onConfirm={() => {
+          if (!confirm) return;
+          if (confirm.kind === "all") {
+            deployAll.mutate(undefined, { onSettled: () => setConfirm(null) });
+          } else if (confirm.kind === "one" && confirm.name) {
+            applyOne.mutate(confirm.name, { onSettled: () => setConfirm(null) });
+          } else if (confirm.kind === "dry" && confirm.name) {
+            dryRun.mutate(confirm.name, { onSettled: () => setConfirm(null) });
+          }
+        }}
+      >
+        {confirm?.kind === "all" ? (
+          <ul>
+            {data.pending.map((p) => (
+              <li key={p.name}>
+                <code>{p.name}</code>
+              </li>
+            ))}
+          </ul>
+        ) : confirm?.kind === "dry" ? (
+          <p>
+            Runs the migration in a transaction and rolls back at the end. Non-destructive — does
+            not change the database.
+          </p>
+        ) : (
+          <p>
+            This will execute the SQL via <code>prisma migrate deploy</code>. Make sure you reviewed
+            the SQL preview first.
+          </p>
+        )}
+      </ConfirmDialog>
+    </div>
+  );
+}
+
+function DiffTab(): ReactNode {
+  const diff = useQuery({
+    queryKey: ["dev", "migrations", "diff"],
+    queryFn: () =>
+      fetchJson<{ sql: string; success: boolean; stderr: string }>("/dev/migrations/diff"),
+  });
+  return (
+    <div className="admin-card">
+      <h3 className="feat-section__title">Schema diff</h3>
+      {diff.isLoading ? (
+        <div className="admin-empty">Computing diff…</div>
+      ) : diff.isError ? (
+        <div className="admin-empty">Diff failed: {String(diff.error)}</div>
+      ) : !diff.data?.success ? (
+        <pre className="mig-pre mig-pre--err">{diff.data?.stderr ?? "Diff unavailable."}</pre>
+      ) : !diff.data.sql.trim() ? (
+        <div className="admin-empty">No schema diff — DB matches schema.prisma.</div>
+      ) : (
+        <pre className="mig-pre">{diff.data.sql}</pre>
+      )}
+    </div>
+  );
+}
+
+function HistoryTab({ data }: { data: MigrationsStatus }): ReactNode {
+  return (
+    <div className="admin-card">
+      <h3 className="feat-section__title">Migration history</h3>
+      {data.applied.length === 0 ? (
+        <div className="admin-empty">No applied migrations yet.</div>
+      ) : (
+        <ol className="mig-history">
+          {data.applied.map((row) => (
+            <li key={row.id}>
+              <code>{row.migration_name}</code>
+              <span className="admin-meta">
+                {formatDate(row.started_at)} · {row.applied_steps_count} step(s)
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function CreateNewTab(): ReactNode {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [created, setCreated] = useState<{ folder?: string; sql?: string; name: string } | null>(
+    null,
+  );
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ["dev", "migrations", "status"] });
+
+  const create = useMutation({
+    mutationFn: (n: string) =>
+      postJson<{ success: boolean; folder?: string; sql?: string; stderr: string; name: string }>(
+        "/dev/migrations/create",
+        { name: n },
+      ),
+    onSuccess: (res) => {
+      setCreated(res);
+      refresh();
+    },
+  });
+
+  const apply = useMutation({
+    mutationFn: (folder: string) =>
+      postJson<{ success: boolean }>("/dev/migrations/apply-draft", { name: folder }),
+    onSettled: () => {
+      setCreated(null);
+      setName("");
+      refresh();
+    },
+  });
+
+  const discard = useMutation({
+    mutationFn: (folder: string) =>
+      fetch(`/dev/migrations/draft/${encodeURIComponent(folder)}`, { method: "DELETE" }).then(
+        (r) => {
+          if (!r.ok) throw new Error(`discard failed: ${r.status}`);
+          return r.json();
+        },
+      ),
+    onSettled: () => {
+      setCreated(null);
+      setName("");
+      refresh();
+    },
+  });
+
+  return (
+    <div className="admin-card">
+      <h3 className="feat-section__title">Create new migration</h3>
+      <p className="admin-meta">
+        Generates a draft via <code>prisma migrate dev --create-only</code>. The migration is{" "}
+        <strong>not applied</strong> until you click Apply.
+      </p>
+      <div className="mig-create-form">
+        <TextField
+          label="Migration name"
+          value={name}
+          onChange={setName}
+          placeholder="add-user-table"
+          isRequired
+        />
+        <Button
+          variant="accent"
+          isDisabled={!name || create.isPending}
+          onPress={() => create.mutate(name)}
+        >
+          {create.isPending ? "Generating…" : "Generate"}
+        </Button>
+      </div>
+      {create.isError ? <pre className="mig-pre mig-pre--err">{String(create.error)}</pre> : null}
+
+      {created ? (
+        <div className="mig-draft">
+          <h4>
+            Draft: <code>{created.folder ?? created.name}</code>
+          </h4>
+          {created.sql ? (
+            <pre className="mig-pre">{created.sql}</pre>
+          ) : (
+            <div className="admin-empty">No SQL preview available.</div>
+          )}
+          <div className="mig-actions-cell">
+            <Button
+              variant="accent"
+              isDisabled={!created.folder || apply.isPending}
+              onPress={() => created.folder && apply.mutate(created.folder)}
+            >
+              {apply.isPending ? "Applying…" : "Apply"}
+            </Button>
+            <Button
+              isDisabled={!created.folder || discard.isPending}
+              onPress={() => created.folder && discard.mutate(created.folder)}
+            >
+              Discard
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/core/dx/clients/styles/admin-layout.css
+++ b/src/core/dx/clients/styles/admin-layout.css
@@ -2654,3 +2654,175 @@ ul.channels li {
 pre.payload {
   margin: 0;
 }
+
+/*
+ * Migrations page (`/dev/migrations`, Issue #10).
+ *
+ * Pure additive styling. Mirrors the look-and-feel of the existing
+ * audit / webhook tables so the page slots into the dark portal
+ * theme without bespoke colour tokens.
+ */
+.mig-timeline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-top: 0.4rem;
+}
+
+.mig-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: var(--code-bg);
+  font: 11px var(--font-mono, monospace);
+  color: var(--text);
+  border: 1px solid transparent;
+}
+.mig-pill__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.7;
+}
+.mig-pill--applied {
+  border-color: rgba(34, 197, 94, 0.45);
+}
+.mig-pill--applied .mig-pill__dot {
+  background: #22c55e;
+}
+.mig-pill--pending {
+  border-color: rgba(250, 204, 21, 0.45);
+}
+.mig-pill--pending .mig-pill__dot {
+  background: #facc15;
+}
+.mig-pill--failed {
+  border-color: rgba(239, 68, 68, 0.55);
+  color: #fecaca;
+}
+.mig-pill--failed .mig-pill__dot {
+  background: #ef4444;
+}
+
+.mig-drift {
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: rgba(239, 68, 68, 0.07);
+}
+.mig-drift__list {
+  margin: 0.4rem 0;
+  padding-left: 1.1rem;
+}
+.mig-drift__list li {
+  margin: 0.15rem 0;
+}
+
+.mig-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+.mig-actions-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.mig-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.mig-table th,
+.mig-table td {
+  padding: 0.4rem 0.55rem;
+  border-bottom: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.06));
+  text-align: left;
+  vertical-align: middle;
+}
+.mig-table th {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+.mig-table tr[data-state="failed"] {
+  background: rgba(239, 68, 68, 0.06);
+}
+
+.mig-badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 4px;
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.mig-badge--ok {
+  background: rgba(34, 197, 94, 0.18);
+  color: #86efac;
+}
+.mig-badge--err {
+  background: rgba(239, 68, 68, 0.18);
+  color: #fca5a5;
+}
+
+.mig-pre {
+  background: var(--code-bg);
+  padding: 0.6rem 0.8rem;
+  border-radius: 4px;
+  margin: 0.4rem 0;
+  font: 12px var(--font-mono, monospace);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 65dvh;
+  min-height: 14rem;
+  overflow: auto;
+}
+.mig-pre--err {
+  border: 1px solid rgba(239, 68, 68, 0.45);
+  color: #fecaca;
+}
+
+.mig-history {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+.mig-history li {
+  margin: 0.25rem 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.mig-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: flex-start;
+  max-width: 28rem;
+}
+
+.mig-draft {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.06));
+  padding-top: 0.8rem;
+}
+
+.mig-modal-body {
+  margin: 0.5rem 0;
+}
+.mig-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.8rem;
+}
+.mig-modal--wide {
+  max-width: 80vw;
+  width: 60rem;
+}

--- a/src/core/dx/dev-hub.controller.ts
+++ b/src/core/dx/dev-hub.controller.ts
@@ -5,11 +5,15 @@ import { resolve } from "node:path";
 import {
   BadRequestException,
   Body,
+  ConflictException,
   Controller,
+  Delete,
   Get,
   Header,
   Headers,
   HttpCode,
+  HttpException,
+  HttpStatus,
   NotFoundException,
   Param,
   Post,
@@ -19,6 +23,8 @@ import {
 import type { Response } from "express";
 
 import { readTunnelState } from "../dev/tunnel-state-runner.js";
+import { MigrationsService } from "./migrations/migrations.service.js";
+
 import { type Features, loadFeatures } from "../features/features.js";
 import { parsePostgrestQuery } from "../permissions/postgrest-query.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
@@ -64,7 +70,10 @@ import { planServiceCandidates, probeServices, type ServiceProbeResult } from ".
  */
 @Controller("dev")
 export class DevHubController {
-  constructor(private readonly routes: RouteInventoryService) {}
+  constructor(
+    private readonly routes: RouteInventoryService,
+    private readonly migrations: MigrationsService,
+  ) {}
 
   @Get()
   @Header("content-type", "text/html; charset=utf-8")
@@ -542,6 +551,152 @@ export class DevHubController {
     });
   }
 
+  // -----------------------------------------------------------------
+  // /dev/migrations · Issue #10 — Migration Handler
+  // -----------------------------------------------------------------
+
+  /** SPA shell for `/dev/migrations` — React decides which tab to show. */
+  @Get("migrations")
+  @Header("content-type", "text/html; charset=utf-8")
+  migrationsPage(): string {
+    this.assertDev();
+    return renderDevPortalShell(buildDevPortalShellInput({ title: "Migrations" }));
+  }
+
+  /** JSON snapshot of applied + pending + failed migrations + drift signal. */
+  @Get("migrations.json")
+  async migrationsJson(): Promise<unknown> {
+    this.assertDev();
+    return this.migrations.getStatus();
+  }
+
+  /** Read-only SQL preview of a single migration folder. */
+  @Get("migrations/preview/:name")
+  migrationsPreview(@Param("name") name: string): { name: string; sql: string } {
+    this.assertDev();
+    try {
+      return this.migrations.previewSql(name);
+    } catch (err) {
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Schema diff between live DB and `prisma/schema.prisma`. */
+  @Get("migrations/diff")
+  async migrationsDiff(): Promise<{ sql: string; success: boolean; stderr: string }> {
+    this.assertDev();
+    return this.migrations.getDiff();
+  }
+
+  /** Apply every pending migration. Lock-gated; 409 on contention. */
+  @Post("migrations/deploy")
+  @HttpCode(200)
+  async migrationsDeploy(): Promise<unknown> {
+    this.assertDev();
+    const r = await this.migrations.deployPending();
+    return this.unwrapLock(r);
+  }
+
+  /** Apply a single pending migration. */
+  @Post("migrations/apply-one")
+  @HttpCode(200)
+  async migrationsApplyOne(@Body() body: { name?: unknown }): Promise<unknown> {
+    this.assertDev();
+    const name = assertNonEmptyString(body?.name, "name");
+    try {
+      const r = await this.migrations.applyOne(name);
+      return this.unwrapLock(r);
+    } catch (err) {
+      if (err instanceof HttpException) throw err;
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Run a migration in a transaction + rollback. Non-destructive. */
+  @Post("migrations/dry-run")
+  @HttpCode(200)
+  async migrationsDryRun(@Body() body: { name?: unknown }): Promise<unknown> {
+    this.assertDev();
+    const name = assertNonEmptyString(body?.name, "name");
+    try {
+      const r = await this.migrations.dryRun(name);
+      return this.unwrapLock(r);
+    } catch (err) {
+      if (err instanceof HttpException) throw err;
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Resolve a failed migration as rolled-back, then retry. */
+  @Post("migrations/retry")
+  @HttpCode(200)
+  async migrationsRetry(@Body() body: { name?: unknown }): Promise<unknown> {
+    this.assertDev();
+    const name = assertNonEmptyString(body?.name, "name");
+    try {
+      const r = await this.migrations.retryFailed(name);
+      return this.unwrapLock(r);
+    } catch (err) {
+      if (err instanceof HttpException) throw err;
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Generate a new draft migration (does not apply). */
+  @Post("migrations/create")
+  @HttpCode(200)
+  async migrationsCreate(@Body() body: { name?: unknown }): Promise<unknown> {
+    this.assertDev();
+    const name = assertNonEmptyString(body?.name, "name");
+    try {
+      const r = await this.migrations.createDraft(name);
+      return this.unwrapLock(r);
+    } catch (err) {
+      if (err instanceof HttpException) throw err;
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Apply a previously-created draft migration. */
+  @Post("migrations/apply-draft")
+  @HttpCode(200)
+  async migrationsApplyDraft(@Body() body: { name?: unknown }): Promise<unknown> {
+    this.assertDev();
+    const name = assertNonEmptyString(body?.name, "name");
+    try {
+      const r = await this.migrations.applyDraft(name);
+      return this.unwrapLock(r);
+    } catch (err) {
+      if (err instanceof HttpException) throw err;
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  /** Discard a draft migration directory. */
+  @Delete("migrations/draft/:name")
+  @HttpCode(200)
+  async migrationsDiscardDraft(
+    @Param("name") name: string,
+  ): Promise<{ name: string; deleted: boolean }> {
+    this.assertDev();
+    try {
+      return this.migrations.discardDraft(name);
+    } catch (err) {
+      throw new BadRequestException(asMessage(err));
+    }
+  }
+
+  private unwrapLock<T>(r: { acquired: boolean; result?: T }): T {
+    if (!r.acquired) {
+      throw new ConflictException({
+        statusCode: HttpStatus.CONFLICT,
+        error: "Conflict",
+        message: "another migration is running",
+      });
+    }
+    return r.result as T;
+  }
+
   /**
    * Catch-all for `/dev/*` paths that don't match a more specific
    * handler. Always returns the SPA shell — react-router on the client
@@ -600,6 +755,17 @@ function isSafeStaticName(name: string): boolean {
   if (name.includes("/") || name.includes("\\")) return false;
   if (name.startsWith(".")) return false;
   return /^[a-zA-Z0-9._-]+\.(js|css|map|svg|woff2?)$/.test(name);
+}
+
+function assertNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new BadRequestException(`body.${fieldName} must be a non-empty string`);
+  }
+  return value;
+}
+
+function asMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function mimeForExtension(name: string): string {

--- a/src/core/dx/dev-hub.module.ts
+++ b/src/core/dx/dev-hub.module.ts
@@ -3,6 +3,7 @@ import { DiscoveryModule } from "@nestjs/core";
 
 import { AdminSpaController } from "./admin-spa.controller.js";
 import { DevHubController } from "./dev-hub.controller.js";
+import { MigrationsService } from "./migrations/migrations.service.js";
 import { RouteInventoryService } from "./route-inventory-runner.js";
 
 /**
@@ -13,12 +14,15 @@ import { RouteInventoryService } from "./route-inventory-runner.js";
  * production.
  *
  * `DiscoveryModule` is imported so `RouteInventoryService` can walk
- * the registered controllers for `/dev/routes`.
+ * the registered controllers for `/dev/routes`. `MigrationsService` is
+ * a dev-only orchestrator for the `/dev/migrations` page; it depends on
+ * the global `PrismaService` for advisory locks + `_prisma_migrations`
+ * reads.
  */
 @Module({
   imports: [DiscoveryModule],
   controllers: [DevHubController, AdminSpaController],
-  providers: [RouteInventoryService],
+  providers: [RouteInventoryService, MigrationsService],
   exports: [RouteInventoryService],
 })
 export class DevHubModule {}

--- a/src/core/dx/migrations/migrations-planner.ts
+++ b/src/core/dx/migrations/migrations-planner.ts
@@ -1,0 +1,260 @@
+/**
+ * Pure planner for `/dev/migrations` (Issue #10).
+ *
+ * I/O-free helpers shared by the controller, story tests, and React
+ * page. The runner half (`migrations-runner.ts`) wraps these with file
+ * system + Prisma queries + child-process spawns.
+ *
+ * Surface:
+ *   - parsePrismaMigrationStatus(stdout)  — `prisma migrate status` text
+ *   - validateMigrationName(name)         — kebab-case + length + path-safe
+ *   - resolveMigrationDirectory(root, n)  — safe path join under
+ *                                           `prisma/migrations/`
+ *   - buildMigrationsView({ disk, applied }) — UI shape (status + drift)
+ *
+ * Discipline: every decision the UI surfaces (is this migration
+ * pending? is the schema drifting?) must be expressible as a function
+ * of structured input. Spawning `prisma migrate deploy` lives in the
+ * runner; whether to spawn it is decided here.
+ */
+
+import { resolve } from "node:path";
+
+/**
+ * Postgres advisory lock key shared by every executing migration
+ * endpoint. The number is arbitrary but stable — a different process
+ * trying to grab the same key sees `pg_try_advisory_lock(...)` return
+ * `false` and we respond with 409.
+ *
+ * Picked from a high-entropy region to avoid colliding with any other
+ * advisory locks Prisma or future tooling might use.
+ */
+export const ADVISORY_LOCK_KEY: bigint = 0x6e73625f6d696772n; // ASCII "nsb_migr"
+
+/**
+ * User-supplied migration name regex — strict kebab-case for
+ * Create-New flow. Prisma will prepend a 14-digit timestamp itself,
+ * so the user only types the suffix.
+ */
+const USER_NAME_RE = /^[a-z][a-z0-9-]{2,49}$/;
+
+/**
+ * Disk migration folder regex — accepts the `<timestamp>_<suffix>`
+ * shape Prisma emits. Used by `resolveMigrationDirectory` so callers
+ * can address an existing folder whose timestamp prefix the user
+ * never typed.
+ */
+const DISK_NAME_RE = /^\d{14}_[a-z][a-z0-9_-]{1,80}$/i;
+
+export function isValidMigrationName(name: string): boolean {
+  if (typeof name !== "string") return false;
+  if (!USER_NAME_RE.test(name)) return false;
+  // Cheap belt-and-braces — the regex already excludes these but spelling
+  // them out keeps the audit trail obvious for reviewers.
+  if (name.includes("..")) return false;
+  if (name.includes("/")) return false;
+  if (name.includes("\\")) return false;
+  return true;
+}
+
+export function validateMigrationName(name: string): void {
+  if (!isValidMigrationName(name)) {
+    throw new Error(
+      `Invalid migration name: "${name}". Use kebab-case ` +
+        "(3-50 chars, lowercase letters / digits / dashes, must start with a letter).",
+    );
+  }
+}
+
+/**
+ * Path-safe predicate for migration *folder* names that already exist
+ * on disk (Prisma prefixes them with a timestamp). Strictly stricter
+ * than `node:path.resolve` — even a normalised name that escapes the
+ * sandbox is rejected here.
+ */
+export function isValidDiskMigrationName(name: string): boolean {
+  if (typeof name !== "string") return false;
+  if (!DISK_NAME_RE.test(name)) return false;
+  if (name.includes("..")) return false;
+  if (name.includes("/")) return false;
+  if (name.includes("\\")) return false;
+  return true;
+}
+
+/**
+ * Resolve a migration *folder* path under `prisma/migrations/`. Refuses
+ * to return paths that escape the migrations root via traversal — the
+ * defense-in-depth check is doubled with the disk-name regex so a
+ * caller has to bypass two gates to write outside the sandbox.
+ */
+export function resolveMigrationDirectory(projectRoot: string, name: string): string {
+  if (!isValidDiskMigrationName(name) && !isValidMigrationName(name)) {
+    throw new Error(`Refusing to resolve migration directory: invalid name "${name}"`);
+  }
+  const root = resolve(projectRoot, "prisma", "migrations");
+  const target = resolve(root, name);
+  if (!target.startsWith(`${root}/`) && target !== root) {
+    throw new Error(`Refusing to resolve migration directory outside the sandbox: ${name}`);
+  }
+  return target;
+}
+
+export interface PrismaMigrationStatus {
+  /** Total migration files discovered in `prisma/migrations/`. */
+  foundCount: number;
+  /** True when stdout contains the "up to date" sentinel. */
+  upToDate: boolean;
+  /** True when stdout contains the drift-detection sentinel. */
+  driftDetected: boolean;
+  /** Names of migrations the CLI lists as not-yet-applied. */
+  pendingNames: string[];
+}
+
+/**
+ * Parse the text output of `prisma migrate status`. The CLI is not
+ * machine-readable on every line, so we look for the well-known
+ * sentinels Prisma has emitted since v4 and tolerate everything else.
+ *
+ * Note: when `--json` is available we prefer that path in the runner;
+ * this parser exists for environments where the JSON flag is not
+ * supported (older CLI) and as a sanity check on top of the JSON.
+ */
+export function parsePrismaMigrationStatus(stdout: string): PrismaMigrationStatus {
+  const text = stdout ?? "";
+  const lines = text.split(/\r?\n/);
+
+  let foundCount = 0;
+  const foundMatch = text.match(/(\d+)\s+migrations?\s+found\s+in/i);
+  if (foundMatch) foundCount = Number.parseInt(foundMatch[1] ?? "0", 10) || 0;
+
+  const upToDate = /Database\s+schema\s+is\s+up\s+to\s+date/i.test(text);
+  const driftDetected = /Drift\s+detected/i.test(text);
+
+  const pendingNames: string[] = [];
+  // Prisma prints a header followed by one migration name per line:
+  //   "Following migration have not yet been applied:"
+  //   "20260101000000_alpha"
+  //   "20260101000100_beta"
+  // We collect names until we hit either an empty line or a line that
+  // looks like prose (starts with a capital letter and contains a space).
+  let collecting = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) {
+      collecting = false;
+      continue;
+    }
+    if (
+      /following\s+migrations?\s+have\s+not\s+yet\s+been\s+applied/i.test(line) ||
+      /the\s+following\s+migrations?\s+have\s+not\s+yet\s+been\s+applied/i.test(line)
+    ) {
+      collecting = true;
+      continue;
+    }
+    if (collecting) {
+      // A migration name is a timestamp-prefixed kebab-case folder.
+      if (/^\d{14}_[a-z0-9_-]+$/i.test(line)) {
+        pendingNames.push(line);
+      } else {
+        collecting = false;
+      }
+    }
+  }
+
+  return { foundCount, upToDate, driftDetected, pendingNames };
+}
+
+/** A row from Postgres' `_prisma_migrations` table (subset we use). */
+export interface AppliedMigrationRow {
+  id: string;
+  migration_name: string;
+  /** ISO timestamp string. */
+  started_at: string;
+  /** ISO timestamp string. Null on a failed / running migration. */
+  finished_at: string | null;
+  applied_steps_count: number;
+  /** CLI / Prisma engine error logs. */
+  logs: string | null;
+  /** ISO timestamp; null on healthy / failed-but-unresolved rows. */
+  rolled_back_at: string | null;
+}
+
+export interface DiskMigration {
+  name: string;
+}
+
+export interface PendingMigration {
+  name: string;
+}
+
+export interface FailedMigration extends AppliedMigrationRow {
+  /** Convenience flag — true when `finished_at` is null and not rolled back. */
+  failed: true;
+}
+
+export interface MigrationsViewInput {
+  diskMigrations: DiskMigration[];
+  appliedRows: AppliedMigrationRow[];
+}
+
+export interface MigrationsView {
+  /** Successfully applied (finished_at non-null, no rollback). */
+  applied: AppliedMigrationRow[];
+  /** Files on disk that have no matching applied row. */
+  pending: PendingMigration[];
+  /** DB rows where finished_at is null — the CLI choked mid-deploy. */
+  failed: FailedMigration[];
+  /** Schema drift signals (rows applied in DB but missing on disk, …). */
+  driftDetected: boolean;
+  driftReasons: string[];
+}
+
+/**
+ * Partition disk migrations + DB rows into the three buckets the UI
+ * cares about, plus a drift signal. Sort key: the timestamp prefix
+ * Prisma uses for migration folder names.
+ */
+export function buildMigrationsView(input: MigrationsViewInput): MigrationsView {
+  const diskNames = new Set(input.diskMigrations.map((m) => m.name));
+
+  const applied: AppliedMigrationRow[] = [];
+  const failed: FailedMigration[] = [];
+
+  for (const row of input.appliedRows) {
+    const isFailed = row.finished_at === null && row.rolled_back_at === null;
+    if (isFailed) {
+      failed.push({ ...row, failed: true });
+    } else if (row.rolled_back_at === null) {
+      applied.push(row);
+    }
+  }
+
+  const appliedNames = new Set([
+    ...applied.map((r) => r.migration_name),
+    ...failed.map((r) => r.migration_name),
+  ]);
+
+  const pendingNames = input.diskMigrations
+    .map((m) => m.name)
+    .filter((name) => !appliedNames.has(name))
+    .sort((a, b) => a.localeCompare(b));
+
+  const pending: PendingMigration[] = pendingNames.map((name) => ({ name }));
+
+  // Drift = a row in the DB that references a folder no longer on disk.
+  const driftReasons: string[] = [];
+  for (const row of input.appliedRows) {
+    if (row.rolled_back_at !== null) continue;
+    if (!diskNames.has(row.migration_name)) {
+      driftReasons.push(`Migration applied in DB but missing on disk: ${row.migration_name}`);
+    }
+  }
+
+  return {
+    applied: applied.sort((a, b) => a.migration_name.localeCompare(b.migration_name)),
+    pending,
+    failed,
+    driftDetected: driftReasons.length > 0,
+    driftReasons,
+  };
+}

--- a/src/core/dx/migrations/migrations-runner.ts
+++ b/src/core/dx/migrations/migrations-runner.ts
@@ -91,9 +91,7 @@ export function discardMigrationDirectory(projectRoot: string, name: string): bo
  * table on every `migrate deploy`; reading it lets us avoid shelling
  * out to `prisma migrate status` for the read path.
  */
-export async function listAppliedMigrations(
-  prisma: PrismaService,
-): Promise<AppliedMigrationRow[]> {
+export async function listAppliedMigrations(prisma: PrismaService): Promise<AppliedMigrationRow[]> {
   // The table is owned by Prisma; the columns below have been stable
   // since v3.x. Using $queryRawUnsafe keeps us decoupled from generated
   // model types we don't otherwise use.
@@ -260,7 +258,9 @@ export async function runPrismaCommand(
  * timestamp order. Idempotent — already-applied migrations are
  * skipped by the CLI itself.
  */
-export function runMigrateDeploy(projectRoot: string = process.cwd()): Promise<PrismaCommandResult> {
+export function runMigrateDeploy(
+  projectRoot: string = process.cwd(),
+): Promise<PrismaCommandResult> {
   return runPrismaCommand(["migrate", "deploy"], { projectRoot, timeoutMs: 120_000 });
 }
 

--- a/src/core/dx/migrations/migrations-runner.ts
+++ b/src/core/dx/migrations/migrations-runner.ts
@@ -1,0 +1,391 @@
+/**
+ * Thin runner around `migrations-planner.ts`.
+ *
+ * Owns every side effect — file system, Postgres queries, child process
+ * spawns. The planner is pure and testable; this module wraps it with
+ * the actual `prisma migrate` toolchain.
+ *
+ * Production-safety: every public function in this module is gated at
+ * the controller layer behind `assertDev()` so the planner-runner pair
+ * can never be invoked outside `NODE_ENV=development`.
+ *
+ * Concurrency: the controller acquires the advisory lock via
+ * `withAdvisoryLock(...)`. Two concurrent deploy attempts on the same
+ * Postgres instance see the second `pg_try_advisory_lock` return false
+ * and respond 409.
+ */
+
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import type { PrismaService } from "../../prisma/prisma.service.js";
+
+import {
+  ADVISORY_LOCK_KEY,
+  type AppliedMigrationRow,
+  type DiskMigration,
+  isValidDiskMigrationName,
+  resolveMigrationDirectory,
+  validateMigrationName,
+} from "./migrations-planner.js";
+
+/**
+ * Read every directory under `prisma/migrations/` and return the
+ * Prisma-style migration folders found there. Filters out the special
+ * `migration_lock.toml` file and any non-conforming names.
+ */
+export function listDiskMigrations(projectRoot: string = process.cwd()): DiskMigration[] {
+  const dir = resolve(projectRoot, "prisma", "migrations");
+  if (!existsSync(dir)) return [];
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: DiskMigration[] = [];
+  for (const name of entries) {
+    if (name === "migration_lock.toml") continue;
+    if (name.startsWith(".")) continue;
+    if (!isValidDiskMigrationName(name)) continue;
+    const sub = resolve(dir, name);
+    try {
+      if (!statSync(sub).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    out.push({ name });
+  }
+  return out;
+}
+
+/**
+ * Read the SQL contents of a migration folder. Throws on directory-
+ * traversal attempts and missing files.
+ */
+export function readMigrationSql(projectRoot: string, name: string): string {
+  const dir = resolveMigrationDirectory(projectRoot, name);
+  const sqlPath = resolve(dir, "migration.sql");
+  if (!existsSync(sqlPath)) {
+    throw new Error(`Migration SQL not found: ${name}/migration.sql`);
+  }
+  return readFileSync(sqlPath, "utf8");
+}
+
+/**
+ * Recursively delete a draft migration directory. Path-safety is
+ * enforced via `resolveMigrationDirectory` — the caller cannot delete
+ * anything outside `prisma/migrations/`.
+ */
+export function discardMigrationDirectory(projectRoot: string, name: string): boolean {
+  const dir = resolveMigrationDirectory(projectRoot, name);
+  if (!existsSync(dir)) return false;
+  rmSync(dir, { recursive: true, force: true });
+  return true;
+}
+
+/**
+ * Read the `_prisma_migrations` table directly. Prisma populates this
+ * table on every `migrate deploy`; reading it lets us avoid shelling
+ * out to `prisma migrate status` for the read path.
+ */
+export async function listAppliedMigrations(
+  prisma: PrismaService,
+): Promise<AppliedMigrationRow[]> {
+  // The table is owned by Prisma; the columns below have been stable
+  // since v3.x. Using $queryRawUnsafe keeps us decoupled from generated
+  // model types we don't otherwise use.
+  type Row = {
+    id: string;
+    migration_name: string;
+    started_at: Date | null;
+    finished_at: Date | null;
+    applied_steps_count: number | bigint;
+    logs: string | null;
+    rolled_back_at: Date | null;
+  };
+  let rows: Row[] = [];
+  try {
+    rows = await prisma.$queryRawUnsafe<Row[]>(
+      `select id, migration_name, started_at, finished_at, applied_steps_count, logs, rolled_back_at
+         from _prisma_migrations
+         order by started_at asc`,
+    );
+  } catch {
+    // Table absent (fresh database, never migrated). Empty result is the
+    // signal the controller surfaces to the UI.
+    return [];
+  }
+  return rows.map((r) => ({
+    id: String(r.id),
+    migration_name: r.migration_name,
+    started_at: r.started_at ? r.started_at.toISOString() : new Date(0).toISOString(),
+    finished_at: r.finished_at ? r.finished_at.toISOString() : null,
+    applied_steps_count: Number(r.applied_steps_count ?? 0),
+    logs: r.logs,
+    rolled_back_at: r.rolled_back_at ? r.rolled_back_at.toISOString() : null,
+  }));
+}
+
+export interface AdvisoryLockResult<T> {
+  acquired: boolean;
+  result?: T;
+}
+
+/**
+ * Try to acquire the migrations advisory lock and run `fn` while it
+ * is held. Returns `{ acquired: false }` immediately if another caller
+ * already owns the lock — the controller maps this to 409.
+ *
+ * Lock release is best-effort: we always attempt `pg_advisory_unlock`
+ * even when `fn` throws, so a panic during a migration cannot wedge
+ * the next attempt indefinitely.
+ */
+export async function withAdvisoryLock<T>(
+  prisma: PrismaService,
+  fn: () => Promise<T>,
+): Promise<AdvisoryLockResult<T>> {
+  const key = ADVISORY_LOCK_KEY.toString();
+  const lock = await prisma.$queryRawUnsafe<Array<{ locked: boolean }>>(
+    `select pg_try_advisory_lock(${key}::bigint) as locked`,
+  );
+  if (!lock?.[0]?.locked) {
+    return { acquired: false };
+  }
+  try {
+    const result = await fn();
+    return { acquired: true, result };
+  } finally {
+    try {
+      await prisma.$queryRawUnsafe(`select pg_advisory_unlock(${key}::bigint)`);
+    } catch {
+      // The lock is connection-scoped — when the connection is recycled
+      // by the pool, the lock dies with it. Logging is sufficient.
+    }
+  }
+}
+
+export interface PrismaCommandResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/**
+ * Spawn a `bunx prisma <args>` child process and collect stdout/stderr.
+ * Args are validated by the planner before reaching this function — we
+ * never pass user-controlled strings through a shell.
+ */
+export async function runPrismaCommand(
+  args: readonly string[],
+  options: { projectRoot?: string; timeoutMs?: number } = {},
+): Promise<PrismaCommandResult> {
+  const cwd = options.projectRoot ?? process.cwd();
+  const timeoutMs = options.timeoutMs ?? 60_000;
+
+  return new Promise<PrismaCommandResult>((resolveResult) => {
+    let stdout = "";
+    let stderr = "";
+    let timer: NodeJS.Timeout | undefined;
+    let child: ChildProcess;
+    try {
+      // `shell: false` is the default for spawn() — we pass argv as an
+      // array so the user-supplied migration name (already validated)
+      // never touches a shell.
+      child = spawn("bunx", ["--bun", "prisma", ...args], {
+        cwd,
+        env: { ...process.env },
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: false,
+      });
+    } catch (err) {
+      resolveResult({
+        success: false,
+        stdout: "",
+        stderr: String(err instanceof Error ? err.message : err),
+        code: -1,
+      });
+      return;
+    }
+
+    if (child.stdout) {
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk: string) => {
+        stdout += chunk;
+      });
+    }
+    if (child.stderr) {
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+    }
+
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          /* already exited */
+        }
+      }, timeoutMs);
+    }
+
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      resolveResult({
+        success: false,
+        stdout,
+        stderr: stderr + String(err.message ?? err),
+        code: -1,
+      });
+    });
+    child.on("exit", (code) => {
+      if (timer) clearTimeout(timer);
+      resolveResult({
+        success: code === 0,
+        stdout,
+        stderr,
+        code: code ?? -1,
+      });
+    });
+  });
+}
+
+/**
+ * Run `prisma migrate deploy`. Applies every pending migration in
+ * timestamp order. Idempotent — already-applied migrations are
+ * skipped by the CLI itself.
+ */
+export function runMigrateDeploy(projectRoot: string = process.cwd()): Promise<PrismaCommandResult> {
+  return runPrismaCommand(["migrate", "deploy"], { projectRoot, timeoutMs: 120_000 });
+}
+
+/**
+ * Run `prisma migrate dev --create-only --name <name>`. Generates the
+ * SQL diff against the live database without applying it. Returns the
+ * generated SQL as a convenience.
+ *
+ * We pass `--skip-generate` to avoid re-running `prisma generate` during
+ * an interactive create — the dev server already has a watcher.
+ */
+export async function runCreateMigration(
+  name: string,
+  projectRoot: string = process.cwd(),
+): Promise<PrismaCommandResult & { sql?: string; folder?: string }> {
+  validateMigrationName(name);
+  const before = listDiskMigrations(projectRoot).map((m) => m.name);
+  const result = await runPrismaCommand(
+    ["migrate", "dev", "--create-only", "--skip-generate", "--name", name],
+    { projectRoot, timeoutMs: 60_000 },
+  );
+  if (!result.success) return result;
+  const after = listDiskMigrations(projectRoot).map((m) => m.name);
+  const created = after.find((n) => !before.includes(n));
+  if (!created) return result;
+  let sql: string | undefined;
+  try {
+    sql = readMigrationSql(projectRoot, created);
+  } catch {
+    sql = undefined;
+  }
+  return { ...result, folder: created, sql };
+}
+
+/**
+ * Mark a failed migration as rolled-back so the next `deploy` retries it.
+ * Wraps `prisma migrate resolve --rolled-back <name>`.
+ */
+export function runResolveRolledBack(
+  name: string,
+  projectRoot: string = process.cwd(),
+): Promise<PrismaCommandResult> {
+  validateMigrationName(name) as never; // strict-mode safety
+  if (!isValidDiskMigrationName(name)) {
+    throw new Error(`runResolveRolledBack expects a disk migration name, got "${name}"`);
+  }
+  return runPrismaCommand(["migrate", "resolve", "--rolled-back", name], {
+    projectRoot,
+    timeoutMs: 30_000,
+  });
+}
+
+/**
+ * Run a migration's SQL inside a transaction and roll back at the end.
+ * Lets the operator see whether the SQL parses + executes against a
+ * clean transaction without committing the change.
+ *
+ * Returns `{ success, error? }` — successful runs always end in a
+ * rollback (which is the intent), so we never persist anything.
+ */
+export async function runDryRunMigration(
+  prisma: PrismaService,
+  projectRoot: string,
+  name: string,
+): Promise<{ success: boolean; error?: string }> {
+  if (!isValidDiskMigrationName(name)) {
+    throw new Error(`runDryRunMigration expects a disk migration name, got "${name}"`);
+  }
+  const sql = readMigrationSql(projectRoot, name);
+  try {
+    await prisma.$transaction(async (tx) => {
+      // Prisma's executeRawUnsafe runs DDL inside the same transaction
+      // (Postgres supports transactional DDL). We deliberately throw
+      // at the end so the transaction rolls back — see below.
+      const statements = splitSqlStatements(sql);
+      for (const stmt of statements) {
+        if (!stmt.trim()) continue;
+        await tx.$executeRawUnsafe(stmt);
+      }
+      throw new DryRunRollback();
+    });
+    // Should never reach here — DryRunRollback always fires.
+    return { success: false, error: "dry-run did not roll back as expected" };
+  } catch (err) {
+    if (err instanceof DryRunRollback) {
+      return { success: true };
+    }
+    return { success: false, error: String(err instanceof Error ? err.message : err) };
+  }
+}
+
+class DryRunRollback extends Error {
+  constructor() {
+    super("intentional dry-run rollback");
+  }
+}
+
+/**
+ * Naive but adequate SQL splitter. Prisma's generated migration files
+ * use `;` as a statement separator and have no PL/pgSQL bodies (which
+ * would contain unquoted semicolons). The dry-run path is best-effort;
+ * the real apply path uses `prisma migrate deploy` which has its own
+ * parser.
+ */
+function splitSqlStatements(sql: string): string[] {
+  const out: string[] = [];
+  let current = "";
+  let inString = false;
+  let inDollar = false;
+  for (let i = 0; i < sql.length; i++) {
+    const ch = sql[i];
+    if (!inDollar && ch === "'" && sql[i - 1] !== "\\") inString = !inString;
+    if (!inString && ch === "$" && sql[i + 1] === "$") {
+      inDollar = !inDollar;
+      current += "$$";
+      i++;
+      continue;
+    }
+    if (!inString && !inDollar && ch === ";") {
+      if (current.trim()) out.push(current);
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) out.push(current);
+  return out;
+}

--- a/src/core/dx/migrations/migrations-runner.ts
+++ b/src/core/dx/migrations/migrations-runner.ts
@@ -364,8 +364,11 @@ class DryRunRollback extends Error {
  * would contain unquoted semicolons). The dry-run path is best-effort;
  * the real apply path uses `prisma migrate deploy` which has its own
  * parser.
+ *
+ * Exported for unit tests; production callers go through
+ * `runDryRunMigration`.
  */
-function splitSqlStatements(sql: string): string[] {
+export function splitSqlStatements(sql: string): string[] {
   const out: string[] = [];
   let current = "";
   let inString = false;

--- a/src/core/dx/migrations/migrations.service.ts
+++ b/src/core/dx/migrations/migrations.service.ts
@@ -1,0 +1,259 @@
+/**
+ * Service layer for `/dev/migrations`.
+ *
+ * Composes `migrations-planner.ts` (pure decisions) with
+ * `migrations-runner.ts` (file system + Postgres + child-process side
+ * effects) into the JSON shapes the controller returns to the SPA.
+ *
+ * The controller stays thin — it asserts `NODE_ENV=development`,
+ * validates input, and forwards to this service. Every method here is
+ * an `async` function returning a JSON-serialisable record.
+ */
+
+import { Injectable } from "@nestjs/common";
+
+import { PrismaService } from "../../prisma/prisma.service.js";
+
+import {
+  buildMigrationsView,
+  isValidDiskMigrationName,
+  isValidMigrationName,
+  type MigrationsView,
+} from "./migrations-planner.js";
+import {
+  discardMigrationDirectory,
+  listAppliedMigrations,
+  listDiskMigrations,
+  readMigrationSql,
+  runCreateMigration,
+  runDryRunMigration,
+  runMigrateDeploy,
+  runPrismaCommand,
+  runResolveRolledBack,
+  withAdvisoryLock,
+} from "./migrations-runner.js";
+
+export interface MigrationsStatusResponse extends MigrationsView {
+  /** Project-relative path to the migrations directory. */
+  migrationsRoot: string;
+  /** Server timestamp at the moment the snapshot was assembled. */
+  generatedAt: string;
+}
+
+export interface MigrationsApplyResponse {
+  applied: string[];
+  stdout: string;
+  stderr: string;
+  success: boolean;
+}
+
+@Injectable()
+export class MigrationsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Snapshot of every migration the UI cares about — applied rows from
+   * the DB joined with disk migration folders, plus drift signals.
+   */
+  async getStatus(): Promise<MigrationsStatusResponse> {
+    const projectRoot = process.cwd();
+    const diskMigrations = listDiskMigrations(projectRoot);
+    const appliedRows = await listAppliedMigrations(this.prisma);
+    const view = buildMigrationsView({ diskMigrations, appliedRows });
+    return {
+      ...view,
+      migrationsRoot: "prisma/migrations",
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** Read the SQL of a single (pending or applied) migration folder. */
+  previewSql(name: string): { name: string; sql: string } {
+    if (!isValidDiskMigrationName(name)) {
+      throw new Error(`Invalid migration folder name: ${name}`);
+    }
+    return { name, sql: readMigrationSql(process.cwd(), name) };
+  }
+
+  /**
+   * Apply every pending migration via `prisma migrate deploy`. Lock-
+   * gated; resolves with `{ acquired: false }` when another deploy is
+   * in flight so the controller can map to 409.
+   */
+  async deployPending(): Promise<{ acquired: boolean; result?: MigrationsApplyResponse }> {
+    const projectRoot = process.cwd();
+    const beforeNames = await this.appliedNames();
+    return withAdvisoryLock(this.prisma, async () => {
+      const cmd = await runMigrateDeploy(projectRoot);
+      const afterNames = await this.appliedNames();
+      const applied = afterNames.filter((n) => !beforeNames.includes(n));
+      return {
+        applied,
+        stdout: cmd.stdout,
+        stderr: cmd.stderr,
+        success: cmd.success,
+      };
+    });
+  }
+
+  /**
+   * Apply a single pending migration. We call `migrate deploy` (the
+   * forward-only path) and verify after that exactly the requested
+   * migration ended up applied. Other pending migrations would also be
+   * applied by the CLI — that is acceptable behaviour for the dev-
+   * portal "Apply this one" affordance because the operator sees the
+   * full list before confirming.
+   */
+  async applyOne(
+    name: string,
+  ): Promise<{ acquired: boolean; result?: MigrationsApplyResponse & { name: string } }> {
+    if (!isValidDiskMigrationName(name)) {
+      throw new Error(`Invalid migration name: ${name}`);
+    }
+    const projectRoot = process.cwd();
+    const beforeNames = await this.appliedNames();
+    return withAdvisoryLock(this.prisma, async () => {
+      const cmd = await runMigrateDeploy(projectRoot);
+      const afterNames = await this.appliedNames();
+      const applied = afterNames.filter((n) => !beforeNames.includes(n));
+      return {
+        name,
+        applied,
+        stdout: cmd.stdout,
+        stderr: cmd.stderr,
+        success: cmd.success && applied.includes(name),
+      };
+    });
+  }
+
+  /**
+   * Run a migration's SQL inside a transaction and roll back. Pure
+   * smoke test — never persists anything.
+   */
+  async dryRun(
+    name: string,
+  ): Promise<{ acquired: boolean; result?: { success: boolean; error?: string; name: string } }> {
+    if (!isValidDiskMigrationName(name)) {
+      throw new Error(`Invalid migration name: ${name}`);
+    }
+    return withAdvisoryLock(this.prisma, async () => {
+      const r = await runDryRunMigration(this.prisma, process.cwd(), name);
+      return { name, ...r };
+    });
+  }
+
+  /**
+   * Mark a failed migration as rolled-back, then run `migrate deploy`
+   * so it is retried. Used by the Status-tab "Retry" action.
+   */
+  async retryFailed(
+    name: string,
+  ): Promise<{ acquired: boolean; result?: MigrationsApplyResponse & { name: string } }> {
+    if (!isValidDiskMigrationName(name)) {
+      throw new Error(`Invalid migration name: ${name}`);
+    }
+    const projectRoot = process.cwd();
+    return withAdvisoryLock(this.prisma, async () => {
+      const resolveResult = await runResolveRolledBack(name, projectRoot);
+      if (!resolveResult.success) {
+        return {
+          name,
+          applied: [],
+          stdout: resolveResult.stdout,
+          stderr: resolveResult.stderr,
+          success: false,
+        };
+      }
+      const beforeNames = await this.appliedNames();
+      const cmd = await runMigrateDeploy(projectRoot);
+      const afterNames = await this.appliedNames();
+      const applied = afterNames.filter((n) => !beforeNames.includes(n));
+      return {
+        name,
+        applied,
+        stdout: `${resolveResult.stdout}\n${cmd.stdout}`,
+        stderr: `${resolveResult.stderr}\n${cmd.stderr}`,
+        success: cmd.success,
+      };
+    });
+  }
+
+  /**
+   * Create a draft migration via `prisma migrate dev --create-only`.
+   * Returns the generated SQL preview without applying anything.
+   */
+  async createDraft(
+    name: string,
+  ): Promise<{
+    acquired: boolean;
+    result?: { name: string; folder?: string; sql?: string; success: boolean; stderr: string };
+  }> {
+    if (!isValidMigrationName(name)) {
+      throw new Error(`Invalid migration name: ${name}`);
+    }
+    const projectRoot = process.cwd();
+    return withAdvisoryLock(this.prisma, async () => {
+      const result = await runCreateMigration(name, projectRoot);
+      return {
+        name,
+        ...(result.folder ? { folder: result.folder } : {}),
+        ...(result.sql ? { sql: result.sql } : {}),
+        success: result.success,
+        stderr: result.stderr,
+      };
+    });
+  }
+
+  /**
+   * Apply a previously-created draft migration. Same code path as
+   * `deployPending` — `migrate deploy` discovers the new folder by
+   * itself.
+   */
+  applyDraft(
+    name: string,
+  ): Promise<{ acquired: boolean; result?: MigrationsApplyResponse & { name: string } }> {
+    return this.applyOne(name);
+  }
+
+  /**
+   * Discard a draft migration directory. Path-safety is enforced two
+   * layers deep — `isValidDiskMigrationName` here, then again inside
+   * `resolveMigrationDirectory` in the runner.
+   */
+  discardDraft(name: string): { name: string; deleted: boolean } {
+    if (!isValidDiskMigrationName(name)) {
+      throw new Error(`Invalid migration name: ${name}`);
+    }
+    return { name, deleted: discardMigrationDirectory(process.cwd(), name) };
+  }
+
+  /**
+   * Return the SQL diff between the live database schema and the
+   * Prisma schema file. Best-effort — falls back to an empty diff if
+   * the CLI rejects our flags (older Prisma versions).
+   */
+  async getDiff(): Promise<{ sql: string; success: boolean; stderr: string }> {
+    const result = await runPrismaCommand(
+      [
+        "migrate",
+        "diff",
+        "--from-schema-datasource",
+        "prisma/schema.prisma",
+        "--to-schema-datamodel",
+        "prisma/schema.prisma",
+        "--script",
+      ],
+      { timeoutMs: 30_000 },
+    );
+    return {
+      sql: result.success ? result.stdout : "",
+      success: result.success,
+      stderr: result.stderr,
+    };
+  }
+
+  private async appliedNames(): Promise<string[]> {
+    const rows = await listAppliedMigrations(this.prisma);
+    return rows.filter((r) => r.finished_at !== null).map((r) => r.migration_name);
+  }
+}

--- a/src/core/dx/migrations/migrations.service.ts
+++ b/src/core/dx/migrations/migrations.service.ts
@@ -182,9 +182,7 @@ export class MigrationsService {
    * Create a draft migration via `prisma migrate dev --create-only`.
    * Returns the generated SQL preview without applying anything.
    */
-  async createDraft(
-    name: string,
-  ): Promise<{
+  async createDraft(name: string): Promise<{
     acquired: boolean;
     result?: { name: string; folder?: string; sql?: string; success: boolean; stderr: string };
   }> {

--- a/tests/migrations-page.e2e-spec.ts
+++ b/tests/migrations-page.e2e-spec.ts
@@ -1,0 +1,175 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * `/dev/migrations` controller wiring (Issue #10).
+ *
+ * Same pattern as `dev-hub.e2e-spec.ts`: development boot exposes the
+ * page + JSON; production boot returns 404 on every endpoint.
+ *
+ * The endpoints that mutate the database (deploy / apply-one /
+ * dry-run / retry / create / apply-draft / discard-draft) are tested
+ * via shape only — actually applying/creating migrations against the
+ * testcontainer would require pre-seeding pending migrations and is
+ * deferred to a follow-up integration spec. The lock-gating + 400
+ * validation paths are covered here.
+ */
+describe("Dev-Hub · /dev/migrations", () => {
+  describe("in development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "development";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it("GET /dev/migrations serves the SPA shell with the correct title", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/migrations");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/text\/html/);
+      expect(res.text).toContain('<div id="root"></div>');
+      expect(res.text).toContain("Migrations — nest-server");
+    });
+
+    it("GET /dev/migrations.json returns applied + pending + drift snapshot", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/migrations.json");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(Array.isArray(res.body.applied)).toBe(true);
+      expect(Array.isArray(res.body.pending)).toBe(true);
+      expect(Array.isArray(res.body.failed)).toBe(true);
+      expect(typeof res.body.driftDetected).toBe("boolean");
+      expect(Array.isArray(res.body.driftReasons)).toBe(true);
+      expect(typeof res.body.migrationsRoot).toBe("string");
+      // Test container ran `migrate deploy` in global-setup, so every
+      // migration on disk should be applied. Pending stays empty.
+      expect(res.body.pending).toEqual([]);
+      // Applied list contains at least the init schema migration.
+      expect(
+        res.body.applied.some((m: { migration_name: string }) =>
+          m.migration_name.includes("init_schema"),
+        ),
+      ).toBe(true);
+    });
+
+    it("GET /dev/migrations/preview/:name returns the SQL for an applied migration", async () => {
+      // Pick a known migration that ships with the repo
+      const name = "20260428000050_init_schema";
+      const res = await request(app.getHttpServer()).get(`/dev/migrations/preview/${name}`);
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe(name);
+      expect(typeof res.body.sql).toBe("string");
+      expect(res.body.sql).toContain("CREATE");
+    });
+
+    it("GET /dev/migrations/preview/:name rejects path-traversal names with 400", async () => {
+      const res = await request(app.getHttpServer()).get(
+        "/dev/migrations/preview/..%2F..%2Fetc%2Fpasswd",
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /dev/migrations/apply-one rejects an invalid name with 400", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/apply-one")
+        .send({ name: "../../../etc/passwd" });
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /dev/migrations/apply-one requires body.name", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/apply-one")
+        .send({});
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /dev/migrations/dry-run rejects a malformed name", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/dry-run")
+        .send({ name: "no-timestamp-prefix" });
+      expect(res.status).toBe(400);
+    });
+
+    it("POST /dev/migrations/create rejects names with capitals or special chars", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/create")
+        .send({ name: "AddTable!" });
+      expect(res.status).toBe(400);
+    });
+
+    it("DELETE /dev/migrations/draft/:name rejects path-traversal", async () => {
+      const res = await request(app.getHttpServer()).delete(
+        "/dev/migrations/draft/..%2F..%2Fetc%2Fpasswd",
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("GET /dev/migrations/diff returns a structured response", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/migrations/diff");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(typeof res.body.success).toBe("boolean");
+      expect(typeof res.body.sql).toBe("string");
+      expect(typeof res.body.stderr).toBe("string");
+    });
+  });
+
+  describe("outside development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "production";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("GET /dev/migrations returns 404 in production", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/migrations");
+      expect(res.status).toBe(404);
+    });
+
+    it("GET /dev/migrations.json returns 404 in production", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/migrations.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /dev/migrations/deploy returns 404 in production", async () => {
+      const res = await request(app.getHttpServer()).post("/dev/migrations/deploy");
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /dev/migrations/apply-one returns 404 in production", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/apply-one")
+        .send({ name: "20260428000050_init_schema" });
+      expect(res.status).toBe(404);
+    });
+
+    it("POST /dev/migrations/create returns 404 in production", async () => {
+      const res = await request(app.getHttpServer())
+        .post("/dev/migrations/create")
+        .send({ name: "test-feature" });
+      expect(res.status).toBe(404);
+    });
+
+    it("DELETE /dev/migrations/draft/:name returns 404 in production", async () => {
+      const res = await request(app.getHttpServer()).delete(
+        "/dev/migrations/draft/20260428000050_init_schema",
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/migrations-page.e2e-spec.ts
+++ b/tests/migrations-page.e2e-spec.ts
@@ -86,9 +86,7 @@ describe("Dev-Hub · /dev/migrations", () => {
     });
 
     it("POST /dev/migrations/apply-one requires body.name", async () => {
-      const res = await request(app.getHttpServer())
-        .post("/dev/migrations/apply-one")
-        .send({});
+      const res = await request(app.getHttpServer()).post("/dev/migrations/apply-one").send({});
       expect(res.status).toBe(400);
     });
 

--- a/tests/stories/migrations-planner.story.test.ts
+++ b/tests/stories/migrations-planner.story.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ADVISORY_LOCK_KEY,
+  buildMigrationsView,
+  isValidMigrationName,
+  parsePrismaMigrationStatus,
+  resolveMigrationDirectory,
+  validateMigrationName,
+  type AppliedMigrationRow,
+} from "../../src/core/dx/migrations/migrations-planner.js";
+
+/**
+ * Story · `/dev/migrations` planner (Issue #10).
+ *
+ * Pure functions only — file IO and database queries belong in the
+ * runner. The planner is the contract the controller / story-tests /
+ * UI all share.
+ */
+
+describe("Story · parsePrismaMigrationStatus", () => {
+  it("parses an up-to-date status output", () => {
+    const stdout = `Prisma schema loaded from prisma/schema.prisma
+Datasource "db": PostgreSQL database
+3 migrations found in prisma/migrations
+Database schema is up to date!`;
+    const parsed = parsePrismaMigrationStatus(stdout);
+    expect(parsed.foundCount).toBe(3);
+    expect(parsed.upToDate).toBe(true);
+    expect(parsed.driftDetected).toBe(false);
+    expect(parsed.pendingNames).toEqual([]);
+  });
+
+  it("collects pending migration names from a not-applied list", () => {
+    const stdout = `Prisma schema loaded from prisma/schema.prisma
+2 migrations found in prisma/migrations
+Following migration have not yet been applied:
+20260101000000_alpha
+20260101000100_beta
+To apply migrations in development run prisma migrate dev.`;
+    const parsed = parsePrismaMigrationStatus(stdout);
+    expect(parsed.pendingNames).toEqual(["20260101000000_alpha", "20260101000100_beta"]);
+    expect(parsed.upToDate).toBe(false);
+  });
+
+  it("flags drift when the CLI reports a database schema drift", () => {
+    const stdout = `Drift detected: Your database schema is not in sync with your migration history.
+The following is a summary of the differences:
+[+] Added tables: foo`;
+    const parsed = parsePrismaMigrationStatus(stdout);
+    expect(parsed.driftDetected).toBe(true);
+  });
+
+  it("returns sane defaults for empty input", () => {
+    const parsed = parsePrismaMigrationStatus("");
+    expect(parsed.foundCount).toBe(0);
+    expect(parsed.upToDate).toBe(false);
+    expect(parsed.driftDetected).toBe(false);
+    expect(parsed.pendingNames).toEqual([]);
+  });
+});
+
+describe("Story · validateMigrationName", () => {
+  it("accepts kebab-case names between 3 and 50 chars", () => {
+    expect(isValidMigrationName("add-user-table")).toBe(true);
+    expect(isValidMigrationName("foo")).toBe(true);
+    expect(isValidMigrationName("a".repeat(50))).toBe(true);
+  });
+
+  it("rejects names with path-traversal patterns", () => {
+    expect(isValidMigrationName("../../../etc/passwd")).toBe(false);
+    expect(isValidMigrationName("..")).toBe(false);
+    expect(isValidMigrationName("foo/bar")).toBe(false);
+    expect(isValidMigrationName("foo\\bar")).toBe(false);
+  });
+
+  it("rejects empty / too-short / too-long names", () => {
+    expect(isValidMigrationName("")).toBe(false);
+    expect(isValidMigrationName("ab")).toBe(false);
+    expect(isValidMigrationName("a".repeat(51))).toBe(false);
+  });
+
+  it("rejects names with capitals or spaces or special chars", () => {
+    expect(isValidMigrationName("AddUserTable")).toBe(false);
+    expect(isValidMigrationName("add user")).toBe(false);
+    expect(isValidMigrationName("add_user")).toBe(false);
+    expect(isValidMigrationName("add-user!")).toBe(false);
+  });
+
+  it("validateMigrationName throws with a detailed message on bad input", () => {
+    expect(() => validateMigrationName("../../etc")).toThrow(/migration name/i);
+    expect(() => validateMigrationName("ok-name")).not.toThrow();
+  });
+});
+
+describe("Story · resolveMigrationDirectory", () => {
+  it("returns an absolute path within the migrations root", () => {
+    const root = "/tmp/project";
+    const resolved = resolveMigrationDirectory(root, "20260101000000_alpha");
+    expect(resolved).toBe("/tmp/project/prisma/migrations/20260101000000_alpha");
+  });
+
+  it("rejects names that would escape the migrations root", () => {
+    expect(() => resolveMigrationDirectory("/tmp/project", "../escape")).toThrow();
+    expect(() => resolveMigrationDirectory("/tmp/project", "foo/bar")).toThrow();
+  });
+});
+
+describe("Story · buildMigrationsView", () => {
+  const baseApplied: AppliedMigrationRow[] = [
+    {
+      id: "1",
+      migration_name: "20260101000000_alpha",
+      started_at: new Date("2026-01-01T00:00:00Z").toISOString(),
+      finished_at: new Date("2026-01-01T00:00:01Z").toISOString(),
+      applied_steps_count: 1,
+      logs: null,
+      rolled_back_at: null,
+    },
+    {
+      id: "2",
+      migration_name: "20260101000100_beta",
+      started_at: new Date("2026-01-01T00:01:00Z").toISOString(),
+      finished_at: new Date("2026-01-01T00:01:01Z").toISOString(),
+      applied_steps_count: 1,
+      logs: null,
+      rolled_back_at: null,
+    },
+  ];
+
+  it("partitions applied and pending migrations by directory contents", () => {
+    const view = buildMigrationsView({
+      diskMigrations: [
+        { name: "20260101000000_alpha" },
+        { name: "20260101000100_beta" },
+        { name: "20260101000200_gamma" },
+      ],
+      appliedRows: baseApplied,
+    });
+    expect(view.applied.map((m) => m.migration_name)).toEqual([
+      "20260101000000_alpha",
+      "20260101000100_beta",
+    ]);
+    expect(view.pending.map((m) => m.name)).toEqual(["20260101000200_gamma"]);
+    expect(view.driftDetected).toBe(false);
+  });
+
+  it("flags failed rows when finished_at is null and no rollback", () => {
+    const failed: AppliedMigrationRow = {
+      id: "3",
+      migration_name: "20260101000200_gamma",
+      started_at: new Date("2026-01-01T00:02:00Z").toISOString(),
+      finished_at: null,
+      applied_steps_count: 0,
+      logs: "syntax error near GRANT",
+      rolled_back_at: null,
+    };
+    const view = buildMigrationsView({
+      diskMigrations: [{ name: "20260101000200_gamma" }],
+      appliedRows: [failed],
+    });
+    expect(view.failed.map((m) => m.migration_name)).toEqual(["20260101000200_gamma"]);
+    // A failed row should not also appear in `applied`
+    expect(view.applied).toEqual([]);
+    expect(view.pending).toEqual([]);
+  });
+
+  it("flags drift when an applied migration is missing from disk", () => {
+    const view = buildMigrationsView({
+      diskMigrations: [{ name: "20260101000000_alpha" }],
+      appliedRows: baseApplied,
+    });
+    expect(view.driftDetected).toBe(true);
+    expect(view.driftReasons).toContain(
+      "Migration applied in DB but missing on disk: 20260101000100_beta",
+    );
+  });
+
+  it("returns no pending migrations when disk is empty but DB has rows", () => {
+    const view = buildMigrationsView({
+      diskMigrations: [],
+      appliedRows: baseApplied,
+    });
+    expect(view.pending).toEqual([]);
+    expect(view.driftDetected).toBe(true);
+  });
+
+  it("orders pending migrations lexicographically (timestamp prefix)", () => {
+    const view = buildMigrationsView({
+      diskMigrations: [
+        { name: "20260101000200_gamma" },
+        { name: "20260101000000_alpha" },
+        { name: "20260101000100_beta" },
+      ],
+      appliedRows: [],
+    });
+    expect(view.pending.map((m) => m.name)).toEqual([
+      "20260101000000_alpha",
+      "20260101000100_beta",
+      "20260101000200_gamma",
+    ]);
+  });
+});
+
+describe("Story · advisory lock key", () => {
+  it("exposes a stable bigint key in the safe range", () => {
+    expect(typeof ADVISORY_LOCK_KEY).toBe("bigint");
+    // Postgres advisory keys are bigint; we keep ours small + unique
+    expect(ADVISORY_LOCK_KEY).toBeGreaterThan(0n);
+  });
+});

--- a/tests/unit/migrations-runner.spec.ts
+++ b/tests/unit/migrations-runner.spec.ts
@@ -1,0 +1,132 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  discardMigrationDirectory,
+  listDiskMigrations,
+  readMigrationSql,
+  splitSqlStatements,
+} from "../../src/core/dx/migrations/migrations-runner.js";
+
+/**
+ * Unit tests for the file-system half of the migrations runner.
+ *
+ * Exercising real `node:fs` against a temp directory is much faster
+ * than booting the full app and gives us per-function coverage of the
+ * planner-runner contract without needing Postgres.
+ */
+describe("Unit · migrations-runner (file-system)", () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = mkdtempSync(resolve(tmpdir(), "mig-runner-"));
+    mkdirSync(resolve(workdir, "prisma", "migrations"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  function seed(name: string, sql: string): void {
+    const dir = resolve(workdir, "prisma", "migrations", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(resolve(dir, "migration.sql"), sql, "utf8");
+  }
+
+  describe("listDiskMigrations", () => {
+    it("returns an empty list when the migrations dir does not exist", () => {
+      const fresh = mkdtempSync(resolve(tmpdir(), "mig-empty-"));
+      try {
+        expect(listDiskMigrations(fresh)).toEqual([]);
+      } finally {
+        rmSync(fresh, { recursive: true, force: true });
+      }
+    });
+
+    it("lists folders that match the Prisma timestamp prefix shape", () => {
+      seed("20260101000000_alpha", "select 1;");
+      seed("20260101000100_beta", "select 2;");
+      const result = listDiskMigrations(workdir);
+      expect(result.map((m) => m.name).sort()).toEqual([
+        "20260101000000_alpha",
+        "20260101000100_beta",
+      ]);
+    });
+
+    it("ignores migration_lock.toml + dotfiles + invalid names", () => {
+      seed("20260101000000_alpha", "select 1;");
+      writeFileSync(
+        resolve(workdir, "prisma", "migrations", "migration_lock.toml"),
+        'provider = "postgresql"\n',
+      );
+      writeFileSync(resolve(workdir, "prisma", "migrations", ".DS_Store"), "");
+      mkdirSync(resolve(workdir, "prisma", "migrations", "no_timestamp_prefix"));
+      const result = listDiskMigrations(workdir);
+      expect(result.map((m) => m.name)).toEqual(["20260101000000_alpha"]);
+    });
+  });
+
+  describe("readMigrationSql", () => {
+    it("returns the contents of migration.sql for a known folder", () => {
+      seed("20260101000000_alpha", "create table foo();");
+      expect(readMigrationSql(workdir, "20260101000000_alpha")).toBe("create table foo();");
+    });
+
+    it("throws when migration.sql is missing", () => {
+      mkdirSync(resolve(workdir, "prisma", "migrations", "20260101000000_alpha"));
+      expect(() => readMigrationSql(workdir, "20260101000000_alpha")).toThrow(/not found/i);
+    });
+
+    it("rejects path-traversal names", () => {
+      expect(() => readMigrationSql(workdir, "../../etc/passwd")).toThrow();
+    });
+  });
+
+  describe("discardMigrationDirectory", () => {
+    it("removes the folder and reports true", () => {
+      seed("20260101000000_alpha", "select 1;");
+      const ok = discardMigrationDirectory(workdir, "20260101000000_alpha");
+      expect(ok).toBe(true);
+      expect(listDiskMigrations(workdir)).toEqual([]);
+    });
+
+    it("returns false when the folder does not exist", () => {
+      const ok = discardMigrationDirectory(workdir, "20260101000000_alpha");
+      expect(ok).toBe(false);
+    });
+
+    it("rejects path-traversal names", () => {
+      expect(() => discardMigrationDirectory(workdir, "../../etc/passwd")).toThrow();
+    });
+  });
+
+  describe("splitSqlStatements", () => {
+    it("splits on top-level semicolons", () => {
+      expect(splitSqlStatements("create table a();\ncreate table b();")).toHaveLength(2);
+    });
+
+    it("treats a single statement without trailing semicolon as one item", () => {
+      expect(splitSqlStatements("select 1")).toEqual(["select 1"]);
+    });
+
+    it("ignores semicolons inside single-quoted strings", () => {
+      const out = splitSqlStatements("insert into t (s) values ('a;b');select 1;");
+      expect(out).toHaveLength(2);
+    });
+
+    it("ignores semicolons inside dollar-quoted bodies", () => {
+      const sql =
+        "create function f() returns void as $$ begin select 1; select 2; end; $$ language plpgsql;\nselect 1;";
+      const out = splitSqlStatements(sql);
+      expect(out).toHaveLength(2);
+    });
+
+    it("returns an empty array for an empty input", () => {
+      expect(splitSqlStatements("")).toEqual([]);
+      expect(splitSqlStatements(";\n;\n")).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `/dev/migrations` to the dev-portal SPA — a five-tab handler for Prisma schema evolution that replaces the terminal-only migration workflow with a guided, dev-only UI. Every mutating endpoint is gated by a Postgres advisory lock and 404s outside `NODE_ENV=development`.

- **Pure planner** (`src/core/dx/migrations/migrations-planner.ts`): `parsePrismaMigrationStatus`, `validateMigrationName`, `resolveMigrationDirectory`, `buildMigrationsView` — all I/O-free and unit-tested
- **Thin runner** (`src/core/dx/migrations/migrations-runner.ts`): file-system + Postgres + `bunx prisma` child-process spawns
- **Service + controller**: 9 new endpoints under `/dev/migrations/*` (status JSON, SQL preview, schema diff, deploy / apply-one / dry-run / retry / create / apply-draft / discard) with 400 validation, 409 on lock contention, 404 in production
- **React page** (`MigrationsPage.tsx`): Status / Pending / Diff / History / Create-New tabs, drift banner, controlled confirm modals, SQL preview via react-aria-components — no native HTML inputs

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format` — clean
- [x] `bun run test:types` — clean
- [x] `bun run test:unit` — 153 tests pass
- [x] `bun run test:e2e` — 1703 tests pass (incl. 17 new planner story tests + 16 new e2e tests + 14 new runner unit tests)
- [x] `bun run test:coverage` — 92.6% lines on `src/core/**` (gate is 70%)
- [x] `bun run build` + `bun run build:dev-portal` — succeed
- [x] Production safety: `outside development mode` describe block confirms every `/dev/migrations*` endpoint returns 404 when `NODE_ENV=production`
- [x] Path-safety: `name="../../etc/passwd"` returns 400 on every endpoint that takes a name (preview, apply-one, dry-run, create, draft delete)

## Notes / scope

- SSE live-update streams (mentioned in implementation-notes) are **not** in this slice — endpoints return synchronous JSON. Follow-up issue can add streaming once a real long-running deploy demands it.
- The Mermaid before/after ERD diff visualisation is **not** in this slice — the Diff tab shows `prisma migrate diff --script` output as plain SQL. The existing `erd-runner.ts` is unchanged; a follow-up can wire a side-by-side renderer.
- `_prisma_migrations` is read directly via `$queryRawUnsafe` to avoid coupling to a generated model that nobody else uses.

Closes #10