### PR TITLE
feat(files): file-manager UI in dev-portal (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ Two-tab view of the in-memory `JobQueueService` (the future pg-boss adapter expo
 
 Pure planner (`buildJobAggregates()`) computes counts / p95 / failure-rate over a flat `JobRecord` list, so the same dashboard renders unchanged once a Postgres-backed adapter ships. Auto-refresh every 4 s. Schedules / Workers / Archive tabs are deferred to the pg-boss adapter slice.
 
+### File Manager — `/dev/files`
+
+Two-column file browser over the Prisma file/folder metadata + storage adapter pipeline (issues #16 + #17 wired the foundations):
+
+- **Folder tree** on the left — recursive, sorted alphabetically, click to navigate; pure planner (`buildFolderTree()`) tolerates orphans and cycles.
+- **File grid** on the right — IPX thumbnails for `image/*` rows via `/_ipx/preset_thumbnail/...`, generic icon fallback for other MIME types.
+- **Breadcrumb** above the grid — root-to-active path, every segment clickable.
+- **Sort + filter** toolbar — name / size / createdAt / updatedAt / mimeType, asc/desc, free-text filename search.
+- **Folder create** + **file delete** — wired to the existing `/folders` and `/files` REST endpoints.
+
+Tenant id resolves from the `x-tenant-id` cookie or a manual UUID input (debug-only). The page 404s outside `NODE_ENV=development`, identical to every other dev-hub surface.
+
+Out of scope for this slice (deferred to follow-up issues): TUS upload UI, drag-and-drop move, multi-select bulk actions, lightbox, share-link creator, visibility toggle, server-side zip download.
+
 ### Routes Inventory — `/dev/routes`
 
 Live audit of every endpoint registered in NestJS, with its decorator-derived guard kind: `@Can(action, subject)` (guarded), `public` (allowlist), `dev-only` (404s in prod), or `unguarded` (red). 5-tile summary with per-kind counts so an auditor can spot gaps. JSON endpoint at `/dev/routes.json` for SDK / agent tooling.

--- a/src/core/dx/clients/App.tsx
+++ b/src/core/dx/clients/App.tsx
@@ -81,6 +81,9 @@ const ErrorsPage = lazy(() =>
 const OpenApiPage = lazy(() =>
   import("./pages/OpenApiPage.js").then((m) => ({ default: m.OpenApiPage })),
 );
+const FileManagerPage = lazy(() =>
+  import("./pages/FileManagerPage.js").then((m) => ({ default: m.FileManagerPage })),
+);
 
 function PageFallback(): ReactNode {
   return (
@@ -111,6 +114,7 @@ export function App(): ReactNode {
         <Route path="/dev/email-preview" element={<EmailPreviewPage />} />
         <Route path="/dev/email-builder" element={<EmailBuilderPage />} />
         <Route path="/dev/postgrest-parse" element={<PostgrestParsePage />} />
+        <Route path="/dev/files" element={<FileManagerPage />} />
         <Route path="/admin/permissions/test" element={<PermissionTesterPage />} />
         <Route path="/admin/webhooks" element={<WebhookInspectorPage />} />
         <Route path="/admin/realtime" element={<RealtimeInspectorPage />} />

--- a/src/core/dx/clients/layout/nav.ts
+++ b/src/core/dx/clients/layout/nav.ts
@@ -39,6 +39,7 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "queries", label: "Queries", href: "/dev/queries", icon: "database" },
       { id: "migrations", label: "Migrations", href: "/dev/migrations", icon: "database" },
       { id: "jobs", label: "Jobs", href: "/dev/jobs", icon: "layers" },
+      { id: "files", label: "File Manager", href: "/dev/files", icon: "file" },
     ],
   },
   {
@@ -98,6 +99,7 @@ export const SPA_ROUTES = new Set<string>([
   "/dev/email-builder",
   "/dev/components",
   "/dev/postgrest-parse",
+  "/dev/files",
   "/admin/permissions/test",
   "/admin/webhooks",
   "/admin/realtime",

--- a/src/core/dx/clients/pages/FileManagerPage.tsx
+++ b/src/core/dx/clients/pages/FileManagerPage.tsx
@@ -1,0 +1,448 @@
+/**
+ * `/dev/files` — Dev-Portal File-Manager.
+ *
+ * Two-column layout:
+ *   - left rail: collapsible folder tree (built from /dev/files/tree.json)
+ *   - right pane: breadcrumb + sort/filter toolbar + file grid
+ *
+ * The page exposes the storage layer that issue #16 (Files persistence)
+ * and issue #17 (IPX thumbnails) made possible: browse what's in
+ * Postgres, see image previews via `/_ipx/preset_thumbnail/...`, sort
+ * + filter without an extra round-trip below 500 entries.
+ *
+ * The tenant id is read from the `x-tenant-id` cookie when present
+ * (debug surface only — operators can paste a value into the input
+ * field). Production will gate the page behind an admin check; for
+ * the dev surface the controller already 404s outside development.
+ *
+ * Out of scope for this slice (tracked by follow-up issues):
+ *   - upload via TUS (foundation already wired in #16; UI follow-up)
+ *   - drag-and-drop move, rename, multi-select bulk actions
+ *   - lightbox / Monaco / PDF preview drawer
+ *   - share-link creator + visibility toggle
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState, type ReactNode } from "react";
+
+import { Button } from "../components/Button.js";
+import { Select, SelectItem } from "../components/Select.js";
+import { TextField } from "../components/TextField.js";
+import { AdminShell } from "../layout/AdminShell.js";
+import { fetchJson, formatBytes } from "../lib/api.js";
+
+interface FolderTreeNodeDto {
+  id: string;
+  name: string;
+  parentId: string | null;
+  depth: number;
+  path: { id: string; name: string }[];
+  children: FolderTreeNodeDto[];
+}
+
+interface FileEntryDto {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  updatedAt: string;
+  folderId: string | null;
+  storageKey: string;
+  thumbnailUrl?: string;
+}
+
+interface BreadcrumbSegment {
+  id: string | null;
+  name: string;
+}
+
+interface TreeResponse {
+  tree: FolderTreeNodeDto[];
+}
+
+interface ListResponse {
+  files: FileEntryDto[];
+  totalCount: number;
+}
+
+interface BreadcrumbResponse {
+  segments: BreadcrumbSegment[];
+}
+
+type SortKey = "name" | "size" | "createdAt" | "updatedAt" | "mimeType";
+type SortDirection = "asc" | "desc";
+
+const SORT_KEYS: { id: SortKey; label: string }[] = [
+  { id: "name", label: "Name" },
+  { id: "size", label: "Größe" },
+  { id: "createdAt", label: "Erstellt" },
+  { id: "updatedAt", label: "Aktualisiert" },
+  { id: "mimeType", label: "Typ" },
+];
+
+export function FileManagerPage(): ReactNode {
+  const [tenantId, setTenantId] = useState<string>(readDefaultTenantId());
+  const [activeFolderId, setActiveFolderId] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortKey>("name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [newFolderName, setNewFolderName] = useState("");
+
+  const queryClient = useQueryClient();
+  const tenantValid = isUuid(tenantId);
+
+  const treeQuery = useQuery({
+    queryKey: ["dev", "files", "tree", tenantId],
+    queryFn: () => fetchJson<TreeResponse>(`/dev/files/tree.json?tenantId=${tenantId}`),
+    enabled: tenantValid,
+  });
+
+  const listUrl = useMemo(() => {
+    const p = new URLSearchParams();
+    p.set("tenantId", tenantId);
+    if (activeFolderId) p.set("folderId", activeFolderId);
+    if (search) p.set("search", search);
+    p.set("sortBy", sortBy);
+    p.set("sortDirection", sortDirection);
+    return `/dev/files/list.json?${p.toString()}`;
+  }, [tenantId, activeFolderId, search, sortBy, sortDirection]);
+
+  const listQuery = useQuery({
+    queryKey: ["dev", "files", "list", listUrl],
+    queryFn: () => fetchJson<ListResponse>(listUrl),
+    enabled: tenantValid,
+  });
+
+  const breadcrumbUrl = useMemo(() => {
+    const p = new URLSearchParams();
+    p.set("tenantId", tenantId);
+    if (activeFolderId) p.set("folderId", activeFolderId);
+    return `/dev/files/breadcrumb.json?${p.toString()}`;
+  }, [tenantId, activeFolderId]);
+
+  const breadcrumbQuery = useQuery({
+    queryKey: ["dev", "files", "breadcrumb", breadcrumbUrl],
+    queryFn: () => fetchJson<BreadcrumbResponse>(breadcrumbUrl),
+    enabled: tenantValid,
+  });
+
+  const createFolder = useMutation({
+    mutationFn: async () => {
+      const res = await fetch("/folders", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-tenant-id": tenantId },
+        body: JSON.stringify({
+          tenantId,
+          parentId: activeFolderId,
+          name: newFolderName,
+        }),
+      });
+      if (!res.ok) throw new Error(`folder create failed (${res.status})`);
+      return res.json();
+    },
+    onSuccess: () => {
+      setNewFolderName("");
+      void queryClient.invalidateQueries({ queryKey: ["dev", "files", "tree"] });
+      void queryClient.invalidateQueries({ queryKey: ["dev", "files", "list"] });
+    },
+  });
+
+  const deleteFile = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/files/${id}`, {
+        method: "DELETE",
+        headers: { "x-tenant-id": tenantId },
+      });
+      if (!res.ok) throw new Error(`file delete failed (${res.status})`);
+      return res.json();
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["dev", "files", "list"] });
+    },
+  });
+
+  const subtitle = tenantValid
+    ? `Tenant: ${tenantId} · ${listQuery.data?.totalCount ?? 0} Dateien im aktiven Ordner`
+    : "Bitte eine gültige Tenant-UUID eingeben oder als Cookie x-tenant-id setzen.";
+
+  return (
+    <AdminShell title="File Manager" subtitle={subtitle} currentNav="files">
+      <div className="admin-card" data-file-manager>
+        <div className="fm-tenant-bar">
+          <TextField
+            label="Tenant-UUID"
+            value={tenantId}
+            onChange={setTenantId}
+            placeholder="00000000-0000-0000-0000-000000000000"
+          />
+          {!tenantValid ? (
+            <span className="admin-meta">UUID muss 8-4-4-4-12 Zeichen lang sein.</span>
+          ) : null}
+        </div>
+        {tenantValid ? (
+          <div className="fm-layout">
+            <aside className="fm-tree" data-fm-region="tree">
+              <header className="fm-tree__header">
+                <strong>Ordner</strong>
+                <button
+                  type="button"
+                  className="fm-tree__rootlink"
+                  onClick={() => setActiveFolderId(null)}
+                  data-action="select-root"
+                  data-active={activeFolderId === null}
+                >
+                  Root
+                </button>
+              </header>
+              {treeQuery.data ? (
+                <FolderTree
+                  nodes={treeQuery.data.tree}
+                  activeId={activeFolderId}
+                  onSelect={setActiveFolderId}
+                />
+              ) : treeQuery.isError ? (
+                <div className="admin-empty">Ordnerbaum konnte nicht geladen werden.</div>
+              ) : (
+                <div className="admin-empty">Lade…</div>
+              )}
+              <form
+                className="fm-tree__create"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  if (newFolderName.trim().length > 0 && !createFolder.isPending) {
+                    createFolder.mutate();
+                  }
+                }}
+              >
+                <TextField
+                  label="Neuer Ordner"
+                  value={newFolderName}
+                  onChange={setNewFolderName}
+                  placeholder="Neuer Ordner"
+                />
+                <Button
+                  variant="ghost"
+                  type="submit"
+                  isDisabled={createFolder.isPending || newFolderName.trim().length === 0}
+                  data-action="create-folder"
+                >
+                  {createFolder.isPending ? "Anlegen…" : "Anlegen"}
+                </Button>
+                {createFolder.isError ? (
+                  <span className="admin-meta">{(createFolder.error as Error).message}</span>
+                ) : null}
+              </form>
+            </aside>
+            <section className="fm-grid" data-fm-region="grid">
+              <div className="fm-breadcrumb" aria-label="Pfad">
+                {breadcrumbQuery.data ? (
+                  <BreadcrumbBar
+                    segments={breadcrumbQuery.data.segments}
+                    onSelect={setActiveFolderId}
+                  />
+                ) : null}
+              </div>
+              <div className="fm-toolbar">
+                <TextField
+                  label="Suche"
+                  value={search}
+                  onChange={setSearch}
+                  placeholder="Dateiname enthält…"
+                />
+                <Select
+                  label="Sortieren nach"
+                  selectedKey={sortBy}
+                  onSelectionChange={(key) => setSortBy(key as SortKey)}
+                >
+                  {SORT_KEYS.map((k) => (
+                    <SelectItem key={k.id} id={k.id}>
+                      {k.label}
+                    </SelectItem>
+                  ))}
+                </Select>
+                <Button
+                  variant="ghost"
+                  onPress={() => setSortDirection((d) => (d === "asc" ? "desc" : "asc"))}
+                  data-action="toggle-direction"
+                >
+                  {sortDirection === "asc" ? "↑ aufsteigend" : "↓ absteigend"}
+                </Button>
+              </div>
+              {listQuery.isError ? (
+                <div className="admin-empty">Datei-Liste konnte nicht geladen werden.</div>
+              ) : !listQuery.data ? (
+                <div className="admin-empty">Lade…</div>
+              ) : listQuery.data.files.length === 0 ? (
+                <div className="admin-empty">Keine Dateien in diesem Ordner.</div>
+              ) : (
+                <FileGrid
+                  files={listQuery.data.files}
+                  onDelete={(id) => deleteFile.mutate(id)}
+                  isDeleting={deleteFile.isPending}
+                />
+              )}
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </AdminShell>
+  );
+}
+
+function FolderTree({
+  nodes,
+  activeId,
+  onSelect,
+}: {
+  nodes: FolderTreeNodeDto[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}): ReactNode {
+  if (nodes.length === 0) {
+    return <div className="admin-empty">Keine Ordner.</div>;
+  }
+  return (
+    <ul className="fm-tree__list" role="tree">
+      {nodes.map((n) => (
+        <FolderTreeNode key={n.id} node={n} activeId={activeId} onSelect={onSelect} />
+      ))}
+    </ul>
+  );
+}
+
+function FolderTreeNode({
+  node,
+  activeId,
+  onSelect,
+}: {
+  node: FolderTreeNodeDto;
+  activeId: string | null;
+  onSelect: (id: string) => void;
+}): ReactNode {
+  const isActive = activeId === node.id;
+  return (
+    <li role="treeitem" aria-selected={isActive} data-folder-id={node.id}>
+      <button
+        type="button"
+        className="fm-tree__node"
+        data-active={isActive}
+        style={{ paddingLeft: `${node.depth * 12}px` }}
+        onClick={() => onSelect(node.id)}
+      >
+        {node.name}
+      </button>
+      {node.children.length > 0 ? (
+        <ul className="fm-tree__list">
+          {node.children.map((c) => (
+            <FolderTreeNode key={c.id} node={c} activeId={activeId} onSelect={onSelect} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function BreadcrumbBar({
+  segments,
+  onSelect,
+}: {
+  segments: BreadcrumbSegment[];
+  onSelect: (id: string | null) => void;
+}): ReactNode {
+  return (
+    <ol className="fm-breadcrumb__list">
+      {segments.map((seg, idx) => (
+        <li key={`${seg.id ?? "root"}-${idx}`} className="fm-breadcrumb__seg">
+          {idx > 0 ? <span className="fm-breadcrumb__sep">/</span> : null}
+          <button
+            type="button"
+            className="fm-breadcrumb__link"
+            onClick={() => onSelect(seg.id)}
+            data-active={idx === segments.length - 1}
+          >
+            {seg.name}
+          </button>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function FileGrid({
+  files,
+  onDelete,
+  isDeleting,
+}: {
+  files: FileEntryDto[];
+  onDelete: (id: string) => void;
+  isDeleting: boolean;
+}): ReactNode {
+  return (
+    <ul className="fm-cards" role="list">
+      {files.map((f) => (
+        <li key={f.id} className="fm-card" data-file-id={f.id}>
+          <div className="fm-card__thumb">
+            {f.thumbnailUrl ? (
+              <img src={f.thumbnailUrl} alt="" loading="lazy" />
+            ) : (
+              <span className="fm-card__icon" aria-hidden="true">
+                {iconForMime(f.mimeType)}
+              </span>
+            )}
+          </div>
+          <div className="fm-card__meta">
+            <strong className="fm-card__name" title={f.filename}>
+              {f.filename}
+            </strong>
+            <span className="admin-meta">
+              {formatBytes(f.sizeBytes)} · {f.mimeType}
+            </span>
+          </div>
+          <div className="fm-card__actions">
+            <Button
+              variant="ghost"
+              isDisabled={isDeleting}
+              onPress={() => {
+                if (typeof window !== "undefined" && !window.confirm(`Löschen: ${f.filename}?`))
+                  return;
+                onDelete(f.id);
+              }}
+              data-action="delete-file"
+            >
+              Löschen
+            </Button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function iconForMime(mime: string): string {
+  if (mime.startsWith("image/")) return "IMG";
+  if (mime.startsWith("video/")) return "VID";
+  if (mime.startsWith("audio/")) return "AUD";
+  if (mime.startsWith("text/")) return "TXT";
+  if (mime === "application/pdf") return "PDF";
+  return "FILE";
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+/**
+ * Read a default tenant id from the `x-tenant-id` cookie if present.
+ * The dev-surface lets operators paste a UUID directly when no cookie
+ * is set; production gating is the controller-side `assertDev()`.
+ */
+function readDefaultTenantId(): string {
+  if (typeof document === "undefined") return "";
+  const match = /(?:^|; )x-tenant-id=([^;]+)/.exec(document.cookie);
+  if (!match || !match[1]) return "";
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return "";
+  }
+}

--- a/src/core/dx/clients/styles/admin-layout.css
+++ b/src/core/dx/clients/styles/admin-layout.css
@@ -3202,3 +3202,210 @@ pre.payload {
   padding-left: 1.1rem;
   list-style: disc;
 }
+
+/* ── File Manager (/dev/files) ─────────────────────────────────────── */
+[data-file-manager] {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.fm-tenant-bar {
+  display: flex;
+  align-items: end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.fm-layout {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 1rem;
+  min-height: 30rem;
+}
+.fm-tree {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: auto;
+  max-height: 65dvh;
+  min-height: 14rem;
+}
+.fm-tree__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+.fm-tree__rootlink {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--fg-muted);
+  padding: 0.2rem 0.55rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  transition:
+    color 120ms var(--ease-out),
+    border-color 120ms var(--ease-out);
+}
+.fm-tree__rootlink[data-active="true"] {
+  color: var(--accent-ink);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.fm-tree__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.fm-tree__node {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--fg);
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 120ms var(--ease-out);
+}
+.fm-tree__node:hover {
+  background: var(--surface-hover);
+}
+.fm-tree__node[data-active="true"] {
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  border-color: var(--accent);
+}
+.fm-tree__create {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--line);
+}
+.fm-grid {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow: auto;
+  max-height: 65dvh;
+  min-height: 14rem;
+}
+.fm-breadcrumb__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+.fm-breadcrumb__seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.fm-breadcrumb__sep {
+  color: var(--fg-faint);
+}
+.fm-breadcrumb__link {
+  background: transparent;
+  border: 0;
+  color: var(--fg-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--radius-sm);
+}
+.fm-breadcrumb__link:hover {
+  color: var(--fg);
+  background: var(--surface-hover);
+}
+.fm-breadcrumb__link[data-active="true"] {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+}
+.fm-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: end;
+}
+.fm-cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+.fm-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  transition: border-color 120ms var(--ease-out);
+}
+.fm-card:hover {
+  border-color: var(--line-strong);
+}
+.fm-card__thumb {
+  width: 100%;
+  aspect-ratio: 1;
+  background: var(--surface-3);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.fm-card__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.fm-card__icon {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  letter-spacing: 0.08em;
+}
+.fm-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.fm-card__name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fm-card__actions {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/core/dx/dev-files.controller.ts
+++ b/src/core/dx/dev-files.controller.ts
@@ -1,0 +1,283 @@
+/**
+ * `/dev/files*` — JSON sidecars for the Dev-Portal File-Manager (issue #18).
+ *
+ * The React page at `/dev/files` reads three sidecar endpoints to
+ * populate its two-column layout:
+ *   - `/dev/files/tree.json`        — recursive folder hierarchy (left rail)
+ *   - `/dev/files/list.json`        — files in the active folder (grid)
+ *   - `/dev/files/breadcrumb.json`  — root-to-active path (header)
+ *
+ * Every endpoint 404s outside `NODE_ENV=development`, identical to
+ * the rest of the dev-hub. The controller is mounted unconditionally
+ * by `DevHubModule` so route discovery (`/dev/routes`) sees it on the
+ * inventory. The `assertDev()` short-circuit keeps the surface from
+ * leaking in a production build.
+ *
+ * Tenant scoping: every endpoint requires the `x-tenant-id` header
+ * (the `TenantInterceptor` validates it). RLS is the last-resort
+ * backstop, but we explicitly scope all reads by tenant id so a
+ * misconfigured RLS policy can never cross-leak.
+ *
+ * The page itself (`GET /dev/files`) is served by the existing
+ * splat-catchall on `DevHubController` — react-router takes over from
+ * the SPA shell.
+ */
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Header,
+  Headers,
+  NotFoundException,
+  Query,
+} from "@nestjs/common";
+
+import { buildDevPortalShellInput, renderDevPortalShell } from "./dev-portal-shell.js";
+import {
+  buildFolderBreadcrumb,
+  type BreadcrumbInput,
+  type BreadcrumbSegment,
+} from "../files/file-manager-breadcrumb.js";
+import { applyFileSearch, type FileSearchSortKey } from "../files/file-manager-search.js";
+import { buildFolderTree, type FolderTreeNode } from "../files/file-manager-tree.js";
+import { PrismaService } from "../prisma/prisma.service.js";
+import { serverConfigFromEnv } from "../server/server-config.js";
+
+interface FileListEntry {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  updatedAt: string;
+  folderId: string | null;
+  storageKey: string;
+  /** IPX thumbnail URL — populated only for `image/*` MIME types. */
+  thumbnailUrl?: string;
+}
+
+interface FileTreeResponse {
+  tree: FolderTreeNode[];
+}
+
+interface FileListResponse {
+  files: FileListEntry[];
+  totalCount: number;
+}
+
+interface BreadcrumbResponse {
+  segments: BreadcrumbSegment[];
+}
+
+@Controller("dev/files")
+export class DevFilesController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * `GET /dev/files` — SPA shell HTML.
+   *
+   * Mirrors the other dev-portal pages: emits the same shell that
+   * `DevHubController.spaCatchAll` would have produced. Listing it
+   * explicitly here means route inventory shows `/dev/files` as a
+   * first-class route instead of "covered by splat".
+   */
+  @Get()
+  @Header("content-type", "text/html; charset=utf-8")
+  page(): string {
+    this.assertDev();
+    return renderDevPortalShell(
+      buildDevPortalShellInput({ title: "File Manager", brand: "central" }),
+    );
+  }
+
+  @Get("tree.json")
+  async tree(
+    @Query("tenantId") tenantQuery: string | undefined,
+    @Headers("x-tenant-id") tenantHeader: string | undefined,
+  ): Promise<FileTreeResponse> {
+    this.assertDev();
+    const tenantId = this.resolveTenantId(tenantQuery, tenantHeader);
+    const folders = await this.prisma.folder.findMany({
+      where: { tenantId, deletedAt: null },
+      select: { id: true, name: true, parentId: true, tenantId: true },
+    });
+    const tree = buildFolderTree(folders);
+    return { tree };
+  }
+
+  @Get("list.json")
+  async list(
+    @Query("tenantId") tenantQuery: string | undefined,
+    @Query("folderId") folderId: string | undefined,
+    @Query("search") search: string | undefined,
+    @Query("mimeTypePrefix") mimeTypePrefix: string | undefined,
+    @Query("sortBy") sortBy: string | undefined,
+    @Query("sortDirection") sortDirection: string | undefined,
+    @Query("limit") limitRaw: string | undefined,
+    @Headers("x-tenant-id") tenantHeader: string | undefined,
+  ): Promise<FileListResponse> {
+    this.assertDev();
+    const tenantId = this.resolveTenantId(tenantQuery, tenantHeader);
+    const effectiveFolderId =
+      folderId === "" || folderId === undefined || folderId === "null" ? null : folderId;
+
+    // Defense in depth: explicit tenant filter on top of RLS so a
+    // misconfigured policy can never cross-leak. Soft-deleted rows
+    // are skipped by the `deletedAt: null` predicate.
+    const rows = await this.prisma.file.findMany({
+      where: {
+        tenantId,
+        folderId: effectiveFolderId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        filename: true,
+        mimeType: true,
+        sizeBytes: true,
+        createdAt: true,
+        updatedAt: true,
+        folderId: true,
+        storageKey: true,
+      },
+    });
+
+    const search$1 = search ?? undefined;
+    const mime$1 = mimeTypePrefix ?? undefined;
+    const sortKey = parseSortKey(sortBy);
+    const direction = sortDirection === "desc" ? "desc" : "asc";
+    const limit = parsePositiveInt(limitRaw);
+
+    const filtered = applyFileSearch(
+      rows.map((r) => ({
+        id: r.id,
+        filename: r.filename,
+        mimeType: r.mimeType,
+        sizeBytes: r.sizeBytes,
+        createdAt: r.createdAt.toISOString(),
+        updatedAt: r.updatedAt.toISOString(),
+        folderId: r.folderId,
+        storageKey: r.storageKey,
+      })),
+      {
+        ...(search$1 !== undefined ? { search: search$1 } : {}),
+        ...(mime$1 !== undefined ? { mimeTypePrefix: mime$1 } : {}),
+        ...(sortKey !== undefined ? { sortBy: sortKey } : {}),
+        sortDirection: direction,
+        ...(limit !== undefined ? { limit } : {}),
+      },
+    );
+
+    const files: FileListEntry[] = filtered.map((f) => {
+      const entry: FileListEntry = {
+        id: f.id,
+        filename: f.filename,
+        mimeType: f.mimeType,
+        sizeBytes: f.sizeBytes,
+        createdAt: f.createdAt,
+        updatedAt: f.updatedAt,
+        folderId: f.folderId,
+        storageKey: f.storageKey,
+      };
+      const thumb = thumbnailUrlFor(f.mimeType, f.storageKey);
+      if (thumb !== undefined) entry.thumbnailUrl = thumb;
+      return entry;
+    });
+
+    return { files, totalCount: rows.length };
+  }
+
+  @Get("breadcrumb.json")
+  async breadcrumb(
+    @Query("tenantId") tenantQuery: string | undefined,
+    @Query("folderId") folderId: string | undefined,
+    @Headers("x-tenant-id") tenantHeader: string | undefined,
+  ): Promise<BreadcrumbResponse> {
+    this.assertDev();
+    const tenantId = this.resolveTenantId(tenantQuery, tenantHeader);
+    const activeId = folderId === "" || folderId === undefined ? null : folderId;
+    if (activeId === null) {
+      return { segments: buildFolderBreadcrumb({ activeId: null, folders: [] }) };
+    }
+    const folders = (await this.prisma.folder.findMany({
+      where: { tenantId, deletedAt: null },
+      select: { id: true, name: true, parentId: true, tenantId: true },
+    })) as BreadcrumbInput[];
+    return { segments: buildFolderBreadcrumb({ activeId, folders }) };
+  }
+
+  private assertDev(): void {
+    const cfg = serverConfigFromEnv(process.env);
+    if (cfg.env !== "development") {
+      throw new NotFoundException();
+    }
+  }
+
+  /**
+   * `/dev/*` paths are exempt from the TenantInterceptor (see
+   * `tenant-guard.ts`'s `EXEMPT_PREFIXES`), so the AsyncLocalStorage
+   * is empty for these handlers. We read the header directly and let
+   * the caller override via `?tenantId=` for ease of debugging from
+   * the React page.
+   *
+   * Defense in depth: explicit UUID check on the resolved value so a
+   * misbehaving operator cannot smuggle a non-UUID into Prisma queries.
+   */
+  private resolveTenantId(
+    queryParam: string | undefined,
+    headerValue: string | undefined,
+  ): string {
+    const candidate = (queryParam ?? headerValue ?? "").trim();
+    if (!candidate) {
+      throw new BadRequestException("tenantId required (header or ?tenantId=)");
+    }
+    if (!isUuid(candidate)) {
+      throw new BadRequestException("tenantId must be a UUID");
+    }
+    return candidate;
+  }
+}
+
+function parseSortKey(value: string | undefined): FileSearchSortKey | undefined {
+  if (value === undefined) return undefined;
+  const allowed: ReadonlySet<FileSearchSortKey> = new Set([
+    "name",
+    "size",
+    "createdAt",
+    "updatedAt",
+    "mimeType",
+  ]);
+  return allowed.has(value as FileSearchSortKey) ? (value as FileSearchSortKey) : undefined;
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) return undefined;
+  return n;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+/**
+ * Build the IPX thumbnail URL for an image file. Non-image MIME types
+ * yield `undefined` so the React grid falls back to the icon-by-mime
+ * placeholder instead of a broken `<img>`.
+ *
+ * Path shape: `/_ipx/<modifiers>/files/<storageKey>` per issue #17 +
+ * #18 spec. The `preset_thumbnail` modifier resolves to the `thumbnail`
+ * preset (200×200 cover WebP) registered in `asset-presets.ts`.
+ */
+export function thumbnailUrlFor(mimeType: string, storageKey: string): string | undefined {
+  if (!mimeType.toLowerCase().startsWith("image/")) return undefined;
+  // Each segment of the storage key may contain `/`; we encode the
+  // whole thing as a single URI component so the IPX router treats it
+  // as the source identifier.
+  const encoded = storageKey
+    .split("/")
+    .map((s) => encodeURIComponent(s))
+    .join("/");
+  return `/_ipx/preset_thumbnail/files/${encoded}`;
+}

--- a/src/core/dx/dev-files.controller.ts
+++ b/src/core/dx/dev-files.controller.ts
@@ -223,10 +223,7 @@ export class DevFilesController {
    * Defense in depth: explicit UUID check on the resolved value so a
    * misbehaving operator cannot smuggle a non-UUID into Prisma queries.
    */
-  private resolveTenantId(
-    queryParam: string | undefined,
-    headerValue: string | undefined,
-  ): string {
+  private resolveTenantId(queryParam: string | undefined, headerValue: string | undefined): string {
     const candidate = (queryParam ?? headerValue ?? "").trim();
     if (!candidate) {
       throw new BadRequestException("tenantId required (header or ?tenantId=)");

--- a/src/core/dx/dev-hub.module.ts
+++ b/src/core/dx/dev-hub.module.ts
@@ -3,6 +3,7 @@ import { DiscoveryModule } from "@nestjs/core";
 
 import { JobsModule } from "../jobs/jobs.module.js";
 import { AdminSpaController } from "./admin-spa.controller.js";
+import { DevFilesController } from "./dev-files.controller.js";
 import { DevHubController } from "./dev-hub.controller.js";
 import { MigrationsService } from "./migrations/migrations.service.js";
 import { RouteInventoryService } from "./route-inventory-runner.js";
@@ -27,7 +28,10 @@ import { RealtimeModule } from "../realtime/realtime.module.js";
  */
 @Module({
   imports: [DiscoveryModule, JobsModule, RealtimeModule],
-  controllers: [DevHubController, AdminSpaController],
+  // Order matters: `DevFilesController` registers before `DevHubController`
+  // so its specific `/dev/files/*.json` routes win over the latter's
+  // `@Get('*splat')` SPA-shell catch-all.
+  controllers: [DevFilesController, AdminSpaController, DevHubController],
   providers: [RouteInventoryService, MigrationsService],
   exports: [RouteInventoryService],
 })

--- a/src/core/files/file-manager-breadcrumb.ts
+++ b/src/core/files/file-manager-breadcrumb.ts
@@ -1,0 +1,58 @@
+/**
+ * File-Manager breadcrumb planner.
+ *
+ * Walks the parent chain from `activeId` back to the root, returning a
+ * list of `{ id, name }` segments. The synthetic "Root" segment with
+ * `id: null` always sits at the head so the UI can render
+ * `Root / customers / acme / invoices`.
+ *
+ * Story coverage: `tests/stories/file-manager-breadcrumb.story.test.ts`.
+ */
+
+export interface BreadcrumbInput {
+  id: string;
+  tenantId: string;
+  parentId: string | null;
+  name: string;
+}
+
+export interface BreadcrumbSegment {
+  id: string | null;
+  name: string;
+}
+
+export interface BuildBreadcrumbOptions {
+  activeId: string | null;
+  folders: readonly BreadcrumbInput[];
+}
+
+/**
+ * Returns Root → … → active. The walk is bounded by the visited set
+ * so a corrupt parent chain cannot loop forever.
+ */
+export function buildFolderBreadcrumb(opts: BuildBreadcrumbOptions): BreadcrumbSegment[] {
+  const root: BreadcrumbSegment = { id: null, name: "Root" };
+  if (opts.activeId === null) return [root];
+
+  const byId = new Map<string, BreadcrumbInput>();
+  for (const folder of opts.folders) {
+    byId.set(folder.id, folder);
+  }
+
+  const active = byId.get(opts.activeId);
+  if (!active) return [root];
+
+  // Walk parents until we hit the root or a cycle. The path is built
+  // tail-first then reversed.
+  const tail: BreadcrumbSegment[] = [];
+  const visited = new Set<string>();
+  let cursor: BreadcrumbInput | undefined = active;
+  while (cursor && !visited.has(cursor.id)) {
+    visited.add(cursor.id);
+    tail.push({ id: cursor.id, name: cursor.name });
+    if (cursor.parentId === null) break;
+    cursor = byId.get(cursor.parentId);
+  }
+  tail.reverse();
+  return [root, ...tail];
+}

--- a/src/core/files/file-manager-search.ts
+++ b/src/core/files/file-manager-search.ts
@@ -1,0 +1,87 @@
+/**
+ * File-Manager sort + filter planner.
+ *
+ * Pure function used by both the React file-grid (client-side, ≤ 500
+ * files) and the server's list endpoint (above 500 files, server-side).
+ * Stable, deterministic, no I/O.
+ *
+ * Story coverage: `tests/stories/file-manager-search.story.test.ts`.
+ */
+
+export interface FileSearchInput {
+  id: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type FileSearchSortKey = "name" | "size" | "createdAt" | "updatedAt" | "mimeType";
+export type FileSearchSortDirection = "asc" | "desc";
+
+export interface FileSearchOptions {
+  /** Free-text substring match against `filename` (case-insensitive). */
+  search?: string;
+  /** MIME-type prefix match (e.g. `image/`). Case-insensitive. */
+  mimeTypePrefix?: string;
+  sortBy?: FileSearchSortKey;
+  sortDirection?: FileSearchSortDirection;
+  /** Cap on the returned slice. Applied after sort. */
+  limit?: number;
+}
+
+const collator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true });
+
+const SORT_KEYS: ReadonlySet<FileSearchSortKey> = new Set([
+  "name",
+  "size",
+  "createdAt",
+  "updatedAt",
+  "mimeType",
+]);
+
+/**
+ * Apply the supplied filter + sort + limit options to a flat file
+ * array. Returns a new array; the input is not mutated.
+ */
+export function applyFileSearch<T extends FileSearchInput>(
+  input: readonly T[],
+  opts: FileSearchOptions,
+): T[] {
+  const search = opts.search?.trim().toLowerCase() ?? "";
+  const mimePrefix = opts.mimeTypePrefix?.trim().toLowerCase() ?? "";
+  const filtered = input.filter((f) => {
+    if (search && !f.filename.toLowerCase().includes(search)) return false;
+    if (mimePrefix && !f.mimeType.toLowerCase().startsWith(mimePrefix)) return false;
+    return true;
+  });
+
+  const sortKey: FileSearchSortKey = SORT_KEYS.has(opts.sortBy as FileSearchSortKey)
+    ? (opts.sortBy as FileSearchSortKey)
+    : "name";
+  const direction: FileSearchSortDirection = opts.sortDirection === "desc" ? "desc" : "asc";
+  const sorted = [...filtered].sort((a, b) => compare(a, b, sortKey));
+  if (direction === "desc") sorted.reverse();
+
+  if (opts.limit !== undefined && opts.limit >= 0 && sorted.length > opts.limit) {
+    return sorted.slice(0, opts.limit);
+  }
+  return sorted;
+}
+
+function compare(a: FileSearchInput, b: FileSearchInput, key: FileSearchSortKey): number {
+  switch (key) {
+    case "size":
+      return a.sizeBytes - b.sizeBytes;
+    case "createdAt":
+      return Date.parse(a.createdAt) - Date.parse(b.createdAt);
+    case "updatedAt":
+      return Date.parse(a.updatedAt) - Date.parse(b.updatedAt);
+    case "mimeType":
+      return collator.compare(a.mimeType, b.mimeType);
+    case "name":
+    default:
+      return collator.compare(a.filename, b.filename);
+  }
+}

--- a/src/core/files/file-manager-tree.ts
+++ b/src/core/files/file-manager-tree.ts
@@ -1,0 +1,149 @@
+/**
+ * File-Manager folder-tree planner.
+ *
+ * Pure function: turns a flat `FolderRecord[]` into a recursive tree
+ * sorted alphabetically (case-insensitive) at every level. The Dev-Portal
+ * File-Manager renders this tree on the left side of the two-column
+ * layout. Keeping the algorithm pure so the React component never has
+ * to maintain incremental insertion logic.
+ *
+ * The planner tolerates corrupt input — orphans (parentId pointing at
+ * an unknown folder) get promoted to root; cycles are broken
+ * deterministically. A half-loaded list still renders rather than
+ * crashing the UI.
+ *
+ * Story coverage: `tests/stories/file-manager-tree.story.test.ts`.
+ */
+
+export interface FolderTreeInput {
+  id: string;
+  tenantId: string;
+  parentId: string | null;
+  name: string;
+}
+
+export interface FolderTreePathSegment {
+  id: string;
+  name: string;
+}
+
+export interface FolderTreeNode {
+  id: string;
+  tenantId: string;
+  parentId: string | null;
+  name: string;
+  depth: number;
+  /** Root-to-node trail. The last entry is the node itself. */
+  path: FolderTreePathSegment[];
+  children: FolderTreeNode[];
+}
+
+const collator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true });
+
+/**
+ * Build a recursive tree from a flat folder list.
+ *
+ * Algorithm:
+ *   1. Index folders by id; track which ids exist.
+ *   2. For each folder, decide its effective parent:
+ *      - `null` if `parentId` is null or unknown (orphan promoted to root)
+ *      - the resolved parent otherwise
+ *   3. Walk roots down; on each step we track the visited set so
+ *      cycles cannot recurse forever.
+ *   4. Sort siblings on every level by name (case-insensitive,
+ *      numeric-aware so `Folder 2` < `Folder 10`).
+ */
+export function buildFolderTree(input: readonly FolderTreeInput[]): FolderTreeNode[] {
+  const byId = new Map<string, FolderTreeInput>();
+  for (const folder of input) {
+    byId.set(folder.id, folder);
+  }
+
+  const childrenByParent = new Map<string | null, FolderTreeInput[]>();
+  for (const folder of input) {
+    const parent = folder.parentId !== null && byId.has(folder.parentId) ? folder.parentId : null;
+    const list = childrenByParent.get(parent) ?? [];
+    list.push(folder);
+    childrenByParent.set(parent, list);
+  }
+
+  // Cycle break: when every folder has a known parent (no nulls), the
+  // root list is empty. We promote one node per orphan-cluster up to
+  // root so the entire input still surfaces. The promoted node is the
+  // lexicographically first id that hasn't been reached from the
+  // synthetic root yet — deterministic across reruns.
+  const reachable = new Set<string>();
+  const collectReachable = (parentId: string | null, visited: Set<string>): void => {
+    const list = childrenByParent.get(parentId) ?? [];
+    for (const f of list) {
+      if (visited.has(f.id)) continue;
+      visited.add(f.id);
+      reachable.add(f.id);
+      collectReachable(f.id, visited);
+    }
+  };
+  collectReachable(null, new Set<string>());
+  if (reachable.size < input.length) {
+    const orphanIds = input
+      .map((f) => f.id)
+      .filter((id) => !reachable.has(id))
+      .sort();
+    for (const id of orphanIds) {
+      if (reachable.has(id)) continue;
+      const folder = byId.get(id);
+      if (!folder) continue;
+      // Detach: remove from its current parent's child list, attach as root.
+      const oldParent = folder.parentId !== null && byId.has(folder.parentId) ? folder.parentId : null;
+      const oldList = childrenByParent.get(oldParent);
+      if (oldList) {
+        childrenByParent.set(
+          oldParent,
+          oldList.filter((f) => f.id !== id),
+        );
+      }
+      const rootList = childrenByParent.get(null) ?? [];
+      rootList.push(folder);
+      childrenByParent.set(null, rootList);
+      // Walk the now-reachable subtree to mark its members.
+      const visited = new Set<string>([id]);
+      reachable.add(id);
+      collectReachable(id, visited);
+    }
+  }
+
+  // Cycle-detection: every node tracks the visited set on its way down
+  // through `walk`. A folder that is its own ancestor is dropped from
+  // its parent's children list — its subtree still surfaces because it
+  // was already attached on a higher level.
+  const walk = (
+    parentId: string | null,
+    depth: number,
+    visited: ReadonlySet<string>,
+    parentPath: readonly FolderTreePathSegment[],
+  ): FolderTreeNode[] => {
+    const raw = childrenByParent.get(parentId) ?? [];
+    const sorted = [...raw].sort((a, b) => collator.compare(a.name, b.name));
+    const out: FolderTreeNode[] = [];
+    for (const folder of sorted) {
+      if (visited.has(folder.id)) {
+        continue;
+      }
+      const next = new Set(visited);
+      next.add(folder.id);
+      const path = [...parentPath, { id: folder.id, name: folder.name }];
+      const children = walk(folder.id, depth + 1, next, path);
+      out.push({
+        id: folder.id,
+        tenantId: folder.tenantId,
+        parentId: folder.parentId,
+        name: folder.name,
+        depth,
+        path,
+        children,
+      });
+    }
+    return out;
+  };
+
+  return walk(null, 0, new Set<string>(), []);
+}

--- a/src/core/files/file-manager-tree.ts
+++ b/src/core/files/file-manager-tree.ts
@@ -93,7 +93,8 @@ export function buildFolderTree(input: readonly FolderTreeInput[]): FolderTreeNo
       const folder = byId.get(id);
       if (!folder) continue;
       // Detach: remove from its current parent's child list, attach as root.
-      const oldParent = folder.parentId !== null && byId.has(folder.parentId) ? folder.parentId : null;
+      const oldParent =
+        folder.parentId !== null && byId.has(folder.parentId) ? folder.parentId : null;
       const oldList = childrenByParent.get(oldParent);
       if (oldList) {
         childrenByParent.set(

--- a/tests/file-manager-dev-hub.e2e-spec.ts
+++ b/tests/file-manager-dev-hub.e2e-spec.ts
@@ -1,0 +1,269 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { PrismaService } from "../src/core/prisma/prisma.service.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * `/dev/files*` — JSON sidecars that drive the File-Manager React page
+ * (issue #18).
+ *
+ * Surface contract:
+ *   - GET /dev/files                   → SPA shell HTML
+ *   - GET /dev/files/tree.json         → folder tree (root + children, recursive)
+ *   - GET /dev/files/list.json         → files in a folder, with sort/filter
+ *   - GET /dev/files/breadcrumb.json   → root-to-active path
+ *
+ * Every endpoint 404s outside `NODE_ENV=development`, identical to the
+ * rest of the dev-hub.
+ */
+describe("Dev-Hub File-Manager · /dev/files*", () => {
+  describe("in development mode", () => {
+    let app: INestApplication;
+    let prisma: PrismaService;
+    let tenantId: string;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "development";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+      prisma = app.get(PrismaService);
+      const tenant = await prisma.tenant.create({
+        data: { name: `files-dev-hub-${Date.now()}` },
+      });
+      tenantId = tenant.id;
+    });
+
+    afterAll(async () => {
+      try {
+        await prisma.file.deleteMany({ where: { tenantId } });
+        await prisma.folder.deleteMany({ where: { tenantId } });
+        await prisma.tenant.delete({ where: { id: tenantId } });
+      } catch {
+        // best-effort
+      }
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("GET /dev/files returns the SPA shell HTML", async () => {
+      const res = await request(app.getHttpServer()).get("/dev/files");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/text\/html/);
+      expect(res.text).toContain('<div id="root"></div>');
+    });
+
+    it("GET /dev/files/tree.json returns an empty tree for an empty tenant", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/dev/files/tree.json")
+        .set("x-tenant-id", tenantId);
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/application\/json/);
+      expect(Array.isArray(res.body.tree)).toBe(true);
+      expect(res.body.tree).toEqual([]);
+    });
+
+    it("GET /dev/files/tree.json returns the folder hierarchy after seeding", async () => {
+      const root = await prisma.folder.create({
+        data: { tenantId, parentId: null, name: "Customers" },
+      });
+      const child = await prisma.folder.create({
+        data: { tenantId, parentId: root.id, name: "Acme" },
+      });
+      try {
+        const res = await request(app.getHttpServer())
+          .get("/dev/files/tree.json")
+          .set("x-tenant-id", tenantId);
+        expect(res.status).toBe(200);
+        expect(res.body.tree).toHaveLength(1);
+        expect(res.body.tree[0].name).toBe("Customers");
+        expect(res.body.tree[0].children).toHaveLength(1);
+        expect(res.body.tree[0].children[0].name).toBe("Acme");
+      } finally {
+        await prisma.folder.delete({ where: { id: child.id } });
+        await prisma.folder.delete({ where: { id: root.id } });
+      }
+    });
+
+    it("GET /dev/files/list.json returns files in the requested folder with metadata", async () => {
+      const folder = await prisma.folder.create({
+        data: { tenantId, parentId: null, name: "Reports" },
+      });
+      const fileRow = await prisma.file.create({
+        data: {
+          tenantId,
+          folderId: folder.id,
+          filename: "annual.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1024,
+          sha256: "0".repeat(64),
+          storageDriver: "local",
+          storageKey: `${tenantId}/${folder.id}/annual.pdf`,
+          uploaderId: "00000000-0000-0000-0000-000000000099",
+        },
+      });
+      try {
+        const res = await request(app.getHttpServer())
+          .get(`/dev/files/list.json?folderId=${folder.id}`)
+          .set("x-tenant-id", tenantId);
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.files)).toBe(true);
+        const matched = (res.body.files as Array<{ id: string; filename: string; thumbnailUrl?: string }>).find(
+          (f) => f.id === fileRow.id,
+        );
+        expect(matched).toBeDefined();
+        expect(matched!.filename).toBe("annual.pdf");
+        expect(typeof res.body.totalCount).toBe("number");
+      } finally {
+        await prisma.file.delete({ where: { id: fileRow.id } });
+        await prisma.folder.delete({ where: { id: folder.id } });
+      }
+    });
+
+    it("GET /dev/files/list.json filters by `search` substring", async () => {
+      const folder = await prisma.folder.create({
+        data: { tenantId, parentId: null, name: "Filter" },
+      });
+      const a = await prisma.file.create({
+        data: {
+          tenantId,
+          folderId: folder.id,
+          filename: "invoice.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1,
+          sha256: "0".repeat(64),
+          storageDriver: "local",
+          storageKey: `${tenantId}/${folder.id}/invoice.pdf`,
+          uploaderId: "00000000-0000-0000-0000-000000000099",
+        },
+      });
+      const b = await prisma.file.create({
+        data: {
+          tenantId,
+          folderId: folder.id,
+          filename: "report.docx",
+          mimeType: "application/msword",
+          sizeBytes: 1,
+          sha256: "0".repeat(64),
+          storageDriver: "local",
+          storageKey: `${tenantId}/${folder.id}/report.docx`,
+          uploaderId: "00000000-0000-0000-0000-000000000099",
+        },
+      });
+      try {
+        const res = await request(app.getHttpServer())
+          .get(`/dev/files/list.json?folderId=${folder.id}&search=invoice`)
+          .set("x-tenant-id", tenantId);
+        expect(res.status).toBe(200);
+        const ids = (res.body.files as Array<{ id: string }>).map((f) => f.id);
+        expect(ids).toContain(a.id);
+        expect(ids).not.toContain(b.id);
+      } finally {
+        await prisma.file.delete({ where: { id: a.id } });
+        await prisma.file.delete({ where: { id: b.id } });
+        await prisma.folder.delete({ where: { id: folder.id } });
+      }
+    });
+
+    it("GET /dev/files/list.json injects an IPX thumbnailUrl for image mime-types", async () => {
+      const fileRow = await prisma.file.create({
+        data: {
+          tenantId,
+          folderId: null,
+          filename: "logo.png",
+          mimeType: "image/png",
+          sizeBytes: 2048,
+          sha256: "0".repeat(64),
+          storageDriver: "local",
+          storageKey: `${tenantId}/null/logo.png`,
+          uploaderId: "00000000-0000-0000-0000-000000000099",
+        },
+      });
+      try {
+        const res = await request(app.getHttpServer())
+          .get("/dev/files/list.json")
+          .set("x-tenant-id", tenantId);
+        expect(res.status).toBe(200);
+        const matched = (
+          res.body.files as Array<{ id: string; thumbnailUrl?: string; mimeType: string }>
+        ).find((f) => f.id === fileRow.id);
+        expect(matched).toBeDefined();
+        // Image rows get an IPX thumbnail URL; non-image rows should
+        // not. The shape isn't asserted byte-for-byte, but it must
+        // route through `/_ipx/` so the React grid can <img src>.
+        expect(matched!.thumbnailUrl).toBeDefined();
+        expect(matched!.thumbnailUrl).toContain("/_ipx/");
+      } finally {
+        await prisma.file.delete({ where: { id: fileRow.id } });
+      }
+    });
+
+    it("GET /dev/files/breadcrumb.json returns Root for activeId=null", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/dev/files/breadcrumb.json")
+        .set("x-tenant-id", tenantId);
+      expect(res.status).toBe(200);
+      expect(res.body.segments).toEqual([{ id: null, name: "Root" }]);
+    });
+
+    it("GET /dev/files/breadcrumb.json walks the parent chain back to the root", async () => {
+      const root = await prisma.folder.create({
+        data: { tenantId, parentId: null, name: "Customers" },
+      });
+      const child = await prisma.folder.create({
+        data: { tenantId, parentId: root.id, name: "Acme" },
+      });
+      try {
+        const res = await request(app.getHttpServer())
+          .get(`/dev/files/breadcrumb.json?folderId=${child.id}`)
+          .set("x-tenant-id", tenantId);
+        expect(res.status).toBe(200);
+        expect(res.body.segments).toEqual([
+          { id: null, name: "Root" },
+          { id: root.id, name: "Customers" },
+          { id: child.id, name: "Acme" },
+        ]);
+      } finally {
+        await prisma.folder.delete({ where: { id: child.id } });
+        await prisma.folder.delete({ where: { id: root.id } });
+      }
+    });
+  });
+
+  describe("outside development mode", () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+      process.env.NODE_ENV = "production";
+      app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    });
+
+    afterAll(async () => {
+      await app.close();
+      process.env.NODE_ENV = "test";
+    });
+
+    it("GET /dev/files/tree.json 404s in production", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/dev/files/tree.json")
+        .set("x-tenant-id", "00000000-0000-0000-0000-000000000001");
+      expect(res.status).toBe(404);
+    });
+
+    it("GET /dev/files/list.json 404s in production", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/dev/files/list.json")
+        .set("x-tenant-id", "00000000-0000-0000-0000-000000000001");
+      expect(res.status).toBe(404);
+    });
+
+    it("GET /dev/files/breadcrumb.json 404s in production", async () => {
+      const res = await request(app.getHttpServer())
+        .get("/dev/files/breadcrumb.json")
+        .set("x-tenant-id", "00000000-0000-0000-0000-000000000001");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/file-manager-dev-hub.e2e-spec.ts
+++ b/tests/file-manager-dev-hub.e2e-spec.ts
@@ -110,9 +110,9 @@ describe("Dev-Hub File-Manager · /dev/files*", () => {
           .set("x-tenant-id", tenantId);
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.files)).toBe(true);
-        const matched = (res.body.files as Array<{ id: string; filename: string; thumbnailUrl?: string }>).find(
-          (f) => f.id === fileRow.id,
-        );
+        const matched = (
+          res.body.files as Array<{ id: string; filename: string; thumbnailUrl?: string }>
+        ).find((f) => f.id === fileRow.id);
         expect(matched).toBeDefined();
         expect(matched!.filename).toBe("annual.pdf");
         expect(typeof res.body.totalCount).toBe("number");

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -50,6 +50,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "/dev/email-preview",
       "/dev/email-builder",
       "/dev/postgrest-parse",
+      "/dev/files",
       "/admin/permissions/test",
       "/admin/webhooks",
       "/admin/realtime",
@@ -84,6 +85,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "/dev/email-builder",
       "/dev/components",
       "/dev/postgrest-parse",
+      "/dev/files",
       "/admin/permissions/test",
       "/admin/webhooks",
       "/admin/realtime",
@@ -286,6 +288,7 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       "realtime",
       "audit",
       "search",
+      "files",
     ];
     for (const id of ids) {
       it(`nav.ts declares sidebar entry id="${id}"`, () => {

--- a/tests/stories/file-manager-breadcrumb.story.test.ts
+++ b/tests/stories/file-manager-breadcrumb.story.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Story · File-Manager breadcrumb planner.
+ *
+ * The breadcrumb above the file grid shows `Root / customers / acme /
+ * invoices` for a deeply-nested folder. The planner walks the parent
+ * chain from the active folder back to the root, collecting display
+ * names. A `null` activeId returns the synthetic "Root" segment alone.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFolderBreadcrumb,
+  type BreadcrumbInput,
+} from "../../src/core/files/file-manager-breadcrumb.js";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+
+function f(id: string, name: string, parentId: string | null = null): BreadcrumbInput {
+  return { id, name, parentId, tenantId: TENANT };
+}
+
+describe("Story · File-Manager breadcrumb planner", () => {
+  it("returns a single Root segment when activeId is null", () => {
+    const crumbs = buildFolderBreadcrumb({ activeId: null, folders: [] });
+    expect(crumbs).toEqual([{ id: null, name: "Root" }]);
+  });
+
+  it("walks the parent chain back to the root for a nested folder", () => {
+    const crumbs = buildFolderBreadcrumb({
+      activeId: "leaf",
+      folders: [f("root", "customers"), f("mid", "acme", "root"), f("leaf", "invoices", "mid")],
+    });
+    expect(crumbs).toEqual([
+      { id: null, name: "Root" },
+      { id: "root", name: "customers" },
+      { id: "mid", name: "acme" },
+      { id: "leaf", name: "invoices" },
+    ]);
+  });
+
+  it("returns just Root + active when the folder has no parent", () => {
+    const crumbs = buildFolderBreadcrumb({
+      activeId: "single",
+      folders: [f("single", "Solo")],
+    });
+    expect(crumbs).toEqual([
+      { id: null, name: "Root" },
+      { id: "single", name: "Solo" },
+    ]);
+  });
+
+  it("breaks gracefully when the activeId is not in the folders list", () => {
+    const crumbs = buildFolderBreadcrumb({
+      activeId: "missing",
+      folders: [f("root", "Root-Folder")],
+    });
+    // Unknown active folder degrades to the synthetic Root segment.
+    expect(crumbs).toEqual([{ id: null, name: "Root" }]);
+  });
+
+  it("breaks parent cycles without infinite recursion", () => {
+    const crumbs = buildFolderBreadcrumb({
+      activeId: "a",
+      folders: [
+        { id: "a", name: "A", parentId: "b", tenantId: TENANT },
+        { id: "b", name: "B", parentId: "a", tenantId: TENANT },
+      ],
+    });
+    // The walk stops when it sees a folder it already visited; the
+    // returned chain is finite.
+    expect(crumbs.length).toBeLessThanOrEqual(4);
+    expect(crumbs[0]).toEqual({ id: null, name: "Root" });
+  });
+});

--- a/tests/stories/file-manager-search.story.test.ts
+++ b/tests/stories/file-manager-search.story.test.ts
@@ -102,7 +102,9 @@ describe("Story · File-Manager sort + filter planner", () => {
     });
 
     it("ignores unknown sortBy values and falls back to name asc", () => {
-      const out = applyFileSearch(files, { sortBy: "garbage" as unknown as FileSearchOptions["sortBy"] });
+      const out = applyFileSearch(files, {
+        sortBy: "garbage" as unknown as FileSearchOptions["sortBy"],
+      });
       expect(out.map((f) => f.id)).toEqual(["2", "1", "3"]);
     });
   });

--- a/tests/stories/file-manager-search.story.test.ts
+++ b/tests/stories/file-manager-search.story.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Story · File-Manager sort + filter planner.
+ *
+ * The file-grid lets the user sort by name / size / created-at /
+ * mime-type and filter by a free-text search string. The planner is
+ * pure so the React grid never re-implements the algorithm and the
+ * server can run the same code for the > 500-file fallback.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  applyFileSearch,
+  type FileSearchInput,
+  type FileSearchOptions,
+} from "../../src/core/files/file-manager-search.js";
+
+function file(input: Partial<FileSearchInput> & { id: string }): FileSearchInput {
+  return {
+    id: input.id,
+    filename: input.filename ?? `${input.id}.txt`,
+    mimeType: input.mimeType ?? "text/plain",
+    sizeBytes: input.sizeBytes ?? 0,
+    createdAt: input.createdAt ?? "2026-01-01T00:00:00.000Z",
+    updatedAt: input.updatedAt ?? "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("Story · File-Manager sort + filter planner", () => {
+  describe("filtering", () => {
+    it("returns the input unchanged when no filter is supplied", () => {
+      const files = [file({ id: "a" }), file({ id: "b" })];
+      const out = applyFileSearch(files, {});
+      expect(out.map((f) => f.id)).toEqual(["a", "b"]);
+    });
+
+    it("filters by case-insensitive substring on filename", () => {
+      const files = [
+        file({ id: "1", filename: "Invoice-2024.pdf" }),
+        file({ id: "2", filename: "report.docx" }),
+        file({ id: "3", filename: "INVOICE-2025.pdf" }),
+      ];
+      const out = applyFileSearch(files, { search: "invoice" });
+      expect(out.map((f) => f.id).sort()).toEqual(["1", "3"]);
+    });
+
+    it("filters by mimeType prefix when the search ends in `/*`", () => {
+      const files = [
+        file({ id: "img", mimeType: "image/png" }),
+        file({ id: "doc", mimeType: "application/pdf" }),
+        file({ id: "img2", mimeType: "image/jpeg" }),
+      ];
+      const out = applyFileSearch(files, { mimeTypePrefix: "image/" });
+      expect(out.map((f) => f.id).sort()).toEqual(["img", "img2"]);
+    });
+
+    it("combines search and mime filter (AND)", () => {
+      const files = [
+        file({ id: "a", filename: "logo.png", mimeType: "image/png" }),
+        file({ id: "b", filename: "logo.pdf", mimeType: "application/pdf" }),
+        file({ id: "c", filename: "hero.png", mimeType: "image/png" }),
+      ];
+      const out = applyFileSearch(files, { search: "logo", mimeTypePrefix: "image/" });
+      expect(out.map((f) => f.id)).toEqual(["a"]);
+    });
+  });
+
+  describe("sorting", () => {
+    const files = [
+      file({ id: "1", filename: "beta.txt", sizeBytes: 100, createdAt: "2026-01-02T00:00:00Z" }),
+      file({ id: "2", filename: "Alpha.txt", sizeBytes: 50, createdAt: "2026-01-01T00:00:00Z" }),
+      file({ id: "3", filename: "gamma.txt", sizeBytes: 200, createdAt: "2026-01-03T00:00:00Z" }),
+    ];
+
+    it("sorts by name ascending (case-insensitive) by default", () => {
+      const out = applyFileSearch(files, {});
+      expect(out.map((f) => f.id)).toEqual(["2", "1", "3"]);
+    });
+
+    it("sorts by size ascending when sortBy is 'size'", () => {
+      const out = applyFileSearch(files, { sortBy: "size" });
+      expect(out.map((f) => f.id)).toEqual(["2", "1", "3"]);
+    });
+
+    it("reverses with sortDirection='desc'", () => {
+      const out = applyFileSearch(files, { sortBy: "size", sortDirection: "desc" });
+      expect(out.map((f) => f.id)).toEqual(["3", "1", "2"]);
+    });
+
+    it("sorts by createdAt", () => {
+      const out = applyFileSearch(files, { sortBy: "createdAt" });
+      expect(out.map((f) => f.id)).toEqual(["2", "1", "3"]);
+    });
+
+    it("sorts by mimeType lexicographically", () => {
+      const mixed = [
+        file({ id: "x", mimeType: "image/png", filename: "a" }),
+        file({ id: "y", mimeType: "application/pdf", filename: "a" }),
+        file({ id: "z", mimeType: "text/plain", filename: "a" }),
+      ];
+      const out = applyFileSearch(mixed, { sortBy: "mimeType" });
+      expect(out.map((f) => f.id)).toEqual(["y", "x", "z"]);
+    });
+
+    it("ignores unknown sortBy values and falls back to name asc", () => {
+      const out = applyFileSearch(files, { sortBy: "garbage" as unknown as FileSearchOptions["sortBy"] });
+      expect(out.map((f) => f.id)).toEqual(["2", "1", "3"]);
+    });
+  });
+
+  describe("limit", () => {
+    it("applies the optional `limit` cap so the client never renders more than asked", () => {
+      const files = Array.from({ length: 50 }, (_, i) =>
+        file({ id: `f-${i}`, filename: `name-${i}.txt` }),
+      );
+      const out = applyFileSearch(files, { limit: 10 });
+      expect(out).toHaveLength(10);
+    });
+  });
+});

--- a/tests/stories/file-manager-tree.story.test.ts
+++ b/tests/stories/file-manager-tree.story.test.ts
@@ -66,10 +66,7 @@ describe("Story · File-Manager folder-tree planner", () => {
   });
 
   it("promotes orphans (unknown parentId) to root so a partial load still renders", () => {
-    const tree = buildFolderTree([
-      f("a", "Anchor"),
-      f("orphan", "Orphan", "missing-parent"),
-    ]);
+    const tree = buildFolderTree([f("a", "Anchor"), f("orphan", "Orphan", "missing-parent")]);
     // Orphan is at the root level; the root array has both nodes.
     expect(tree.map((n) => n.name).sort()).toEqual(["Anchor", "Orphan"]);
   });

--- a/tests/stories/file-manager-tree.story.test.ts
+++ b/tests/stories/file-manager-tree.story.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Story · File-Manager folder-tree planner.
+ *
+ * The dev-portal File-Manager renders a recursive folder tree on the
+ * left side. The shape is built from a flat list of `FolderRecord`s
+ * (one tenant, no nesting metadata baked into the row beyond
+ * `parentId`). The planner is pure — given a flat list, it returns a
+ * deterministic tree rooted at the synthetic `null` parent — so the
+ * React tree never has to build it incrementally.
+ *
+ * Locking:
+ *   - children are sorted by name (case-insensitive) for stable rendering
+ *   - orphan rows (parentId pointing at an unknown id) are silently
+ *     promoted to root so a half-loaded list never disappears
+ *   - cycles are broken (first-write-wins) so a corrupt parent chain
+ *     can't crash the renderer
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildFolderTree,
+  type FolderTreeInput,
+  type FolderTreeNode,
+} from "../../src/core/files/file-manager-tree.js";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+
+function f(id: string, name: string, parentId: string | null = null): FolderTreeInput {
+  return { id, name, parentId, tenantId: TENANT };
+}
+
+describe("Story · File-Manager folder-tree planner", () => {
+  it("returns an empty array when the input is empty", () => {
+    expect(buildFolderTree([])).toEqual([]);
+  });
+
+  it("builds a single root for a flat list of root folders sorted by name", () => {
+    const tree = buildFolderTree([f("a", "Beta"), f("b", "Alpha"), f("c", "Gamma")]);
+    expect(tree).toHaveLength(3);
+    expect(tree.map((n: FolderTreeNode) => n.name)).toEqual(["Alpha", "Beta", "Gamma"]);
+    for (const node of tree) {
+      expect(node.children).toEqual([]);
+      expect(node.depth).toBe(0);
+    }
+  });
+
+  it("nests children under their parents and sorts each level alphabetically", () => {
+    const tree = buildFolderTree([
+      f("root", "Root"),
+      f("c1", "Charlie", "root"),
+      f("c2", "Alpha", "root"),
+      f("c3", "Bravo", "root"),
+      f("gc", "Inner", "c2"),
+    ]);
+    expect(tree).toHaveLength(1);
+    const root = tree[0]!;
+    expect(root.children.map((c) => c.name)).toEqual(["Alpha", "Bravo", "Charlie"]);
+    expect(root.children[0]!.children).toHaveLength(1);
+    expect(root.children[0]!.children[0]!.name).toBe("Inner");
+    expect(root.children[0]!.children[0]!.depth).toBe(2);
+  });
+
+  it("uses case-insensitive name sort so 'a' and 'A' interleave naturally", () => {
+    const tree = buildFolderTree([f("1", "alpha"), f("2", "Bravo"), f("3", "ALPHA-2")]);
+    expect(tree.map((n) => n.name)).toEqual(["alpha", "ALPHA-2", "Bravo"]);
+  });
+
+  it("promotes orphans (unknown parentId) to root so a partial load still renders", () => {
+    const tree = buildFolderTree([
+      f("a", "Anchor"),
+      f("orphan", "Orphan", "missing-parent"),
+    ]);
+    // Orphan is at the root level; the root array has both nodes.
+    expect(tree.map((n) => n.name).sort()).toEqual(["Anchor", "Orphan"]);
+  });
+
+  it("breaks cycles deterministically so corrupt input never loops", () => {
+    // a → b → c → a (cycle). Planner should pick one as root and
+    // attach the other two as children, never recursing forever.
+    const tree = buildFolderTree([
+      { id: "a", name: "A", parentId: "c", tenantId: TENANT },
+      { id: "b", name: "B", parentId: "a", tenantId: TENANT },
+      { id: "c", name: "C", parentId: "b", tenantId: TENANT },
+    ]);
+    // Result is finite — we don't blow the stack.
+    const collectIds = (nodes: FolderTreeNode[], acc: string[] = []): string[] => {
+      for (const n of nodes) {
+        acc.push(n.id);
+        collectIds(n.children, acc);
+      }
+      return acc;
+    };
+    const ids = collectIds(tree);
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids)).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  it("attaches a `path` array tracing root-to-node for breadcrumb lookups", () => {
+    const tree = buildFolderTree([
+      f("root", "Root"),
+      f("mid", "Mid", "root"),
+      f("leaf", "Leaf", "mid"),
+    ]);
+    const root = tree[0]!;
+    expect(root.path.map((p) => p.id)).toEqual(["root"]);
+    const mid = root.children[0]!;
+    expect(mid.path.map((p) => p.id)).toEqual(["root", "mid"]);
+    const leaf = mid.children[0]!;
+    expect(leaf.path.map((p) => p.id)).toEqual(["root", "mid", "leaf"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #18. Adds the Dev-Portal File-Manager at `/dev/files` on top of the storage foundations from #16 (Prisma metadata + storage adapters + TUS) and #17 (IPX thumbnails).

- New React page `FileManagerPage.tsx` with a two-column layout: recursive folder tree on the left, breadcrumb + sort/filter toolbar + file grid on the right; image rows render IPX thumbnails (`/_ipx/preset_thumbnail/...`).
- Three pure planners (`buildFolderTree`, `buildFolderBreadcrumb`, `applyFileSearch`) — cycle-safe, deterministic, story-tested.
- New `DevFilesController` exposes `/dev/files`, `/dev/files/tree.json`, `/dev/files/list.json`, `/dev/files/breadcrumb.json` — all 404 outside `NODE_ENV=development` and explicitly scope by tenant id (header or `?tenantId=` override) on top of RLS.
- Folder create + file delete wired through the existing `/folders` and `/files` REST surfaces.
- Sidebar gains a "File Manager" entry under Übersicht; the dev-portal-pages story locks the route, sidebar id, and SPA_ROUTES set.
- README documents the new page and what's deferred.

### Out of scope (deferred to follow-up issues)

The original issue body lists a deep feature set; this slice lands the foundations honestly and defers the rest:

- TUS upload UI (foundation already wired in #16; UI follow-up)
- Drag-and-drop move, rename, multi-select bulk actions
- Lightbox / Monaco / PDF preview drawer
- Share-link creator + visibility toggle (would require a new `FileShare` Prisma model)
- Audit-log integration on visibility changes
- Server-side zip download

These are tracked in the README's "Out of scope for this slice" paragraph and remain open against issue #18 for prioritisation.

## Test plan

- [x] `bun run lint` (oxlint, 0 warnings/errors)
- [x] `bun run format` (oxfmt, all files formatted)
- [x] `bun run test:types` (tsc --noEmit)
- [x] `bun run test:unit` (153 / 153 passing)
- [x] `bun run build:dev-portal` (36 artifacts, 991 kB total)
- [x] `bun run test:e2e` (2195 / 2195 passing — includes 11 new e2e for the JSON sidecars + production 404 lock)
- [x] `bun run test:coverage` (src/core 90.66 % statements, 92.56 % lines — meets ≥ 90 %)
- [x] `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)