### PR TITLE
feat(outbox): at-least-once email delivery via outbox table (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Live Mermaid `erDiagram` of the active Prisma schema (concat'd from `schema.pris
 
 Every registered email template rendered with a realistic sample payload. Subject + sandboxed HTML iframe + plain-text version side-by-side, plus the sample-payload JSON. Mailpit at `:8025` shows actually-sent emails; this page is for "did my edit to the welcome template break anything?".
 
+### Email Outbox — `/dev/outbox.json`
+
+JSON snapshot of the email-outbox subsystem (issue #11 — at-least-once delivery). Shows the lag classification (pending count, oldest age, threshold) plus the 100 most-recent dispatchable rows. Better-Auth hooks (verify / reset / welcome / invitation) enqueue via the outbox by default with a deterministic idempotency-key (recipient + token), so a "click resend twice" collapses into one row and a server crash between trigger and SMTP-ACK never loses a verification mail. Worker tick is configurable via `EMAIL_OUTBOX_TICK_MS` (default 1s); records that fail transiently retry with exponential backoff (1m → 5m → 25m, 2h cap, 5 attempts) before graduating to `dead-letter`. The `/health/ready` probe trips to 503 when lag exceeds 30s.
+
 ### Migrations — `/dev/migrations`
 
 Five-tab handler for Prisma schema evolution: **Status** (rows from `_prisma_migrations` with retry on failed), **Pending** (preview SQL · apply one · apply all · dry-run in a transaction), **Diff** (`prisma migrate diff` between live DB and `schema.prisma`), **History** (timeline of applied migrations), **Create New** (kebab-case validated → `prisma migrate dev --create-only` → SQL preview → apply or discard). Drift banner above all tabs. Every mutating endpoint is gated by a Postgres advisory lock (409 on contention) and 404s outside `NODE_ENV=development`.

--- a/prisma/migrations/20260430170000_email_outbox/migration.sql
+++ b/prisma/migrations/20260430170000_email_outbox/migration.sql
@@ -1,0 +1,45 @@
+-- Email-Outbox table (issue #11 — at-least-once email delivery).
+--
+-- Backs EmailOutboxRecorder + EmailOutboxWorker. Every record stores
+-- the exact args of EmailService.send / sendTemplate as JSON so the
+-- worker can replay them without re-running domain logic.
+--
+-- Idempotency: `idempotency_key` is unique-when-present, so two
+-- hook-triggers within the same dedup window collapse to a single
+-- row. Concurrency: `claimed_at` is set the moment a worker decides
+-- to send; stale claims (> STALE_CLAIM_THRESHOLD_MS) are rescued by
+-- the next tick (see email-outbox-planner.ts).
+
+CREATE TYPE "EmailOutboxStatus" AS ENUM ('PENDING', 'SENT', 'DEAD_LETTER');
+CREATE TYPE "EmailOutboxKind"   AS ENUM ('SEND', 'SEND_TEMPLATE');
+
+CREATE TABLE "email_outbox" (
+    "id"               UUID                NOT NULL,
+    "kind"             "EmailOutboxKind"   NOT NULL,
+    "payload"          JSONB               NOT NULL,
+    "idempotency_key"  TEXT,
+    "status"           "EmailOutboxStatus" NOT NULL DEFAULT 'PENDING',
+    "attempt_count"    INTEGER             NOT NULL DEFAULT 0,
+    "next_attempt_at"  TIMESTAMP(3),
+    "claimed_at"       TIMESTAMP(3),
+    "last_error"       TEXT,
+    "succeeded_at"     TIMESTAMP(3),
+    "failed_at"        TIMESTAMP(3),
+    "created_at"       TIMESTAMP(3)        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"       TIMESTAMP(3)        NOT NULL,
+
+    CONSTRAINT "email_outbox_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique-when-present: the index ignores NULLs by default. Two
+-- pending rows with the same idempotency_key would violate this,
+-- which is exactly the dedup guarantee Better-Auth needs.
+CREATE UNIQUE INDEX "email_outbox_idempotency_key_key"
+    ON "email_outbox"("idempotency_key");
+
+-- Hot-path indexes for the worker tick.
+CREATE INDEX "email_outbox_status_next_attempt_at_idx"
+    ON "email_outbox"("status", "next_attempt_at");
+
+CREATE INDEX "email_outbox_status_created_at_idx"
+    ON "email_outbox"("status", "created_at");

--- a/prisma/schema.generated.prisma
+++ b/prisma/schema.generated.prisma
@@ -325,6 +325,49 @@ model WebhookDelivery {
   @@map("webhook_deliveries")
 }
 
+// ---------- Email-Outbox (at-least-once delivery, issue #11) ----------
+
+enum EmailOutboxStatus {
+  PENDING
+  SENT
+  DEAD_LETTER
+}
+
+enum EmailOutboxKind {
+  SEND
+  SEND_TEMPLATE
+}
+
+// Backs the EmailOutboxRecorder + EmailOutboxWorker. Every record
+// stores the exact args of EmailService.send / sendTemplate as JSON
+// so the worker can replay them without re-running domain logic.
+//
+// Idempotency: `idempotency_key` is unique-when-present so two
+// hook-triggers within the same dedup window collapse to a single
+// row. Dispatch concurrency: `claimed_at` is set the moment a
+// worker decides to send; stale claims (> STALE_CLAIM_THRESHOLD_MS)
+// are picked up by the next tick — see email-outbox-planner.ts.
+model EmailOutbox {
+  id              String            @id @default(uuid()) @db.Uuid
+  kind            EmailOutboxKind
+  payload         Json
+  idempotencyKey  String?           @unique @map("idempotency_key")
+  status          EmailOutboxStatus @default(PENDING)
+  attemptCount    Int               @default(0) @map("attempt_count")
+  nextAttemptAt   DateTime?         @map("next_attempt_at")
+  claimedAt       DateTime?         @map("claimed_at")
+  lastError       String?           @map("last_error")
+  succeededAt     DateTime?         @map("succeeded_at")
+  failedAt        DateTime?         @map("failed_at")
+  createdAt       DateTime          @default(now()) @map("created_at")
+  updatedAt       DateTime          @updatedAt @map("updated_at")
+
+  // Hot path: worker tick scans pending rows ordered by created_at.
+  @@index([status, nextAttemptAt])
+  @@index([status, createdAt])
+  @@map("email_outbox")
+}
+
 model Role {
   id          String   @id @default(uuid()) @db.Uuid
   name        String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -321,6 +321,49 @@ model WebhookDelivery {
   @@map("webhook_deliveries")
 }
 
+// ---------- Email-Outbox (at-least-once delivery, issue #11) ----------
+
+enum EmailOutboxStatus {
+  PENDING
+  SENT
+  DEAD_LETTER
+}
+
+enum EmailOutboxKind {
+  SEND
+  SEND_TEMPLATE
+}
+
+// Backs the EmailOutboxRecorder + EmailOutboxWorker. Every record
+// stores the exact args of EmailService.send / sendTemplate as JSON
+// so the worker can replay them without re-running domain logic.
+//
+// Idempotency: `idempotency_key` is unique-when-present so two
+// hook-triggers within the same dedup window collapse to a single
+// row. Dispatch concurrency: `claimed_at` is set the moment a
+// worker decides to send; stale claims (> STALE_CLAIM_THRESHOLD_MS)
+// are picked up by the next tick — see email-outbox-planner.ts.
+model EmailOutbox {
+  id              String            @id @default(uuid()) @db.Uuid
+  kind            EmailOutboxKind
+  payload         Json
+  idempotencyKey  String?           @unique @map("idempotency_key")
+  status          EmailOutboxStatus @default(PENDING)
+  attemptCount    Int               @default(0) @map("attempt_count")
+  nextAttemptAt   DateTime?         @map("next_attempt_at")
+  claimedAt       DateTime?         @map("claimed_at")
+  lastError       String?           @map("last_error")
+  succeededAt     DateTime?         @map("succeeded_at")
+  failedAt        DateTime?         @map("failed_at")
+  createdAt       DateTime          @default(now()) @map("created_at")
+  updatedAt       DateTime          @updatedAt @map("updated_at")
+
+  // Hot path: worker tick scans pending rows ordered by created_at.
+  @@index([status, nextAttemptAt])
+  @@index([status, createdAt])
+  @@map("email_outbox")
+}
+
 model Role {
   id          String   @id @default(uuid()) @db.Uuid
   name        String

--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -10,6 +10,7 @@ import { BetterAuthSessionMiddleware } from "../auth/session-middleware.js";
 import { ConfigModule } from "../config/config.module.js";
 import { DevHubModule } from "../dx/dev-hub.module.js";
 import { EmailModule } from "../email/email.module.js";
+import { EmailOutboxModule } from "../email/email-outbox.module.js";
 import { EncryptionModule } from "../encryption/encryption.module.js";
 import { ErrorCodesModule } from "../errors/error-codes.module.js";
 import { FilesModule } from "../files/files.module.js";
@@ -76,6 +77,10 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
     GeoIpModule,
     PowerSyncModule,
     IdempotencyModule,
+    // EmailOutboxModule must come BEFORE EmailModule so the
+    // EMAIL_OUTBOX_RECORDER token is registered before EmailModule's
+    // factory runs (it picks the recorder up via optional inject).
+    EmailOutboxModule,
     EmailModule,
     AuditLogModule,
     TenantMemberModule,

--- a/src/core/auth/better-auth-email-hooks.runner.ts
+++ b/src/core/auth/better-auth-email-hooks.runner.ts
@@ -24,14 +24,22 @@ import { buildEmailHookPayload, type BetterAuthEmailUser } from "./better-auth-e
  * tests pass a fake without modelling the rate-limiter, whitelist,
  * or driver wiring.
  */
+export interface EmailHookSendDispatchOptions {
+  mode?: "direct" | "outbox";
+  idempotencyKey?: string;
+}
+
 export interface EmailSenderForHooks {
-  sendTemplate(args: {
-    to: string;
-    template: string;
-    vars?: object;
-    locale?: string;
-    from?: string;
-  }): Promise<{ messageId: string; driver: string }>;
+  sendTemplate(
+    args: {
+      to: string;
+      template: string;
+      vars?: object;
+      locale?: string;
+      from?: string;
+    },
+    dispatch?: EmailHookSendDispatchOptions,
+  ): Promise<{ messageId: string; driver: string }>;
 }
 
 export interface EmailHookErrorContext {
@@ -51,6 +59,13 @@ export interface EmailHookRunnerOptions {
   locale?: string;
   /** Optional sink for transport failures. Defaults to a NestJS Logger. */
   onError?: (error: Error, ctx: EmailHookErrorContext) => void;
+  /**
+   * When true the runner asks the EmailService to enqueue mails into
+   * the email-outbox (issue #11) instead of sending synchronously.
+   * Each call carries a deterministic idempotencyKey so a duplicate
+   * trigger (Resend / retry click) collapses to one outbox row.
+   */
+  useOutbox?: boolean;
 }
 
 export interface VerificationHookData {
@@ -97,6 +112,7 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
   async function send(
     kind: EmailHookErrorContext["kind"],
     builder: () => { template: string; to: string; vars: Record<string, string> },
+    idempotencyToken?: string,
   ): Promise<void> {
     let plan: { template: string; to: string; vars: Record<string, string> };
     try {
@@ -109,12 +125,21 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
       return;
     }
     try {
-      await options.sender.sendTemplate({
-        to: plan.to,
-        template: plan.template,
-        vars: plan.vars,
-        locale: options.locale ?? "en",
-      });
+      const dispatch = options.useOutbox
+        ? {
+            mode: "outbox" as const,
+            idempotencyKey: buildIdempotencyKey(kind, plan.to, idempotencyToken),
+          }
+        : undefined;
+      await options.sender.sendTemplate(
+        {
+          to: plan.to,
+          template: plan.template,
+          vars: plan.vars,
+          locale: options.locale ?? "en",
+        },
+        dispatch,
+      );
     } catch (raw) {
       onError(toError(raw), { kind, template: plan.template, to: plan.to });
     }
@@ -122,46 +147,80 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
 
   return {
     async sendVerificationEmail(data) {
-      await send("email-verification", () =>
-        buildEmailHookPayload({
-          kind: "email-verification",
-          user: data.user,
-          url: data.url,
-          appName: options.appName,
-        }),
+      await send(
+        "email-verification",
+        () =>
+          buildEmailHookPayload({
+            kind: "email-verification",
+            user: data.user,
+            url: data.url,
+            appName: options.appName,
+          }),
+        // Token is the unique handle Better-Auth issued for this verification
+        // flow — using it as the dedup-key means a "click resend twice" never
+        // produces two outbox rows for the same token, while a fresh request
+        // (new token) gets a new mail.
+        data.token,
       );
     },
     async sendResetPassword(data) {
-      await send("password-reset", () =>
-        buildEmailHookPayload({
-          kind: "password-reset",
-          user: data.user,
-          url: data.url,
-          appName: options.appName,
-        }),
+      await send(
+        "password-reset",
+        () =>
+          buildEmailHookPayload({
+            kind: "password-reset",
+            user: data.user,
+            url: data.url,
+            appName: options.appName,
+          }),
+        data.token,
       );
     },
     async sendWelcome(data) {
-      await send("welcome", () =>
-        buildEmailHookPayload({
-          kind: "welcome",
-          user: data.user,
-          appName: options.appName,
-        }),
+      await send(
+        "welcome",
+        () =>
+          buildEmailHookPayload({
+            kind: "welcome",
+            user: data.user,
+            appName: options.appName,
+          }),
+        // No flow-token for welcome mails — the user-id is the natural
+        // dedup key (we only ever want to send one welcome per signup).
+        data.user.id,
       );
     },
     async sendInvitation(data) {
-      await send("invitation", () =>
-        buildEmailHookPayload({
-          kind: "invitation",
-          user: data.user,
-          url: data.url,
-          appName: options.appName,
-          senderName: data.senderName ?? "",
-        }),
+      await send(
+        "invitation",
+        () =>
+          buildEmailHookPayload({
+            kind: "invitation",
+            user: data.user,
+            url: data.url,
+            appName: options.appName,
+            senderName: data.senderName ?? "",
+          }),
+        // Invitations don't carry an explicit token; the URL is the
+        // closest stable identifier — duplicate URLs dedup, fresh
+        // resends with a new URL re-enqueue.
+        data.url,
       );
     },
   };
+}
+
+function buildIdempotencyKey(
+  kind: EmailHookErrorContext["kind"],
+  to: string,
+  token: string | undefined,
+): string {
+  // The kind segments the namespace so a verification + welcome to the
+  // same recipient never collide. The recipient + token (if any) are
+  // the natural per-flow uniqueness anchor. Falls back to recipient
+  // alone when no token is available — caller passes user.id for
+  // welcome, url for invitation.
+  return token ? `${kind}:${to}:${token}` : `${kind}:${to}`;
 }
 
 function toError(raw: unknown): Error {

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -104,6 +104,14 @@ export interface EmailHooksOptions {
   appName: string;
   /** Optional locale override; defaults to "en" until issue #011 lands. */
   locale?: string;
+  /**
+   * When true, Better-Auth's email hooks enqueue mails via the
+   * email-outbox (issue #11) so a server crash between trigger and
+   * SMTP-ACK doesn't lose the verification / reset / welcome mail.
+   * Defaults to true — wired by BetterAuthModule when EmailService
+   * has the recorder injected.
+   */
+  useOutbox?: boolean;
 }
 
 export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof betterAuth> {
@@ -170,6 +178,10 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
         sender: input.emailHooks.sender,
         appName: input.emailHooks.appName,
         ...(input.emailHooks.locale ? { locale: input.emailHooks.locale } : {}),
+        // Default to outbox-mode delivery for at-least-once durability
+        // (issue #11). Tests / call-sites that want the legacy direct
+        // path can opt out by passing `useOutbox: false`.
+        useOutbox: input.emailHooks.useOutbox ?? true,
       })
     : undefined;
 

--- a/src/core/dx/dev-hub.controller.ts
+++ b/src/core/dx/dev-hub.controller.ts
@@ -14,7 +14,9 @@ import {
   HttpCode,
   HttpException,
   HttpStatus,
+  Inject,
   NotFoundException,
+  Optional,
   Param,
   Post,
   Query,
@@ -33,6 +35,9 @@ import { readTunnelState } from "../dev/tunnel-state-runner.js";
 import { MigrationsService } from "./migrations/migrations.service.js";
 
 import { type Features, loadFeatures } from "../features/features.js";
+import { EMAIL_OUTBOX_STORAGE } from "../email/email-outbox.module.js";
+import type { EmailOutboxStorage } from "../email/email-outbox.js";
+import { classifyEmailOutboxLag } from "../email/email-outbox-health.js";
 import { JobNotFoundError, JobNotRetryableError, type ListJobsOptions } from "../jobs/job-queue.js";
 import type { JobState } from "../jobs/dev-jobs-aggregations.js";
 import { JobQueueService } from "../jobs/jobs.module.js";
@@ -84,6 +89,7 @@ export class DevHubController {
     private readonly routes: RouteInventoryService,
     private readonly migrations: MigrationsService,
     private readonly jobs: JobQueueService,
+    @Optional() @Inject(EMAIL_OUTBOX_STORAGE) private readonly emailOutbox?: EmailOutboxStorage,
   ) {}
 
   @Get()
@@ -899,6 +905,45 @@ export class DevHubController {
       if (error instanceof JobNotRetryableError) throw new ConflictException(error.message);
       throw error;
     }
+  }
+
+  /**
+   * `/dev/outbox.json` — snapshot of the email-outbox subsystem
+   * (issue #11). Returns lag classification + the most recent
+   * records (capped at 100) so operators can spot stuck mails. The
+   * JSON is the only surface; visibility happens via the existing
+   * Jobs Dashboard (the worker tick aggregates as a job entry).
+   */
+  @Get("outbox.json")
+  async outboxJson() {
+    this.assertDev();
+    if (!this.emailOutbox) {
+      return {
+        enabled: false,
+        message: "email-outbox storage not wired (EmailOutboxModule absent)",
+      };
+    }
+    const now = new Date();
+    const [pendingCount, oldestAgeMs] = await Promise.all([
+      this.emailOutbox.countPending(),
+      this.emailOutbox.oldestPendingAge(now),
+    ]);
+    const lag = classifyEmailOutboxLag({ pendingCount, oldestAgeMs });
+    const dispatchable = await this.emailOutbox.listDispatchable(now, 100);
+    return {
+      enabled: true,
+      health: lag,
+      dispatchable: dispatchable.map((r) => ({
+        id: r.id,
+        kind: r.kind,
+        status: r.status,
+        attemptCount: r.attemptCount,
+        nextAttemptAt: r.nextAttemptAt,
+        lastError: r.lastError,
+        idempotencyKey: r.idempotencyKey,
+        createdAt: r.createdAt,
+      })),
+    };
   }
 
   /**

--- a/src/core/email/CLAUDE.md
+++ b/src/core/email/CLAUDE.md
@@ -5,8 +5,14 @@ Transactional-email subsystem. The current shape:
 ```
 email/
 ├── brand.ts                       ← BrandConfig + defaults + resolveBrandConfig()
-├── email.service.ts               ← EmailService (driver + renderer + rate-limit + whitelist)
+├── email.service.ts               ← EmailService (driver + renderer + rate-limit + whitelist + outbox)
 ├── email.module.ts                ← EmailService DI factory
+├── email-outbox.ts                ← Recorder + Worker (at-least-once delivery, #11)
+├── email-outbox-planner.ts        ← Pure backoff / dispatch-eligibility helpers
+├── email-outbox-health.ts         ← Lag classifier consumed by /health/ready
+├── email-outbox.prisma.ts         ← PrismaEmailOutboxStorage (production adapter)
+├── email-outbox.module.ts         ← EmailOutboxModule (Global) — recorder, worker tick
+├── email-outbox.token.ts          ← EMAIL_OUTBOX_RECORDER injection token
 ├── email-templates.ts             ← Legacy EJS-subset renderer (kept for back-compat)
 ├── email-templates.react.ts       ← React-Email loader + renderer (default)
 ├── layouts/
@@ -25,6 +31,15 @@ email/
     ├── welcome.tsx
     └── invitation.tsx
 ```
+
+## Delivery modes
+
+`EmailService.send / sendTemplate` accept an optional second arg:
+
+- **direct** (default): synchronous driver call; the result carries the real provider message-id. Used by ad-hoc sends from project code.
+- **outbox**: `EmailService.send(opts, { mode: "outbox", idempotencyKey })` writes to the `email_outbox` table and returns immediately with `outbox:<uuid>`. The worker (`EmailOutboxWorker`, ticking on `EMAIL_OUTBOX_TICK_MS`) claims due rows, dispatches via the same driver, and graduates them to `sent` / `dead-letter`. Retry policy: 1m → 5m → 25m, 2h cap, 5 attempts.
+
+Better-Auth hooks default to outbox-mode with a deterministic idempotency-key (recipient + token / user-id / url) so duplicate triggers (Resend click) collapse to one row but a fresh request (new token) re-enqueues. `/dev/outbox.json` returns a JSON snapshot for inspection; `/health/ready` flips to 503 when oldest-pending age exceeds 30s.
 
 ## How rendering works
 

--- a/src/core/email/email-outbox-health.ts
+++ b/src/core/email/email-outbox-health.ts
@@ -1,0 +1,49 @@
+/**
+ * Email-Outbox health helper.
+ *
+ * Pure classifier — readiness probe (or any caller) feeds in the
+ * current pending count + oldest-pending-age and gets back an
+ * ok/fail verdict. The threshold is the issue-#11 acceptance
+ * criterion: if the worker hasn't drained the outbox for >30s, the
+ * load-balancer should drain this instance so the stalled outbox
+ * doesn't hold up downstream verification flows.
+ */
+
+export const EMAIL_OUTBOX_LAG_THRESHOLD_MS = 30_000;
+
+export interface EmailOutboxHealthInput {
+  pendingCount: number;
+  oldestAgeMs: number;
+  /** Optional override; defaults to EMAIL_OUTBOX_LAG_THRESHOLD_MS. */
+  thresholdMs?: number;
+}
+
+export interface EmailOutboxHealthResult {
+  status: "ok" | "fail";
+  pendingCount: number;
+  lagMs: number;
+  thresholdMs: number;
+  error?: string;
+}
+
+export function classifyEmailOutboxLag(input: EmailOutboxHealthInput): EmailOutboxHealthResult {
+  const thresholdMs = input.thresholdMs ?? EMAIL_OUTBOX_LAG_THRESHOLD_MS;
+  if (input.pendingCount === 0) {
+    return { status: "ok", pendingCount: 0, lagMs: 0, thresholdMs };
+  }
+  if (input.oldestAgeMs > thresholdMs) {
+    return {
+      status: "fail",
+      pendingCount: input.pendingCount,
+      lagMs: input.oldestAgeMs,
+      thresholdMs,
+      error: `email-outbox lag (${input.oldestAgeMs}ms) exceeds threshold (${thresholdMs}ms)`,
+    };
+  }
+  return {
+    status: "ok",
+    pendingCount: input.pendingCount,
+    lagMs: input.oldestAgeMs,
+    thresholdMs,
+  };
+}

--- a/src/core/email/email-outbox-planner.ts
+++ b/src/core/email/email-outbox-planner.ts
@@ -82,7 +82,9 @@ export interface PlanEmailRetryResult {
 export function planEmailRetry(input: PlanEmailRetryInput): PlanEmailRetryResult {
   const { attemptCount, errorKind, now, config } = input;
   if (attemptCount < 1 || !Number.isInteger(attemptCount)) {
-    throw new Error(`planEmailRetry: attemptCount must be a positive integer (got ${attemptCount})`);
+    throw new Error(
+      `planEmailRetry: attemptCount must be a positive integer (got ${attemptCount})`,
+    );
   }
   if (errorKind === "permanent") return { terminal: true };
   if (attemptCount >= config.maxAttempts) return { terminal: true };

--- a/src/core/email/email-outbox-planner.ts
+++ b/src/core/email/email-outbox-planner.ts
@@ -1,0 +1,121 @@
+/**
+ * Email-Outbox planners.
+ *
+ * Pure helpers used by `EmailOutboxWorker` and `EmailOutboxRecorder`
+ * — backoff math, retry-eligibility, claim-staleness. Splitting them
+ * out keeps the worker dispatch loop a thin runner so the
+ * scheduling logic is unit-testable without DB or driver wiring.
+ */
+
+/** Terminal status values produced by the worker for a record. */
+export type EmailOutboxTerminalStatus = "sent" | "dead-letter";
+
+/** All status values an email-outbox record can hold. */
+export type EmailOutboxStatus = "pending" | EmailOutboxTerminalStatus;
+
+/**
+ * Error classification — drives retry vs. immediate dead-letter.
+ *
+ * - `transient`: connection refused, 5xx, timeout — worth retrying.
+ * - `permanent`: invalid recipient, 4xx-not-rate-limit — never retry.
+ */
+export type EmailOutboxErrorKind = "transient" | "permanent";
+
+export interface EmailOutboxRetryConfig {
+  /** Delay applied between attempt 1 and attempt 2. */
+  initialDelayMs: number;
+  /** Multiplier applied per additional attempt. */
+  factor: number;
+  /** Hard ceiling — backoff is min(factor^n * initial, maxDelayMs). */
+  maxDelayMs: number;
+  /**
+   * Inclusive upper bound on attempts. When a failure pushes
+   * `attemptCount` to `maxAttempts`, the record transitions to
+   * `dead-letter` instead of being scheduled for another try.
+   */
+  maxAttempts: number;
+}
+
+/**
+ * Default retry policy: 1m, 5m, 25m, 2h cap, 5 attempts total.
+ *
+ * Aligned with issue #11's "max 5 attempts, then dead-letter"
+ * acceptance criterion. Numbers picked so a Brevo / SMTP outage <2h
+ * is recoverable without manual replay; longer outages surface as
+ * dead-letter records that operators can inspect via the dev-hub.
+ */
+export const DEFAULT_EMAIL_OUTBOX_RETRY: EmailOutboxRetryConfig = {
+  initialDelayMs: 60_000,
+  factor: 5,
+  maxDelayMs: 2 * 60 * 60 * 1000,
+  maxAttempts: 5,
+};
+
+/**
+ * Crash-safety threshold: a `claimedAt` older than this means the
+ * worker that picked the record up never released it (process died,
+ * deploy rolled, etc.) — the next worker tick is allowed to steal
+ * the claim and retry.
+ */
+export const STALE_CLAIM_THRESHOLD_MS = 30_000;
+
+export interface PlanEmailRetryInput {
+  /** 1-based count: 1 means "the first attempt just failed". */
+  attemptCount: number;
+  errorKind: EmailOutboxErrorKind;
+  now: Date;
+  config: EmailOutboxRetryConfig;
+}
+
+export interface PlanEmailRetryResult {
+  terminal: boolean;
+  /** Absent when `terminal === true`. */
+  nextAttemptAt?: Date;
+}
+
+/**
+ * Plans the next attempt after a failure. Returns either
+ * `{ terminal: true }` (record graduates to dead-letter) or
+ * `{ terminal: false, nextAttemptAt }` (record stays pending and gets
+ * picked up at or after `nextAttemptAt`).
+ */
+export function planEmailRetry(input: PlanEmailRetryInput): PlanEmailRetryResult {
+  const { attemptCount, errorKind, now, config } = input;
+  if (attemptCount < 1 || !Number.isInteger(attemptCount)) {
+    throw new Error(`planEmailRetry: attemptCount must be a positive integer (got ${attemptCount})`);
+  }
+  if (errorKind === "permanent") return { terminal: true };
+  if (attemptCount >= config.maxAttempts) return { terminal: true };
+  const raw = config.initialDelayMs * config.factor ** (attemptCount - 1);
+  const delayMs = Math.min(raw, config.maxDelayMs);
+  return { terminal: false, nextAttemptAt: new Date(now.getTime() + delayMs) };
+}
+
+export interface ShouldDispatchInput {
+  status: EmailOutboxStatus;
+  nextAttemptAt: Date | null;
+  claimedAt: Date | null;
+  now: Date;
+}
+
+/**
+ * Pure decision: should the worker pick this record up on the
+ * current tick? Pending status, no live claim (or claim is stale),
+ * `nextAttemptAt` not in the future.
+ */
+export function shouldDispatchNow(input: ShouldDispatchInput): boolean {
+  if (input.status !== "pending") return false;
+  if (input.claimedAt && !isStaleClaim(input.claimedAt, input.now)) return false;
+  if (input.nextAttemptAt && input.nextAttemptAt.getTime() > input.now.getTime()) return false;
+  return true;
+}
+
+/**
+ * Returns true when a `claimedAt` timestamp is older than the
+ * crash-safety threshold — the previous worker probably died before
+ * releasing the claim.
+ */
+export function isStaleClaim(claimedAt: Date | null, now: Date): boolean {
+  if (!claimedAt) return false;
+  return now.getTime() - claimedAt.getTime() > STALE_CLAIM_THRESHOLD_MS;
+}

--- a/src/core/email/email-outbox.module.ts
+++ b/src/core/email/email-outbox.module.ts
@@ -1,0 +1,255 @@
+import {
+  Global,
+  Inject,
+  Injectable,
+  Logger,
+  Module,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from "@nestjs/common";
+
+import { PrismaService } from "../prisma/prisma.service.js";
+import { resolveBrandConfig } from "./brand.js";
+import { BrevoEmailDriver, createBrevoHttpClient } from "./drivers/brevo.driver.js";
+import {
+  SmtpEmailDriver,
+  createSmtpTransporter,
+  readSmtpConfigFromEnv,
+} from "./drivers/smtp.driver.js";
+import {
+  selectEmailDriver,
+  type EmailDriverName,
+} from "./email.module.js";
+import { ReactEmailTemplateRenderer } from "./email-templates.react.js";
+import {
+  EmailOutboxRecorder,
+  EmailOutboxWorker,
+  type EmailOutboxDriver,
+  type EmailOutboxRecord,
+  type EmailOutboxStorage,
+} from "./email-outbox.js";
+import { PrismaEmailOutboxStorage } from "./email-outbox.prisma.js";
+import {
+  type EmailDriver,
+  type EmailMessage,
+  type EmailSendResult,
+  type EmailTemplateRenderer,
+} from "./email.service.js";
+import { loadFeatures } from "../features/features.js";
+import { loadBrandSync } from "../branding/brand-loader.js";
+import { EMAIL_OUTBOX_RECORDER } from "./email-outbox.token.js";
+
+/**
+ * EmailOutboxModule — wires the recorder, the worker, and the
+ * Prisma storage so EmailService can switch to outbox mode for
+ * at-least-once delivery (issue #11).
+ *
+ * The worker runs as a per-second tick lifecycle hook
+ * (`OnModuleInit` starts the timer, `OnModuleDestroy` stops it).
+ * The tick interval is configurable via `EMAIL_OUTBOX_TICK_MS` so
+ * dev can poll fast and prod can poll slower.
+ *
+ * Driver selection mirrors `EmailModule` — same env / feature
+ * matrix — but the worker holds its own driver instance to keep
+ * the dispatch path independent of `EmailService`'s caches.
+ */
+export const EMAIL_OUTBOX_STORAGE = Symbol.for("lt:EmailOutboxStorage");
+export const EMAIL_OUTBOX_DRIVER = Symbol.for("lt:EmailOutboxDriver");
+
+const DEFAULT_TICK_MS = 1000;
+
+/**
+ * Adapter: bridges EmailService-style drivers into the
+ * EmailOutboxDriver shape the worker expects.
+ *
+ * The worker doesn't care about EmailService's whitelist /
+ * rate-limit (those ran at enqueue time). It only needs to send
+ * the persisted message via the configured transport.
+ */
+class EmailServiceDriverAdapter implements EmailOutboxDriver {
+  constructor(
+    private readonly primary: EmailDriver,
+    private readonly transactional: EmailDriver | null,
+    private readonly renderer: EmailTemplateRenderer,
+    private readonly defaultFrom: string,
+  ) {}
+
+  async dispatch(record: EmailOutboxRecord): Promise<EmailSendResult> {
+    if (record.kind === "send") {
+      const opts = record.payload as {
+        to: string;
+        from?: string;
+        subject: string;
+        html?: string;
+        text?: string;
+      };
+      const message: EmailMessage = {
+        to: opts.to,
+        from: opts.from ?? this.defaultFrom,
+        subject: opts.subject,
+        html: opts.html,
+        text: opts.text,
+      };
+      return this.primary.send(message);
+    }
+    // sendTemplate
+    const opts = record.payload as {
+      to: string;
+      template: string;
+      locale?: string;
+      vars?: object;
+      brevoTemplateId?: number;
+      from?: string;
+    };
+    const vars = opts.vars ?? {};
+    if (opts.brevoTemplateId !== undefined) {
+      if (!this.transactional) {
+        throw new Error("email-outbox: brevoTemplateId set but no transactional driver wired");
+      }
+      const baseMessage: EmailMessage = {
+        to: opts.to,
+        from: opts.from ?? this.defaultFrom,
+        subject: "",
+      };
+      return this.transactional.sendTemplate(baseMessage, opts.brevoTemplateId, vars);
+    }
+    const locale = opts.locale ?? "en";
+    const rendered = await this.renderer.render(opts.template, locale, vars);
+    return this.primary.send({
+      to: opts.to,
+      from: opts.from ?? this.defaultFrom,
+      subject: rendered.subject,
+      html: rendered.html,
+      text: rendered.text,
+    });
+  }
+}
+
+/**
+ * Log-only stand-in driver — same shape used in EmailModule. Kept
+ * local so EmailOutboxModule doesn't import the LogOnly class out
+ * of EmailModule (avoids a circular dependency).
+ */
+class LogOnlyEmailDriver implements EmailDriver {
+  readonly name = "log-only";
+  private readonly logger = new Logger("EmailOutbox");
+  async send(msg: EmailMessage): Promise<EmailSendResult> {
+    this.logger.log(`[email-outbox] to=${msg.to} subject="${msg.subject}" via=${this.name}`);
+    return { messageId: `log-${Date.now()}`, driver: this.name };
+  }
+  async sendTemplate(
+    msg: EmailMessage,
+    templateId: number,
+    vars: object,
+  ): Promise<EmailSendResult> {
+    this.logger.log(
+      `[email-outbox] templateId=${templateId} to=${msg.to} vars=${JSON.stringify(vars)} via=${this.name}`,
+    );
+    return { messageId: `log-tpl-${templateId}-${Date.now()}`, driver: this.name };
+  }
+}
+
+function createDriver(name: EmailDriverName, env: Record<string, string | undefined>): EmailDriver {
+  if (name === "log-only") return new LogOnlyEmailDriver();
+  if (name === "smtp") {
+    const cfg = readSmtpConfigFromEnv(env);
+    if (!cfg) return new LogOnlyEmailDriver();
+    return new SmtpEmailDriver({ transporter: createSmtpTransporter(cfg) });
+  }
+  // brevo
+  const apiKey = env.BREVO_API_KEY ?? "";
+  return new BrevoEmailDriver({ apiKey, http: createBrevoHttpClient({ apiKey }) });
+}
+
+@Injectable()
+export class EmailOutboxRecorderProvider extends EmailOutboxRecorder {
+  constructor(@Inject(EMAIL_OUTBOX_STORAGE) storage: EmailOutboxStorage) {
+    super({ storage });
+  }
+}
+
+@Injectable()
+export class EmailOutboxWorkerLifecycle implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger("EmailOutboxWorker");
+  private readonly worker: EmailOutboxWorker;
+  private timer?: ReturnType<typeof setInterval>;
+  private readonly tickMs: number;
+
+  constructor(
+    @Inject(EMAIL_OUTBOX_STORAGE) storage: EmailOutboxStorage,
+    @Inject(EMAIL_OUTBOX_DRIVER) driver: EmailOutboxDriver,
+  ) {
+    const env = process.env as Record<string, string | undefined>;
+    const raw = env.EMAIL_OUTBOX_TICK_MS ? Number.parseInt(env.EMAIL_OUTBOX_TICK_MS, 10) : NaN;
+    this.tickMs = Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TICK_MS;
+    this.worker = new EmailOutboxWorker({ storage, driver });
+  }
+
+  async onModuleInit(): Promise<void> {
+    // Ticking in setInterval keeps the worker process-local — once
+    // pg-boss / a real distributed scheduler lands the OutboxWorker
+    // can run as a queued job instead. Until then, every server
+    // instance owns its tick + the SQL claim() prevents
+    // double-dispatch.
+    this.timer = setInterval(() => {
+      this.worker.runOnce().catch((err) => this.logger.error(err));
+    }, this.tickMs);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  /** Test hook — runs one tick on demand. */
+  async tickOnce(): Promise<void> {
+    await this.worker.runOnce();
+  }
+}
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: EMAIL_OUTBOX_STORAGE,
+      useFactory: (prisma: PrismaService) => new PrismaEmailOutboxStorage(prisma),
+      inject: [PrismaService],
+    },
+    {
+      provide: EMAIL_OUTBOX_DRIVER,
+      useFactory: (): EmailOutboxDriver => {
+        const env = process.env as Record<string, string | undefined>;
+        const features = loadFeatures(env);
+        const selection = selectEmailDriver({
+          enabled: features.email.enabled,
+          provider: features.email.provider,
+          env,
+        });
+        const renderer = new ReactEmailTemplateRenderer({ brand: resolveBrandConfig() });
+        const primary = createDriver(selection.primary, env);
+        const transactional = selection.transactional
+          ? createDriver(selection.transactional, env)
+          : null;
+        const brand = loadBrandSync();
+        const defaultFrom = env.SMTP_FROM ?? brand.fromEmail;
+        return new EmailServiceDriverAdapter(primary, transactional, renderer, defaultFrom);
+      },
+    },
+    EmailOutboxRecorderProvider,
+    // Alias the recorder under the dedicated injection token so
+    // EmailModule (and any consumer) can opt-in to outbox-mode
+    // without importing the recorder class directly.
+    {
+      provide: EMAIL_OUTBOX_RECORDER,
+      useExisting: EmailOutboxRecorderProvider,
+    },
+    EmailOutboxWorkerLifecycle,
+  ],
+  exports: [
+    EmailOutboxRecorderProvider,
+    EMAIL_OUTBOX_RECORDER,
+    EMAIL_OUTBOX_STORAGE,
+    EmailOutboxWorkerLifecycle,
+  ],
+})
+export class EmailOutboxModule {}

--- a/src/core/email/email-outbox.module.ts
+++ b/src/core/email/email-outbox.module.ts
@@ -16,10 +16,7 @@ import {
   createSmtpTransporter,
   readSmtpConfigFromEnv,
 } from "./drivers/smtp.driver.js";
-import {
-  selectEmailDriver,
-  type EmailDriverName,
-} from "./email.module.js";
+import { selectEmailDriver, type EmailDriverName } from "./email.module.js";
 import { ReactEmailTemplateRenderer } from "./email-templates.react.js";
 import {
   EmailOutboxRecorder,

--- a/src/core/email/email-outbox.prisma.ts
+++ b/src/core/email/email-outbox.prisma.ts
@@ -1,8 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 
-import {
-  STALE_CLAIM_THRESHOLD_MS,
-} from "./email-outbox-planner.js";
+import { STALE_CLAIM_THRESHOLD_MS } from "./email-outbox-planner.js";
 import type {
   AppendInput,
   EmailOutboxKind,

--- a/src/core/email/email-outbox.prisma.ts
+++ b/src/core/email/email-outbox.prisma.ts
@@ -1,0 +1,203 @@
+import type { PrismaClient } from "@prisma/client";
+
+import {
+  STALE_CLAIM_THRESHOLD_MS,
+} from "./email-outbox-planner.js";
+import type {
+  AppendInput,
+  EmailOutboxKind,
+  EmailOutboxPayload,
+  EmailOutboxRecord,
+  EmailOutboxStorage,
+} from "./email-outbox.js";
+import type { EmailOutboxStatus } from "./email-outbox-planner.js";
+
+/**
+ * Prisma-backed EmailOutboxStorage.
+ *
+ * Persists outbox records to the `email_outbox` table declared in
+ * `prisma/schema.prisma`. The in-memory storage in unit tests is the
+ * dev-friendly fake; this class is the production default wired up
+ * in `email-outbox.module.ts`.
+ *
+ * The `claim()` path uses a conditional `UPDATE … WHERE claimed_at
+ * IS NULL OR claimed_at < (NOW() - interval)` so concurrent workers
+ * never duplicate-dispatch a record; only the first transaction
+ * flips `claimed_at` to the current timestamp, the others see a
+ * zero-row affect and skip.
+ *
+ * Why a separate class instead of inlining into the recorder/worker:
+ * the recorder + worker stay storage-agnostic (matches the rest of
+ * the core's pure-planner / thin-runner split — every adapter
+ * passes the same EmailOutboxStorage interface).
+ */
+type PrismaEmailOutboxModel = Pick<
+  PrismaClient,
+  "emailOutbox" | "$queryRaw" | "$executeRaw" | "$transaction"
+>;
+
+const STATUS_DB_TO_DOMAIN = {
+  PENDING: "pending",
+  SENT: "sent",
+  DEAD_LETTER: "dead-letter",
+} as const satisfies Record<string, EmailOutboxStatus>;
+
+const STATUS_DOMAIN_TO_DB = {
+  pending: "PENDING",
+  sent: "SENT",
+  "dead-letter": "DEAD_LETTER",
+} as const satisfies Record<EmailOutboxStatus, "PENDING" | "SENT" | "DEAD_LETTER">;
+
+const KIND_DB_TO_DOMAIN = {
+  SEND: "send",
+  SEND_TEMPLATE: "sendTemplate",
+} as const satisfies Record<string, EmailOutboxKind>;
+
+const KIND_DOMAIN_TO_DB = {
+  send: "SEND",
+  sendTemplate: "SEND_TEMPLATE",
+} as const satisfies Record<EmailOutboxKind, "SEND" | "SEND_TEMPLATE">;
+
+interface PrismaEmailOutboxRow {
+  id: string;
+  kind: keyof typeof KIND_DB_TO_DOMAIN;
+  payload: unknown;
+  idempotencyKey: string | null;
+  status: keyof typeof STATUS_DB_TO_DOMAIN;
+  attemptCount: number;
+  nextAttemptAt: Date | null;
+  claimedAt: Date | null;
+  lastError: string | null;
+  succeededAt: Date | null;
+  failedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export class PrismaEmailOutboxStorage implements EmailOutboxStorage {
+  constructor(private readonly prisma: PrismaEmailOutboxModel) {}
+
+  async append(record: AppendInput): Promise<void> {
+    await this.prisma.emailOutbox.create({
+      data: {
+        id: record.id,
+        kind: KIND_DOMAIN_TO_DB[record.kind],
+        payload: record.payload as object,
+        idempotencyKey: record.idempotencyKey,
+        status: STATUS_DOMAIN_TO_DB[record.status],
+        attemptCount: record.attemptCount,
+        nextAttemptAt: record.nextAttemptAt,
+        claimedAt: record.claimedAt,
+        lastError: record.lastError,
+        succeededAt: record.succeededAt,
+        failedAt: record.failedAt,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      },
+    });
+  }
+
+  async findByIdempotencyKey(key: string): Promise<EmailOutboxRecord | null> {
+    const row = await this.prisma.emailOutbox.findUnique({
+      where: { idempotencyKey: key },
+    });
+    return row ? toRecord(row as PrismaEmailOutboxRow) : null;
+  }
+
+  async listDispatchable(now: Date, limit: number): Promise<EmailOutboxRecord[]> {
+    const staleBefore = new Date(now.getTime() - STALE_CLAIM_THRESHOLD_MS);
+    const rows = await this.prisma.emailOutbox.findMany({
+      where: {
+        status: "PENDING",
+        AND: [
+          {
+            OR: [{ nextAttemptAt: null }, { nextAttemptAt: { lte: now } }],
+          },
+          {
+            OR: [{ claimedAt: null }, { claimedAt: { lt: staleBefore } }],
+          },
+        ],
+      },
+      orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+      take: limit,
+    });
+    return (rows as PrismaEmailOutboxRow[]).map(toRecord);
+  }
+
+  async claim(id: string, claimedAt: Date): Promise<boolean> {
+    // Atomic claim: only flip claimed_at when the row is pending and
+    // either unclaimed or holds a stale claim. Returns the affected
+    // row-count so concurrent workers see a `false` and skip.
+    const staleBefore = new Date(claimedAt.getTime() - STALE_CLAIM_THRESHOLD_MS);
+    const result = await this.prisma.emailOutbox.updateMany({
+      where: {
+        id,
+        status: "PENDING",
+        OR: [{ claimedAt: null }, { claimedAt: { lt: staleBefore } }],
+      },
+      data: { claimedAt },
+    });
+    return result.count > 0;
+  }
+
+  async markSent(id: string, at: Date): Promise<boolean> {
+    const result = await this.prisma.emailOutbox.updateMany({
+      where: { id },
+      data: { status: "SENT", succeededAt: at, claimedAt: null },
+    });
+    return result.count > 0;
+  }
+
+  async markDeadLetter(id: string, at: Date, error: string): Promise<boolean> {
+    const result = await this.prisma.emailOutbox.updateMany({
+      where: { id },
+      data: { status: "DEAD_LETTER", failedAt: at, lastError: error, claimedAt: null },
+    });
+    return result.count > 0;
+  }
+
+  async recordTransientFailure(
+    id: string,
+    attemptCount: number,
+    nextAttemptAt: Date,
+    error: string,
+  ): Promise<boolean> {
+    const result = await this.prisma.emailOutbox.updateMany({
+      where: { id },
+      data: { attemptCount, nextAttemptAt, lastError: error, claimedAt: null },
+    });
+    return result.count > 0;
+  }
+
+  async countPending(): Promise<number> {
+    return this.prisma.emailOutbox.count({ where: { status: "PENDING" } });
+  }
+
+  async oldestPendingAge(now: Date): Promise<number> {
+    const oldest = await this.prisma.emailOutbox.findFirst({
+      where: { status: "PENDING" },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    });
+    if (!oldest) return 0;
+    return Math.max(0, now.getTime() - oldest.createdAt.getTime());
+  }
+}
+
+function toRecord(row: PrismaEmailOutboxRow): EmailOutboxRecord {
+  return {
+    id: row.id,
+    kind: KIND_DB_TO_DOMAIN[row.kind],
+    payload: row.payload as EmailOutboxPayload,
+    idempotencyKey: row.idempotencyKey,
+    status: STATUS_DB_TO_DOMAIN[row.status],
+    attemptCount: row.attemptCount,
+    nextAttemptAt: row.nextAttemptAt,
+    claimedAt: row.claimedAt,
+    lastError: row.lastError,
+    succeededAt: row.succeededAt,
+    failedAt: row.failedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/src/core/email/email-outbox.token.ts
+++ b/src/core/email/email-outbox.token.ts
@@ -1,0 +1,10 @@
+/**
+ * Injection token for the EmailOutboxRecorder.
+ *
+ * Lives in its own file (rather than email-outbox.module.ts) so
+ * EmailModule can import it without pulling the whole outbox module
+ * graph — that prevents a circular import between EmailModule
+ * (provides EmailService) and EmailOutboxModule (consumes
+ * EmailService's drivers via the adapter).
+ */
+export const EMAIL_OUTBOX_RECORDER = Symbol.for("lt:EmailOutboxRecorder");

--- a/src/core/email/email-outbox.ts
+++ b/src/core/email/email-outbox.ts
@@ -6,11 +6,7 @@ import {
   type EmailOutboxStatus,
   planEmailRetry,
 } from "./email-outbox-planner.js";
-import type {
-  EmailSendResult,
-  SendOptions,
-  SendTemplateOptions,
-} from "./email.service.js";
+import type { EmailSendResult, SendOptions, SendTemplateOptions } from "./email.service.js";
 
 /**
  * Email-Outbox subsystem.

--- a/src/core/email/email-outbox.ts
+++ b/src/core/email/email-outbox.ts
@@ -1,0 +1,243 @@
+import { uuidV7 } from "../uuid/uuid-v7.js";
+import {
+  DEFAULT_EMAIL_OUTBOX_RETRY,
+  type EmailOutboxErrorKind,
+  type EmailOutboxRetryConfig,
+  type EmailOutboxStatus,
+  planEmailRetry,
+} from "./email-outbox-planner.js";
+import type {
+  EmailSendResult,
+  SendOptions,
+  SendTemplateOptions,
+} from "./email.service.js";
+
+/**
+ * Email-Outbox subsystem.
+ *
+ * `EmailService.send / sendTemplate` (when invoked with `mode:
+ * "outbox"`) writes a record here and returns immediately with a
+ * synthetic message id (`outbox:<uuid>`). A worker (Nest scheduled
+ * lifecycle, see `EmailOutboxModule`) polls pending records and
+ * forwards them to the actual driver — at-least-once delivery with
+ * exponential backoff, idempotency-key dedup, and a hard
+ * dead-letter ceiling.
+ *
+ * Storage and driver are injected so unit tests run DB-free; the
+ * Prisma binding lives next to the module for the same reason.
+ */
+
+export type EmailOutboxKind = "send" | "sendTemplate";
+
+/** Persisted payload — exactly the args the EmailService method needs. */
+export type EmailOutboxPayload = SendOptions | SendTemplateOptions;
+
+export interface EmailOutboxRecord {
+  id: string;
+  kind: EmailOutboxKind;
+  payload: EmailOutboxPayload;
+  /** Optional dedup key — see EmailOutboxRecorder.enqueue(). */
+  idempotencyKey: string | null;
+  status: EmailOutboxStatus;
+  attemptCount: number;
+  nextAttemptAt: Date | null;
+  /** Set by the worker before dispatch; cleared after the attempt. */
+  claimedAt: Date | null;
+  lastError: string | null;
+  succeededAt: Date | null;
+  failedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** What a recorder writes — the long-lived fields are storage-managed. */
+export interface AppendInput {
+  id: string;
+  kind: EmailOutboxKind;
+  payload: EmailOutboxPayload;
+  idempotencyKey: string | null;
+  status: "pending";
+  attemptCount: 0;
+  nextAttemptAt: null;
+  claimedAt: null;
+  lastError: null;
+  succeededAt: null;
+  failedAt: null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface EmailOutboxStorage {
+  append(record: AppendInput): Promise<void>;
+  /** Returns the existing record for `key`, or null if free. */
+  findByIdempotencyKey(key: string): Promise<EmailOutboxRecord | null>;
+  /** Returns dispatchable records (pending, due, no fresh claim). */
+  listDispatchable(now: Date, limit: number): Promise<EmailOutboxRecord[]>;
+  /** Atomic claim — returns false if a sibling already grabbed the record. */
+  claim(id: string, claimedAt: Date): Promise<boolean>;
+  markSent(id: string, at: Date): Promise<boolean>;
+  markDeadLetter(id: string, at: Date, error: string): Promise<boolean>;
+  recordTransientFailure(
+    id: string,
+    attemptCount: number,
+    nextAttemptAt: Date,
+    error: string,
+  ): Promise<boolean>;
+  countPending(): Promise<number>;
+  /** Age in ms of the oldest pending record, or 0 if none. */
+  oldestPendingAge(now: Date): Promise<number>;
+}
+
+/** Driver wrapper — the worker is decoupled from EmailService internals. */
+export interface EmailOutboxDriver {
+  dispatch(record: EmailOutboxRecord): Promise<EmailSendResult>;
+}
+
+export interface EnqueueInput {
+  kind: EmailOutboxKind;
+  payload: EmailOutboxPayload;
+  /** Optional dedup token — duplicate enqueues return the existing record. */
+  idempotencyKey?: string;
+}
+
+export interface EmailOutboxRecorderOptions {
+  storage: EmailOutboxStorage;
+  /** Override for tests; defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+export class EmailOutboxRecorder {
+  private readonly storage: EmailOutboxStorage;
+  private readonly now: () => Date;
+
+  constructor(options: EmailOutboxRecorderOptions) {
+    this.storage = options.storage;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async enqueue(input: EnqueueInput): Promise<EmailOutboxRecord> {
+    if (input.idempotencyKey) {
+      const existing = await this.storage.findByIdempotencyKey(input.idempotencyKey);
+      if (existing) return existing;
+    }
+    const now = this.now();
+    const record: AppendInput = {
+      id: uuidV7(),
+      kind: input.kind,
+      payload: input.payload,
+      idempotencyKey: input.idempotencyKey ?? null,
+      status: "pending",
+      attemptCount: 0,
+      nextAttemptAt: null,
+      claimedAt: null,
+      lastError: null,
+      succeededAt: null,
+      failedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.storage.append(record);
+    return record satisfies EmailOutboxRecord;
+  }
+}
+
+export interface EmailOutboxWorkerOptions {
+  storage: EmailOutboxStorage;
+  driver: EmailOutboxDriver;
+  /** Override for tests; defaults to `() => new Date()`. */
+  now?: () => Date;
+  retry?: EmailOutboxRetryConfig;
+  batchSize?: number;
+}
+
+export interface EmailOutboxRunResult {
+  /** Records that completed successfully on this tick. */
+  sent: number;
+  /** Records that failed transiently and were rescheduled. */
+  retry: number;
+  /** Records that hit the cap or returned a permanent error. */
+  deadLetter: number;
+}
+
+export class EmailOutboxWorker {
+  private readonly storage: EmailOutboxStorage;
+  private readonly driver: EmailOutboxDriver;
+  private readonly now: () => Date;
+  private readonly retry: EmailOutboxRetryConfig;
+  private readonly batchSize: number;
+
+  constructor(options: EmailOutboxWorkerOptions) {
+    this.storage = options.storage;
+    this.driver = options.driver;
+    this.now = options.now ?? (() => new Date());
+    this.retry = options.retry ?? DEFAULT_EMAIL_OUTBOX_RETRY;
+    this.batchSize = options.batchSize ?? 25;
+  }
+
+  async runOnce(): Promise<EmailOutboxRunResult> {
+    const now = this.now();
+    const candidates = await this.storage.listDispatchable(now, this.batchSize);
+    const result: EmailOutboxRunResult = { sent: 0, retry: 0, deadLetter: 0 };
+
+    for (const candidate of candidates) {
+      const claimedAt = this.now();
+      const claimed = await this.storage.claim(candidate.id, claimedAt);
+      // claim() returns false when another worker beat us to it — in
+      // that case we silently skip this candidate and let the sibling
+      // process complete the record.
+      if (!claimed) continue;
+
+      try {
+        await this.driver.dispatch(candidate);
+        await this.storage.markSent(candidate.id, this.now());
+        result.sent++;
+      } catch (raw) {
+        const error = toError(raw);
+        const errorKind = classifyErrorKind(raw);
+        const attemptCount = candidate.attemptCount + 1;
+        const plan = planEmailRetry({
+          attemptCount,
+          errorKind,
+          now: this.now(),
+          config: this.retry,
+        });
+        if (plan.terminal) {
+          await this.storage.markDeadLetter(candidate.id, this.now(), error.message);
+          result.deadLetter++;
+        } else {
+          await this.storage.recordTransientFailure(
+            candidate.id,
+            attemptCount,
+            plan.nextAttemptAt!,
+            error.message,
+          );
+          result.retry++;
+        }
+      }
+    }
+
+    return result;
+  }
+}
+
+function toError(raw: unknown): Error {
+  if (raw instanceof Error) return raw;
+  return new Error(typeof raw === "string" ? raw : JSON.stringify(raw));
+}
+
+/**
+ * Map a thrown value to a transient/permanent classification.
+ *
+ * Rule: drivers MAY tag the error with a `kind` property; otherwise
+ * we default to `transient` (better to retry an unknown failure than
+ * dead-letter a recoverable one). The SMTP / Brevo drivers from
+ * issue #7 attach their own classification — until they do, this
+ * default keeps mail flowing.
+ */
+function classifyErrorKind(raw: unknown): EmailOutboxErrorKind {
+  if (raw && typeof raw === "object" && "kind" in raw) {
+    const kind = (raw as { kind?: unknown }).kind;
+    if (kind === "permanent") return "permanent";
+  }
+  return "transient";
+}

--- a/src/core/email/email.module.ts
+++ b/src/core/email/email.module.ts
@@ -12,11 +12,13 @@ import {
 import {
   type EmailDriver,
   type EmailMessage,
+  type EmailOutboxEnqueuer,
   type EmailSendResult,
   type EmailTemplateRenderer,
   EmailService,
 } from "./email.service.js";
 import { ReactEmailTemplateRenderer } from "./email-templates.react.js";
+import { EMAIL_OUTBOX_RECORDER } from "./email-outbox.token.js";
 
 /**
  * Logs the message to stdout instead of sending. Default driver when
@@ -104,7 +106,7 @@ export function selectEmailDriver(input: DriverSelectionInput): DriverSelection 
   providers: [
     {
       provide: EmailService,
-      useFactory: (): EmailService => {
+      useFactory: (outbox?: EmailOutboxEnqueuer): EmailService => {
         const env = process.env as Record<string, string | undefined>;
         const features = loadFeatures(env);
         const selection = selectEmailDriver({
@@ -129,8 +131,15 @@ export function selectEmailDriver(input: DriverSelectionInput): DriverSelection 
         if (selection.transactional) {
           options.transactional = createDriver(selection.transactional, env);
         }
+        // Wire the outbox recorder when EmailOutboxModule is in the
+        // import graph. EmailService stays usable without it (direct
+        // mode); only `mode: "outbox"` calls would then throw.
+        if (outbox) options.outbox = outbox;
         return new EmailService(options);
       },
+      // Optional inject — EmailService still works in test setups
+      // that don't pull in the outbox module.
+      inject: [{ token: EMAIL_OUTBOX_RECORDER, optional: true }],
     },
   ],
   exports: [EmailService],

--- a/src/core/email/email.service.ts
+++ b/src/core/email/email.service.ts
@@ -10,7 +10,23 @@
  *     sendTemplate() → brevoTemplateId   → transactional driver
  *                       (no Id)          → renderer + primary
  *
- * Two cross-cutting concerns sit in front of every send:
+ * Delivery modes (per call, see SendDispatchOptions):
+ *   - `direct`  (default) — synchronous driver call; the returned
+ *                EmailSendResult carries the real provider
+ *                message-id.
+ *   - `outbox`            — write the request to the email-outbox
+ *                table and return immediately with a synthetic
+ *                `outbox:<uuid>` message-id and `driver: "outbox"`.
+ *                The actual transport happens on the worker
+ *                (EmailOutboxWorker) with exponential backoff and
+ *                dead-letter on persistent failure. Better-Auth
+ *                hooks (#8) opt into this mode so a crash between
+ *                trigger and SMTP-ACK doesn't lose verification
+ *                mails.
+ *
+ * Two cross-cutting concerns sit in front of every send (in BOTH
+ * modes — dev whitelist + rate-limit run before the outbox write
+ * so a denied recipient never reaches the worker):
  *   - dev whitelist (only allow specific recipient patterns)
  *   - per-recipient rate-limit
  *
@@ -64,6 +80,12 @@ export interface EmailServiceOptions {
   defaultFrom: string;
   devWhitelist?: string[];
   rateLimit?: EmailRateLimiter;
+  /**
+   * Optional outbox enqueuer — when set, callers may pass
+   * `mode: "outbox"` to defer transport to the worker. When unset,
+   * `mode: "outbox"` throws `EmailOutboxNotConfiguredError`.
+   */
+  outbox?: EmailOutboxEnqueuer;
 }
 
 export interface SendOptions {
@@ -81,6 +103,39 @@ export interface SendTemplateOptions {
   vars?: object;
   brevoTemplateId?: number;
   from?: string;
+}
+
+/**
+ * Per-call dispatch options.
+ *
+ * `mode` defaults to `"direct"` for backwards compatibility with
+ * pre-#11 callers. The Better-Auth hook layer is the canonical
+ * `"outbox"` consumer; project code may opt in case-by-case.
+ */
+export interface SendDispatchOptions {
+  mode?: "direct" | "outbox";
+  /**
+   * Idempotency token forwarded to the outbox enqueuer. Two
+   * `mode: "outbox"` calls with the same key dedupe to a single
+   * outbox row — the second call returns the same synthetic id.
+   * Ignored in `direct` mode.
+   */
+  idempotencyKey?: string;
+}
+
+/**
+ * Structural slice of `EmailOutboxRecorder` consumed by the service.
+ *
+ * Restricting the contract to `enqueue()` keeps the unit tests free
+ * of storage / driver / planner concerns — they pass a tiny fake
+ * that records the call.
+ */
+export interface EmailOutboxEnqueuer {
+  enqueue(input: {
+    kind: "send" | "sendTemplate";
+    payload: SendOptions | SendTemplateOptions;
+    idempotencyKey?: string;
+  }): Promise<{ id: string; kind: "send" | "sendTemplate"; payload: unknown; status: string }>;
 }
 
 export class EmailRecipientNotAllowedError extends Error {
@@ -106,21 +161,41 @@ export class TransactionalDriverMissingError extends Error {
   }
 }
 
+export class EmailOutboxNotConfiguredError extends Error {
+  constructor() {
+    super('email: mode "outbox" requested but no outbox enqueuer was configured');
+    this.name = "EmailOutboxNotConfiguredError";
+  }
+}
+
 export class EmailService {
   constructor(private readonly options: EmailServiceOptions) {}
 
-  async send(opts: SendOptions): Promise<EmailSendResult> {
+  async send(opts: SendOptions, dispatch?: SendDispatchOptions): Promise<EmailSendResult> {
     this.assertAllowed(opts.to);
     this.assertWithinRateLimit(opts.to);
+    if (dispatch?.mode === "outbox") {
+      const result = await this.enqueueViaOutbox("send", opts, dispatch.idempotencyKey);
+      this.options.rateLimit?.record(opts.to);
+      return result;
+    }
     const message = this.composeMessage(opts);
     const result = await this.options.primary.send(message);
     this.options.rateLimit?.record(opts.to);
     return result;
   }
 
-  async sendTemplate(opts: SendTemplateOptions): Promise<EmailSendResult> {
+  async sendTemplate(
+    opts: SendTemplateOptions,
+    dispatch?: SendDispatchOptions,
+  ): Promise<EmailSendResult> {
     this.assertAllowed(opts.to);
     this.assertWithinRateLimit(opts.to);
+    if (dispatch?.mode === "outbox") {
+      const result = await this.enqueueViaOutbox("sendTemplate", opts, dispatch.idempotencyKey);
+      this.options.rateLimit?.record(opts.to);
+      return result;
+    }
     const vars = opts.vars ?? {};
     let result: EmailSendResult;
     if (opts.brevoTemplateId !== undefined) {
@@ -149,6 +224,20 @@ export class EmailService {
     }
     this.options.rateLimit?.record(opts.to);
     return result;
+  }
+
+  private async enqueueViaOutbox(
+    kind: "send" | "sendTemplate",
+    payload: SendOptions | SendTemplateOptions,
+    idempotencyKey?: string,
+  ): Promise<EmailSendResult> {
+    if (!this.options.outbox) throw new EmailOutboxNotConfiguredError();
+    const record = await this.options.outbox.enqueue({
+      kind,
+      payload,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
+    });
+    return { messageId: `outbox:${record.id}`, driver: "outbox" };
   }
 
   private composeMessage(opts: SendOptions): EmailMessage {

--- a/src/core/health/health.service.ts
+++ b/src/core/health/health.service.ts
@@ -1,5 +1,11 @@
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable, Optional } from "@nestjs/common";
 
+import {
+  classifyEmailOutboxLag,
+  type EmailOutboxHealthResult,
+} from "../email/email-outbox-health.js";
+import { EMAIL_OUTBOX_STORAGE } from "../email/email-outbox.module.js";
+import type { EmailOutboxStorage } from "../email/email-outbox.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 
 export interface CheckResult {
@@ -12,16 +18,28 @@ export interface ReadinessReport {
   status: "ok" | "fail";
   checks: {
     database: CheckResult;
+    /**
+     * Present when the EmailOutboxModule is wired (always true in
+     * production). The probe inspects pending count + oldest age and
+     * flags `fail` if the worker is stalling — the load balancer
+     * drains this instance so downstream Better-Auth verification
+     * mails don't keep stacking up.
+     */
+    emailOutbox?: EmailOutboxHealthResult;
   };
 }
 
 /**
- * Aggregates readiness checks. Currently only Postgres connectivity —
- * later slices add Redis/RustFS/queue once those land.
+ * Aggregates readiness checks. Currently Postgres connectivity +
+ * email-outbox lag (issue #11). Later slices add Redis/RustFS once
+ * those land.
  */
 @Injectable()
 export class HealthService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    @Optional() @Inject(EMAIL_OUTBOX_STORAGE) private readonly emailOutbox?: EmailOutboxStorage,
+  ) {}
 
   async checkDatabase(): Promise<CheckResult> {
     const start = performance.now();
@@ -37,9 +55,39 @@ export class HealthService {
     }
   }
 
+  async checkEmailOutbox(): Promise<EmailOutboxHealthResult | undefined> {
+    if (!this.emailOutbox) return undefined;
+    try {
+      const now = new Date();
+      const [pendingCount, oldestAgeMs] = await Promise.all([
+        this.emailOutbox.countPending(),
+        this.emailOutbox.oldestPendingAge(now),
+      ]);
+      return classifyEmailOutboxLag({ pendingCount, oldestAgeMs });
+    } catch (error) {
+      // A storage error here surfaces as `fail` so the LB drains
+      // the instance — better than reporting "ok" while the outbox
+      // tests are silently broken.
+      return {
+        status: "fail",
+        pendingCount: 0,
+        lagMs: 0,
+        thresholdMs: 0,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
   async readiness(): Promise<ReadinessReport> {
-    const database = await this.checkDatabase();
-    const status: ReadinessReport["status"] = database.status === "ok" ? "ok" : "fail";
-    return { status, checks: { database } };
+    const [database, emailOutbox] = await Promise.all([
+      this.checkDatabase(),
+      this.checkEmailOutbox(),
+    ]);
+    const dbOk = database.status === "ok";
+    const outboxOk = !emailOutbox || emailOutbox.status === "ok";
+    const status: ReadinessReport["status"] = dbOk && outboxOk ? "ok" : "fail";
+    const checks: ReadinessReport["checks"] = { database };
+    if (emailOutbox) checks.emailOutbox = emailOutbox;
+    return { status, checks };
   }
 }

--- a/tests/email-outbox-flow.e2e-spec.ts
+++ b/tests/email-outbox-flow.e2e-spec.ts
@@ -1,0 +1,123 @@
+import type { INestApplication, LoggerService } from "@nestjs/common";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { EmailService } from "../src/core/email/email.service.js";
+import {
+  EMAIL_OUTBOX_STORAGE,
+  EmailOutboxRecorderProvider,
+  EmailOutboxWorkerLifecycle,
+} from "../src/core/email/email-outbox.module.js";
+import type { EmailOutboxStorage } from "../src/core/email/email-outbox.js";
+import { PrismaService } from "../src/core/prisma/prisma.service.js";
+
+const SILENT_LOGGER: LoggerService = {
+  log() {},
+  warn() {},
+  error() {},
+  debug() {},
+  verbose() {},
+};
+
+/**
+ * E2E · Email-Outbox flow.
+ *
+ * Drives the full at-least-once pipeline:
+ *   - EmailService.send({ mode: "outbox" }) writes a record
+ *   - EmailOutboxWorker tick claims + dispatches via the configured
+ *     driver (log-only in this suite — features.email is off without
+ *     SMTP_HOST set)
+ *   - Record graduates to status "sent"
+ *
+ * `/dev/outbox.json` and `/health/ready` reflect the state so
+ * operators see the same thing the worker sees.
+ */
+describe("E2E · Email-Outbox flow", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let emailService: EmailService;
+  let worker: EmailOutboxWorkerLifecycle;
+  let storage: EmailOutboxStorage;
+  let recorder: EmailOutboxRecorderProvider;
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    prisma = app.get(PrismaService);
+    emailService = app.get(EmailService);
+    worker = app.get(EmailOutboxWorkerLifecycle);
+    storage = app.get<EmailOutboxStorage>(EMAIL_OUTBOX_STORAGE);
+    recorder = app.get(EmailOutboxRecorderProvider);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(async () => {
+    await prisma.emailOutbox.deleteMany({});
+  });
+
+  it("EmailService.send({ mode: 'outbox' }) writes a pending row", async () => {
+    const result = await emailService.send(
+      { to: "to@example.com", subject: "Hi", text: "hello" },
+      { mode: "outbox" },
+    );
+    expect(result.driver).toBe("outbox");
+    expect(result.messageId).toMatch(/^outbox:/);
+
+    const row = await prisma.emailOutbox.findFirstOrThrow();
+    expect(row.status).toBe("PENDING");
+    expect(row.kind).toBe("SEND");
+  });
+
+  it("worker tick processes pending rows and marks them sent", async () => {
+    await emailService.send(
+      { to: "a@example.com", subject: "Hi a", text: "x" },
+      { mode: "outbox" },
+    );
+    await emailService.send(
+      { to: "b@example.com", subject: "Hi b", text: "y" },
+      { mode: "outbox" },
+    );
+    await emailService.send(
+      { to: "c@example.com", subject: "Hi c", text: "z" },
+      { mode: "outbox" },
+    );
+
+    const pendingBefore = await storage.countPending();
+    expect(pendingBefore).toBe(3);
+
+    await worker.tickOnce();
+
+    const pendingAfter = await storage.countPending();
+    expect(pendingAfter).toBe(0);
+    const sentRows = await prisma.emailOutbox.findMany({ where: { status: "SENT" } });
+    expect(sentRows).toHaveLength(3);
+  });
+
+  it("idempotency key dedups two enqueues of the same payload", async () => {
+    const first = await emailService.send(
+      { to: "dup@example.com", subject: "First", text: "x" },
+      { mode: "outbox", idempotencyKey: "verify:dup-1" },
+    );
+    const second = await emailService.send(
+      { to: "dup@example.com", subject: "Second", text: "y" },
+      { mode: "outbox", idempotencyKey: "verify:dup-1" },
+    );
+    expect(second.messageId).toBe(first.messageId);
+    const all = await prisma.emailOutbox.findMany();
+    expect(all).toHaveLength(1);
+    // The first call's payload wins — second call dedupes.
+    expect((all[0]!.payload as { subject: string }).subject).toBe("First");
+  });
+
+  it("recorder is the same provider as injected EMAIL_OUTBOX_RECORDER", () => {
+    expect(recorder).toBeDefined();
+    // The factory wires this recorder into EmailService — calling
+    // through the service writes via the same recorder, so a row
+    // shows up under both inspection paths.
+    expect(typeof recorder.enqueue).toBe("function");
+  });
+});

--- a/tests/email-outbox-prisma.e2e-spec.ts
+++ b/tests/email-outbox-prisma.e2e-spec.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+
+import {
+  EmailOutboxRecorder,
+  EmailOutboxWorker,
+  type EmailOutboxDriver,
+} from "../src/core/email/email-outbox.js";
+import { PrismaEmailOutboxStorage } from "../src/core/email/email-outbox.prisma.js";
+
+/**
+ * E2E · Prisma-backed Email-Outbox storage.
+ *
+ * Verifies the recorder + worker against the real `email_outbox`
+ * table — covers the SQL paths that the in-memory fakes can't
+ * exercise (idempotency unique constraint, atomic claim, status
+ * transitions, lag query).
+ */
+describe("E2E · Prisma email-outbox storage", () => {
+  let prisma: PrismaClient;
+  let storage: PrismaEmailOutboxStorage;
+
+  beforeAll(() => {
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL required for the email-outbox e2e suite");
+    prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) });
+    storage = new PrismaEmailOutboxStorage(prisma);
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    // Test isolation — each test starts from a clean table.
+    await prisma.emailOutbox.deleteMany({});
+  });
+
+  it("appends a record and reads it back as dispatchable", async () => {
+    const recorder = new EmailOutboxRecorder({ storage });
+    const entry = await recorder.enqueue({
+      kind: "send",
+      payload: { to: "test@example.com", subject: "Hi", html: "<b>hi</b>" },
+    });
+    expect(entry.id).toBeDefined();
+
+    const list = await storage.listDispatchable(new Date(), 10);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.kind).toBe("send");
+  });
+
+  it("idempotency-key dedups concurrent enqueues to a single row", async () => {
+    const recorder = new EmailOutboxRecorder({ storage });
+    const a = await recorder.enqueue({
+      kind: "send",
+      idempotencyKey: "verify:user-1",
+      payload: { to: "u@example.com", subject: "Verify", html: "<a>x</a>" },
+    });
+    const b = await recorder.enqueue({
+      kind: "send",
+      idempotencyKey: "verify:user-1",
+      payload: { to: "u@example.com", subject: "Verify (dup)", html: "<a>y</a>" },
+    });
+    expect(b.id).toBe(a.id);
+    const all = await prisma.emailOutbox.findMany();
+    expect(all).toHaveLength(1);
+  });
+
+  it("worker dispatches a pending record and marks it sent", async () => {
+    const recorder = new EmailOutboxRecorder({ storage });
+    await recorder.enqueue({
+      kind: "send",
+      payload: { to: "test@example.com", subject: "Hi", html: "<b>hi</b>" },
+    });
+
+    const driver: EmailOutboxDriver = {
+      async dispatch() {
+        return { messageId: "ok-1", driver: "fake" };
+      },
+    };
+    const worker = new EmailOutboxWorker({ storage, driver, batchSize: 10 });
+    const result = await worker.runOnce();
+    expect(result.sent).toBe(1);
+
+    const row = await prisma.emailOutbox.findFirstOrThrow();
+    expect(row.status).toBe("SENT");
+    expect(row.succeededAt).not.toBeNull();
+    expect(row.claimedAt).toBeNull();
+  });
+
+  it("worker dead-letters after maxAttempts transient failures", async () => {
+    const recorder = new EmailOutboxRecorder({ storage });
+    await recorder.enqueue({
+      kind: "send",
+      payload: { to: "test@example.com", subject: "Hi", html: "<b>hi</b>" },
+    });
+
+    const driver: EmailOutboxDriver = {
+      async dispatch() {
+        throw new Error("transient boom");
+      },
+    };
+    let now = new Date();
+    const worker = new EmailOutboxWorker({
+      storage,
+      driver,
+      now: () => now,
+      retry: {
+        initialDelayMs: 1,
+        factor: 2,
+        maxDelayMs: 1000,
+        maxAttempts: 2,
+      },
+      batchSize: 10,
+    });
+
+    const r1 = await worker.runOnce();
+    expect(r1.retry).toBe(1);
+    let row = await prisma.emailOutbox.findFirstOrThrow();
+    expect(row.status).toBe("PENDING");
+    expect(row.attemptCount).toBe(1);
+
+    // Advance past the backoff and tick again.
+    now = new Date(row.nextAttemptAt!.getTime() + 1);
+    const r2 = await worker.runOnce();
+    expect(r2.deadLetter).toBe(1);
+    row = await prisma.emailOutbox.findFirstOrThrow();
+    expect(row.status).toBe("DEAD_LETTER");
+    expect(row.lastError).toMatch(/transient/);
+    expect(row.failedAt).not.toBeNull();
+  });
+
+  it("oldestPendingAge() reports lag for the readiness probe", async () => {
+    const recorder = new EmailOutboxRecorder({ storage });
+    await recorder.enqueue({
+      kind: "send",
+      payload: { to: "test@example.com", subject: "Hi", html: "<b>hi</b>" },
+    });
+    const lagFresh = await storage.oldestPendingAge(new Date());
+    expect(lagFresh).toBeGreaterThanOrEqual(0);
+
+    // Manually move the createdAt back one minute → lag ~60s.
+    await prisma.emailOutbox.updateMany({
+      data: { createdAt: new Date(Date.now() - 60_000) },
+    });
+    const lagOld = await storage.oldestPendingAge(new Date());
+    expect(lagOld).toBeGreaterThanOrEqual(60_000);
+  });
+});

--- a/tests/stories/better-auth-email-hooks-outbox.story.test.ts
+++ b/tests/stories/better-auth-email-hooks-outbox.story.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmailHookRunner,
+  type EmailSenderForHooks,
+} from "../../src/core/auth/better-auth-email-hooks.runner.js";
+
+/**
+ * Story · Better-Auth hook runner uses outbox mode.
+ *
+ * Issue #11 acceptance: hooks must enqueue mail via the email-outbox
+ * (mode: "outbox" + an idempotency-key derived from the hook
+ * payload) so a server crash between trigger and SMTP-ACK never
+ * loses verification / reset mails. The runner surface stays
+ * unchanged; the second arg flowing into sender.sendTemplate is the
+ * SendDispatchOptions object EmailService accepts.
+ */
+describe("Story · Better-Auth hook runner outbox dispatch", () => {
+  function recordingSender(): EmailSenderForHooks & {
+    calls: Array<{
+      template: string;
+      to: string;
+      vars: object;
+      dispatch?: { mode?: string; idempotencyKey?: string };
+    }>;
+  } {
+    const calls: Array<{
+      template: string;
+      to: string;
+      vars: object;
+      dispatch?: { mode?: string; idempotencyKey?: string };
+    }> = [];
+    return {
+      calls,
+      async sendTemplate(args, dispatch) {
+        calls.push({
+          template: args.template,
+          to: args.to,
+          vars: args.vars ?? {},
+          ...(dispatch ? { dispatch } : {}),
+        });
+        return { messageId: `m-${calls.length}`, driver: "outbox" };
+      },
+    };
+  }
+
+  const user = { id: "u1", email: "alice@example.com", name: "Alice" };
+  const appName = "Acme";
+
+  it("forwards mode: 'outbox' + a stable idempotencyKey for verification mails", async () => {
+    const sender = recordingSender();
+    const runner = createEmailHookRunner({ sender, appName, useOutbox: true });
+    await runner.sendVerificationEmail({
+      user,
+      url: "https://x/verify?t=tok-123",
+      token: "tok-123",
+    });
+    expect(sender.calls).toHaveLength(1);
+    expect(sender.calls[0]?.dispatch?.mode).toBe("outbox");
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toBeDefined();
+    // Two enqueues with the same payload share the same key — that's
+    // the dedup contract for "user clicks Resend twice".
+    await runner.sendVerificationEmail({
+      user,
+      url: "https://x/verify?t=tok-123",
+      token: "tok-123",
+    });
+    expect(sender.calls[1]?.dispatch?.idempotencyKey).toBe(
+      sender.calls[0]?.dispatch?.idempotencyKey,
+    );
+  });
+
+  it("derives idempotency-keys for password-reset mails from the token", async () => {
+    const sender = recordingSender();
+    const runner = createEmailHookRunner({ sender, appName, useOutbox: true });
+    await runner.sendResetPassword({
+      user,
+      url: "https://x/reset?t=reset-1",
+      token: "reset-1",
+    });
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain("password-reset");
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain("reset-1");
+  });
+
+  it("welcome mails get a per-user key (no token in the payload)", async () => {
+    const sender = recordingSender();
+    const runner = createEmailHookRunner({ sender, appName, useOutbox: true });
+    await runner.sendWelcome({ user });
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain("welcome");
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain(user.id);
+  });
+
+  it("default mode (useOutbox: false) sends synchronously without dispatch options", async () => {
+    const sender = recordingSender();
+    const runner = createEmailHookRunner({ sender, appName });
+    await runner.sendVerificationEmail({
+      user,
+      url: "https://x/verify",
+      token: "t1",
+    });
+    expect(sender.calls[0]?.dispatch).toBeUndefined();
+  });
+});

--- a/tests/stories/email-outbox-health.story.test.ts
+++ b/tests/stories/email-outbox-health.story.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EMAIL_OUTBOX_LAG_THRESHOLD_MS,
+  classifyEmailOutboxLag,
+} from "../../src/core/email/email-outbox-health.js";
+
+/**
+ * Story · Email-Outbox lag classifier.
+ *
+ * The readiness probe consults the lag classifier to decide whether
+ * to flag the outbox subsystem as stalled. The classifier is pure
+ * (no DB, no clock) so the storyline stays deterministic — the
+ * caller passes the current oldestPendingAge value.
+ */
+describe("Story · Email-Outbox lag classifier", () => {
+  it("returns ok when there are no pending records", () => {
+    const r = classifyEmailOutboxLag({ pendingCount: 0, oldestAgeMs: 0 });
+    expect(r.status).toBe("ok");
+    expect(r.lagMs).toBe(0);
+  });
+
+  it("returns ok when lag is below threshold", () => {
+    const r = classifyEmailOutboxLag({ pendingCount: 3, oldestAgeMs: 5_000 });
+    expect(r.status).toBe("ok");
+    expect(r.lagMs).toBe(5_000);
+  });
+
+  it("returns fail when oldestAgeMs exceeds the threshold", () => {
+    const r = classifyEmailOutboxLag({
+      pendingCount: 1,
+      oldestAgeMs: EMAIL_OUTBOX_LAG_THRESHOLD_MS + 1,
+    });
+    expect(r.status).toBe("fail");
+    expect(r.error).toMatch(/lag/i);
+  });
+
+  it("respects an explicit threshold override", () => {
+    const r = classifyEmailOutboxLag({ pendingCount: 1, oldestAgeMs: 6_000, thresholdMs: 5_000 });
+    expect(r.status).toBe("fail");
+  });
+});

--- a/tests/stories/email-outbox-planner.story.test.ts
+++ b/tests/stories/email-outbox-planner.story.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_EMAIL_OUTBOX_RETRY,
+  STALE_CLAIM_THRESHOLD_MS,
+  isStaleClaim,
+  planEmailRetry,
+  shouldDispatchNow,
+} from "../../src/core/email/email-outbox-planner.js";
+
+/**
+ * Story · Email-Outbox planner.
+ *
+ * Pure functions used by `EmailOutboxWorker` and `EmailOutboxRecorder`:
+ *
+ *  - `planEmailRetry()`  computes next-attempt time / terminal state
+ *    given current `attemptCount`, the (transient/permanent) error
+ *    classification, and `now`.
+ *  - `shouldDispatchNow()` decides whether a record is due for the
+ *    current tick — pending status, no live claim, `nextAttemptAt`
+ *    in the past.
+ *  - `isStaleClaim()` flags claim-timestamps older than the
+ *    crash-safety threshold so the worker can rescue them.
+ *
+ * Splitting the decisions out keeps the worker dispatch loop a thin
+ * runner — the math is testable without DB or driver wiring.
+ */
+describe("Story · Email-Outbox planner", () => {
+  const NOW = new Date("2026-04-30T12:00:00.000Z");
+
+  describe("planEmailRetry()", () => {
+    it("returns exponential delays following the configured factor", () => {
+      const cfg = DEFAULT_EMAIL_OUTBOX_RETRY;
+      const r1 = planEmailRetry({ attemptCount: 1, errorKind: "transient", now: NOW, config: cfg });
+      const r2 = planEmailRetry({ attemptCount: 2, errorKind: "transient", now: NOW, config: cfg });
+      const r3 = planEmailRetry({ attemptCount: 3, errorKind: "transient", now: NOW, config: cfg });
+
+      expect(r1.terminal).toBe(false);
+      expect(r2.terminal).toBe(false);
+      expect(r3.terminal).toBe(false);
+
+      // Each subsequent retry waits longer than the previous one.
+      const d1 = r1.nextAttemptAt!.getTime() - NOW.getTime();
+      const d2 = r2.nextAttemptAt!.getTime() - NOW.getTime();
+      const d3 = r3.nextAttemptAt!.getTime() - NOW.getTime();
+      expect(d2).toBeGreaterThan(d1);
+      expect(d3).toBeGreaterThan(d2);
+
+      // Configured factor ⇒ each delay is `factor x` the previous.
+      expect(d2).toBe(d1 * cfg.factor);
+      expect(d3).toBe(d2 * cfg.factor);
+    });
+
+    it("caps the delay at maxDelayMs", () => {
+      const cfg = { ...DEFAULT_EMAIL_OUTBOX_RETRY, maxDelayMs: 60_000, maxAttempts: 100 };
+      const r = planEmailRetry({ attemptCount: 50, errorKind: "transient", now: NOW, config: cfg });
+      expect(r.terminal).toBe(false);
+      const delta = r.nextAttemptAt!.getTime() - NOW.getTime();
+      expect(delta).toBeLessThanOrEqual(60_000);
+    });
+
+    it("marks the record terminal once attemptCount reaches maxAttempts", () => {
+      const cfg = DEFAULT_EMAIL_OUTBOX_RETRY;
+      const r = planEmailRetry({
+        attemptCount: cfg.maxAttempts,
+        errorKind: "transient",
+        now: NOW,
+        config: cfg,
+      });
+      expect(r.terminal).toBe(true);
+      expect(r.nextAttemptAt).toBeUndefined();
+    });
+
+    it("treats permanent errors as terminal on the first attempt", () => {
+      const cfg = DEFAULT_EMAIL_OUTBOX_RETRY;
+      const r = planEmailRetry({ attemptCount: 1, errorKind: "permanent", now: NOW, config: cfg });
+      expect(r.terminal).toBe(true);
+      expect(r.nextAttemptAt).toBeUndefined();
+    });
+
+    it("rejects non-positive attempt counts", () => {
+      const cfg = DEFAULT_EMAIL_OUTBOX_RETRY;
+      expect(() =>
+        planEmailRetry({ attemptCount: 0, errorKind: "transient", now: NOW, config: cfg }),
+      ).toThrow(/attempt/i);
+    });
+  });
+
+  describe("shouldDispatchNow()", () => {
+    it("returns true for pending records whose nextAttemptAt is in the past", () => {
+      expect(
+        shouldDispatchNow({
+          status: "pending",
+          nextAttemptAt: new Date(NOW.getTime() - 1000),
+          claimedAt: null,
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true for pending records with null nextAttemptAt (first try)", () => {
+      expect(
+        shouldDispatchNow({
+          status: "pending",
+          nextAttemptAt: null,
+          claimedAt: null,
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when nextAttemptAt is still in the future", () => {
+      expect(
+        shouldDispatchNow({
+          status: "pending",
+          nextAttemptAt: new Date(NOW.getTime() + 60_000),
+          claimedAt: null,
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns false for terminal statuses", () => {
+      for (const status of ["sent", "dead-letter"] as const) {
+        expect(
+          shouldDispatchNow({
+            status,
+            nextAttemptAt: new Date(NOW.getTime() - 60_000),
+            claimedAt: null,
+            now: NOW,
+          }),
+        ).toBe(false);
+      }
+    });
+
+    it("returns false when a fresh claim exists (someone else is sending)", () => {
+      expect(
+        shouldDispatchNow({
+          status: "pending",
+          nextAttemptAt: null,
+          claimedAt: new Date(NOW.getTime() - 1000), // 1s ago — fresh
+          now: NOW,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns true when the claim is stale (worker probably crashed)", () => {
+      expect(
+        shouldDispatchNow({
+          status: "pending",
+          nextAttemptAt: null,
+          claimedAt: new Date(NOW.getTime() - STALE_CLAIM_THRESHOLD_MS - 1),
+          now: NOW,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("isStaleClaim()", () => {
+    it("returns false for fresh claims", () => {
+      expect(isStaleClaim(new Date(NOW.getTime() - 1000), NOW)).toBe(false);
+    });
+    it("returns true for claims older than the threshold", () => {
+      expect(isStaleClaim(new Date(NOW.getTime() - STALE_CLAIM_THRESHOLD_MS - 1), NOW)).toBe(true);
+    });
+    it("returns false for null", () => {
+      expect(isStaleClaim(null, NOW)).toBe(false);
+    });
+  });
+});

--- a/tests/stories/email-outbox.story.test.ts
+++ b/tests/stories/email-outbox.story.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  EmailOutboxRecorder,
+  EmailOutboxWorker,
+  type EmailOutboxDriver,
+  type EmailOutboxRecord,
+  type EmailOutboxStorage,
+} from "../../src/core/email/email-outbox.js";
+import { DEFAULT_EMAIL_OUTBOX_RETRY } from "../../src/core/email/email-outbox-planner.js";
+
+/**
+ * Story · Email-Outbox recorder + worker.
+ *
+ * Recorder writes pending records (with optional idempotency-key
+ * dedup); worker claims due records, dispatches to a driver, and
+ * transitions them to `sent` / `dead-letter`. Failures fall back into
+ * `pending` with `nextAttemptAt` shifted by the backoff planner.
+ */
+describe("Story · Email-Outbox", () => {
+  function makeStorage(): EmailOutboxStorage & { records: EmailOutboxRecord[] } {
+    const records: EmailOutboxRecord[] = [];
+    return {
+      get records() {
+        return records;
+      },
+      async append(record) {
+        records.push({ ...record });
+      },
+      async findByIdempotencyKey(key) {
+        return records.find((r) => r.idempotencyKey === key) ?? null;
+      },
+      async listDispatchable(now, limit) {
+        return records
+          .filter((r) => {
+            if (r.status !== "pending") return false;
+            // Skip live claims (fresh claimedAt within stale-window)
+            if (r.claimedAt) {
+              const ageMs = now.getTime() - r.claimedAt.getTime();
+              if (ageMs <= 30_000) return false;
+            }
+            if (r.nextAttemptAt && r.nextAttemptAt.getTime() > now.getTime()) return false;
+            return true;
+          })
+          .slice(0, limit)
+          .map((r) => ({ ...r }));
+      },
+      async claim(id, claimedAt) {
+        const r = records.find((rec) => rec.id === id);
+        if (!r) return false;
+        if (r.status !== "pending") return false;
+        if (r.claimedAt) {
+          const ageMs = claimedAt.getTime() - r.claimedAt.getTime();
+          if (ageMs <= 30_000) return false;
+        }
+        r.claimedAt = claimedAt;
+        return true;
+      },
+      async markSent(id, at) {
+        const r = records.find((rec) => rec.id === id);
+        if (!r) return false;
+        r.status = "sent";
+        r.succeededAt = at;
+        r.claimedAt = null;
+        return true;
+      },
+      async markDeadLetter(id, at, error) {
+        const r = records.find((rec) => rec.id === id);
+        if (!r) return false;
+        r.status = "dead-letter";
+        r.failedAt = at;
+        r.lastError = error;
+        r.claimedAt = null;
+        return true;
+      },
+      async recordTransientFailure(id, attemptCount, nextAttemptAt, error) {
+        const r = records.find((rec) => rec.id === id);
+        if (!r) return false;
+        r.attemptCount = attemptCount;
+        r.nextAttemptAt = nextAttemptAt;
+        r.lastError = error;
+        r.claimedAt = null;
+        return true;
+      },
+      async countPending() {
+        return records.filter((r) => r.status === "pending").length;
+      },
+      async oldestPendingAge(now) {
+        const pending = records.filter((r) => r.status === "pending");
+        if (pending.length === 0) return 0;
+        const oldest = pending.reduce((a, b) => (a.createdAt < b.createdAt ? a : b));
+        return Math.max(0, now.getTime() - oldest.createdAt.getTime());
+      },
+    };
+  }
+
+  function fakeDriver(opts?: {
+    failKind?: "transient" | "permanent";
+    failTimes?: number;
+  }): EmailOutboxDriver & { calls: number } {
+    let calls = 0;
+    const failTimes = opts?.failTimes ?? 0;
+    return {
+      get calls() {
+        return calls;
+      },
+      async dispatch(_record) {
+        calls++;
+        if (calls <= failTimes) {
+          const err = new Error(`fail #${calls}`);
+          (err as { kind?: string }).kind = opts?.failKind ?? "transient";
+          throw err;
+        }
+        return { messageId: `msg-${calls}`, driver: "fake" };
+      },
+    };
+  }
+
+  let now: Date;
+  beforeEach(() => {
+    now = new Date("2026-04-30T12:00:00.000Z");
+  });
+
+  describe("EmailOutboxRecorder", () => {
+    it("appends a pending record with the supplied payload", async () => {
+      const storage = makeStorage();
+      const rec = new EmailOutboxRecorder({ storage, now: () => now });
+      const entry = await rec.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+      expect(entry.id).toBeDefined();
+      expect(entry.status).toBe("pending");
+      expect(entry.attemptCount).toBe(0);
+      expect(entry.kind).toBe("send");
+      expect(storage.records).toHaveLength(1);
+    });
+
+    it("dedupes by idempotencyKey — second enqueue returns the first record", async () => {
+      const storage = makeStorage();
+      const rec = new EmailOutboxRecorder({ storage, now: () => now });
+      const a = await rec.enqueue({
+        kind: "send",
+        idempotencyKey: "reset:user@example.com:abc",
+        payload: { to: "user@example.com", subject: "Reset", html: "<a>x</a>" },
+      });
+      const b = await rec.enqueue({
+        kind: "send",
+        idempotencyKey: "reset:user@example.com:abc",
+        payload: { to: "user@example.com", subject: "Reset (dup)", html: "<a>y</a>" },
+      });
+      expect(b.id).toBe(a.id);
+      expect(storage.records).toHaveLength(1);
+    });
+
+    it("supports send-template payloads", async () => {
+      const storage = makeStorage();
+      const rec = new EmailOutboxRecorder({ storage, now: () => now });
+      const entry = await rec.enqueue({
+        kind: "sendTemplate",
+        payload: {
+          to: "user@example.com",
+          template: "password-reset",
+          vars: { resetUrl: "https://x" },
+        },
+      });
+      expect(entry.kind).toBe("sendTemplate");
+      expect(storage.records[0]!.kind).toBe("sendTemplate");
+    });
+  });
+
+  describe("EmailOutboxWorker", () => {
+    it("runOnce() dispatches a pending record and marks it sent", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      await recorder.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+
+      const driver = fakeDriver();
+      const worker = new EmailOutboxWorker({
+        storage,
+        driver,
+        now: () => now,
+        retry: DEFAULT_EMAIL_OUTBOX_RETRY,
+        batchSize: 10,
+      });
+      const result = await worker.runOnce();
+      expect(result.sent).toBe(1);
+      expect(result.deadLetter).toBe(0);
+      expect(result.retry).toBe(0);
+      expect(driver.calls).toBe(1);
+      expect(storage.records[0]!.status).toBe("sent");
+      expect(storage.records[0]!.succeededAt).toBeInstanceOf(Date);
+    });
+
+    it("retries a transient failure with backoff and eventually succeeds", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      await recorder.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+
+      const driver = fakeDriver({ failKind: "transient", failTimes: 1 });
+      const worker = new EmailOutboxWorker({
+        storage,
+        driver,
+        now: () => now,
+        retry: DEFAULT_EMAIL_OUTBOX_RETRY,
+        batchSize: 10,
+      });
+
+      const r1 = await worker.runOnce();
+      expect(r1.retry).toBe(1);
+      expect(storage.records[0]!.status).toBe("pending");
+      expect(storage.records[0]!.attemptCount).toBe(1);
+      expect(storage.records[0]!.nextAttemptAt!.getTime()).toBeGreaterThan(now.getTime());
+
+      // Advance past the backoff window.
+      now = new Date(storage.records[0]!.nextAttemptAt!.getTime() + 1);
+      const r2 = await worker.runOnce();
+      expect(r2.sent).toBe(1);
+      expect(storage.records[0]!.status).toBe("sent");
+    });
+
+    it("escalates a permanent failure to dead-letter on first attempt", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      await recorder.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+
+      const driver = fakeDriver({ failKind: "permanent", failTimes: 99 });
+      const worker = new EmailOutboxWorker({
+        storage,
+        driver,
+        now: () => now,
+        retry: DEFAULT_EMAIL_OUTBOX_RETRY,
+        batchSize: 10,
+      });
+
+      const result = await worker.runOnce();
+      expect(result.deadLetter).toBe(1);
+      expect(storage.records[0]!.status).toBe("dead-letter");
+      expect(storage.records[0]!.lastError).toMatch(/fail/);
+    });
+
+    it("escalates to dead-letter when max attempts is reached", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      await recorder.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+
+      // 2-attempt cap so we don't have to fast-forward five times.
+      const cfg = { ...DEFAULT_EMAIL_OUTBOX_RETRY, maxAttempts: 2 };
+      const driver = fakeDriver({ failKind: "transient", failTimes: 99 });
+      const worker = new EmailOutboxWorker({
+        storage,
+        driver,
+        now: () => now,
+        retry: cfg,
+        batchSize: 10,
+      });
+
+      // Attempt 1 → still retryable.
+      const r1 = await worker.runOnce();
+      expect(r1.retry).toBe(1);
+      expect(storage.records[0]!.status).toBe("pending");
+
+      // Advance past the backoff and run again — attempt 2 hits the
+      // ceiling and the record is dead-lettered.
+      now = new Date(storage.records[0]!.nextAttemptAt!.getTime() + 1);
+      const r2 = await worker.runOnce();
+      expect(r2.deadLetter).toBe(1);
+      expect(storage.records[0]!.status).toBe("dead-letter");
+    });
+
+    it("runOnce() does not dispatch records whose nextAttemptAt is still in the future", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      await recorder.enqueue({
+        kind: "send",
+        payload: { to: "user@example.com", subject: "Hi", html: "<b>hi</b>" },
+      });
+
+      const driver = fakeDriver({ failKind: "transient", failTimes: 1 });
+      const worker = new EmailOutboxWorker({
+        storage,
+        driver,
+        now: () => now,
+        retry: DEFAULT_EMAIL_OUTBOX_RETRY,
+        batchSize: 10,
+      });
+      await worker.runOnce(); // moves to retry, nextAttemptAt in future
+
+      // Run again immediately — no time has passed.
+      const r = await worker.runOnce();
+      expect(r.sent).toBe(0);
+      expect(r.retry).toBe(0);
+      expect(r.deadLetter).toBe(0);
+      // Driver was only called once (the original attempt).
+      expect(driver.calls).toBe(1);
+    });
+
+    it("reports lag = age of the oldest pending record", async () => {
+      const storage = makeStorage();
+      const recorder = new EmailOutboxRecorder({ storage, now: () => now });
+      const earlier = new Date(now.getTime() - 60_000);
+      // Override createdAt to simulate an old pending record.
+      storage.records.push({
+        id: "rec-1",
+        kind: "send",
+        payload: { to: "u@x", subject: "S", html: "<b>x</b>" },
+        idempotencyKey: null,
+        status: "pending",
+        attemptCount: 0,
+        nextAttemptAt: null,
+        claimedAt: null,
+        lastError: null,
+        succeededAt: null,
+        failedAt: null,
+        createdAt: earlier,
+        updatedAt: earlier,
+      });
+      void recorder;
+
+      const lag = await storage.oldestPendingAge(now);
+      expect(lag).toBe(60_000);
+    });
+  });
+});

--- a/tests/stories/email-service-outbox.story.test.ts
+++ b/tests/stories/email-service-outbox.story.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  EmailService,
+  type EmailDriver,
+  type EmailMessage,
+  type EmailOutboxEnqueuer,
+  type EmailSendResult,
+  type EmailTemplateRenderer,
+} from "../../src/core/email/email.service.js";
+
+/**
+ * Story · EmailService outbox mode.
+ *
+ * The default behaviour stays "send synchronously and return the
+ * driver result". Issue #11 adds an `EmailOutboxEnqueuer` injection
+ * and a per-call `mode: "outbox"` flag. When the flag is set, the
+ * service writes the args to the enqueuer and returns immediately
+ * with a synthetic `outbox:<id>` message id — the worker handles
+ * delivery on the next tick.
+ *
+ * Idempotency keys forwarded by the caller flow into the enqueuer so
+ * Better-Auth's "user clicks resend twice in 5s" pattern dedupes
+ * before it reaches the SMTP relay.
+ */
+describe("Story · EmailService outbox mode", () => {
+  function fakeDriver(name = "nodemailer"): EmailDriver & {
+    sent: Array<{ msg: EmailMessage; templateId?: number; vars?: object }>;
+  } {
+    const sent: Array<{ msg: EmailMessage; templateId?: number; vars?: object }> = [];
+    return {
+      name,
+      sent,
+      async send(msg): Promise<EmailSendResult> {
+        sent.push({ msg });
+        return { messageId: `${name}-${sent.length}`, driver: name };
+      },
+      async sendTemplate(msg, templateId, vars): Promise<EmailSendResult> {
+        sent.push({ msg, templateId, vars });
+        return { messageId: `${name}-tpl-${sent.length}`, driver: name };
+      },
+    };
+  }
+
+  function fakeRenderer(): EmailTemplateRenderer & {
+    calls: Array<{ template: string; locale: string; vars: object }>;
+  } {
+    const calls: Array<{ template: string; locale: string; vars: object }> = [];
+    return {
+      calls,
+      async render(template, locale, vars) {
+        calls.push({ template, locale, vars });
+        return {
+          subject: `[${template}] subject`,
+          html: `<p>${template}</p>`,
+          text: template,
+        };
+      },
+    };
+  }
+
+  function fakeEnqueuer(): EmailOutboxEnqueuer & {
+    enqueued: Array<{ kind: "send" | "sendTemplate"; payload: object; idempotencyKey?: string }>;
+  } {
+    const enqueued: Array<{
+      kind: "send" | "sendTemplate";
+      payload: object;
+      idempotencyKey?: string;
+    }> = [];
+    return {
+      enqueued,
+      async enqueue(input) {
+        enqueued.push({
+          kind: input.kind,
+          payload: input.payload as object,
+          ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
+        });
+        return {
+          id: `rec-${enqueued.length}`,
+          kind: input.kind,
+          payload: input.payload,
+          status: "pending",
+        };
+      },
+    };
+  }
+
+  it("send({ mode: 'outbox' }) writes to the enqueuer instead of the driver", async () => {
+    const primary = fakeDriver();
+    const outbox = fakeEnqueuer();
+    const svc = new EmailService({
+      primary,
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+      outbox,
+    });
+
+    const result = await svc.send(
+      { to: "a@example.com", subject: "hi", text: "hello" },
+      { mode: "outbox" },
+    );
+
+    expect(primary.sent).toHaveLength(0);
+    expect(outbox.enqueued).toHaveLength(1);
+    expect(outbox.enqueued[0]?.kind).toBe("send");
+    expect(result.driver).toBe("outbox");
+    expect(result.messageId).toMatch(/^outbox:/);
+  });
+
+  it("send() defaults to direct mode (back-compat)", async () => {
+    const primary = fakeDriver();
+    const outbox = fakeEnqueuer();
+    const svc = new EmailService({
+      primary,
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+      outbox,
+    });
+    const result = await svc.send({ to: "a@example.com", subject: "hi", text: "hello" });
+    expect(primary.sent).toHaveLength(1);
+    expect(outbox.enqueued).toHaveLength(0);
+    expect(result.driver).toBe("nodemailer");
+  });
+
+  it("sendTemplate({ mode: 'outbox' }) writes a sendTemplate record", async () => {
+    const primary = fakeDriver();
+    const outbox = fakeEnqueuer();
+    const svc = new EmailService({
+      primary,
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+      outbox,
+    });
+
+    const result = await svc.sendTemplate(
+      {
+        to: "a@example.com",
+        template: "password-reset",
+        vars: { resetUrl: "https://x" },
+      },
+      { mode: "outbox" },
+    );
+
+    expect(primary.sent).toHaveLength(0);
+    expect(outbox.enqueued).toHaveLength(1);
+    expect(outbox.enqueued[0]?.kind).toBe("sendTemplate");
+    expect(result.driver).toBe("outbox");
+  });
+
+  it("forwards an idempotencyKey through to the enqueuer", async () => {
+    const primary = fakeDriver();
+    const outbox = fakeEnqueuer();
+    const svc = new EmailService({
+      primary,
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+      outbox,
+    });
+
+    await svc.send(
+      { to: "a@example.com", subject: "hi", text: "hello" },
+      { mode: "outbox", idempotencyKey: "verify:user-1" },
+    );
+
+    expect(outbox.enqueued[0]?.idempotencyKey).toBe("verify:user-1");
+  });
+
+  it("throws when mode is 'outbox' but no enqueuer is configured", async () => {
+    const svc = new EmailService({
+      primary: fakeDriver(),
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+    });
+    await expect(
+      svc.send({ to: "a@example.com", subject: "hi", text: "hello" }, { mode: "outbox" }),
+    ).rejects.toThrow(/outbox/i);
+  });
+
+  it("dev-whitelist + rate-limit still apply when enqueuing", async () => {
+    const primary = fakeDriver();
+    const outbox = fakeEnqueuer();
+    const svc = new EmailService({
+      primary,
+      renderer: fakeRenderer(),
+      defaultFrom: "noreply@example.com",
+      outbox,
+      devWhitelist: ["*@example.com"],
+    });
+    await expect(
+      svc.send({ to: "real@user.io", subject: "s", text: "t" }, { mode: "outbox" }),
+    ).rejects.toThrow(/whitelist/);
+    expect(outbox.enqueued).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Routes `EmailService.send / sendTemplate` through a Postgres-backed email-outbox so a server crash between trigger and SMTP-ACK never loses a verification / reset / welcome mail.

- **Schema**: new `email_outbox` table (kind / payload / status / attempt / claim / next-attempt / lastError) with a unique-when-present `idempotency_key` index for dedup. Migration `20260430170000_email_outbox`.
- **Subsystem**: `EmailOutboxRecorder` (writes pending rows + dedup) + `EmailOutboxWorker` (claims, dispatches, retries with exponential backoff: 1m → 5m → 25m, 2h cap, 5 attempts, then `dead-letter`). Worker tick interval is configurable via `EMAIL_OUTBOX_TICK_MS`. Pure planners cover backoff, dispatch eligibility, and stale-claim detection.
- **EmailService**: new `SendDispatchOptions` arg — `send(opts, { mode: "outbox", idempotencyKey })`. Default stays `direct` for back-compat. Whitelist + rate-limit run before the outbox write. New `outbox:<uuid>` synthetic message-id.
- **Better-Auth hooks** default to `useOutbox: true` with deterministic idempotency-keys (`<kind>:<recipient>:<token>`), so duplicate triggers (Resend click) collapse to one row but a fresh request re-enqueues.
- **Health**: `/health/ready` consults the new lag classifier and returns 503 if oldest-pending age > 30 s.
- **Visibility**: `/dev/outbox.json` returns lag classification + 100 most-recent dispatchable rows.
- README + `src/core/email/CLAUDE.md` describe the new mode and surfaces.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format` — clean
- [x] `bun run test:types` — clean
- [x] `bun run test:unit` — 153 passed
- [x] `bun run build:dev-portal` — built
- [x] `bun run test:e2e` — 2204 passed across 231 files (added: planner / outbox / outbox-health / outbox-flow stories + Prisma adapter e2e + outbox flow e2e + better-auth-outbox dispatch)
- [x] `bun run test:coverage` — lines 92.6%, statements 90.71%, functions 92.54% (above CORE thresholds)
- [x] `bun run build` — wrote 2 artifacts

## Acceptance criteria coverage (issue #11)

- [x] `EmailOutboxRecorder` in `src/core/email/email-outbox.ts` — writes records to a dedicated `email_outbox` table.
- [x] `EmailOutboxWorker` registered as a Nest `OnModuleInit` lifecycle tick — pulls pending records, dispatches via the same driver matrix as `EmailService`.
- [x] Retry policy consistent with the issue's spec (exponential backoff, max 5 attempts, then `dead-letter`).
- [x] `EmailService.send / sendTemplate` accept `mode: "direct" | "outbox"` with `direct` default for back-compat. Better-Auth hooks default to outbox-mode.
- [x] Idempotency-key dedups duplicate enqueues (unique-when-present DB index + recorder lookup).
- [x] Outbox lag is part of `/health/ready` and returns 503 above the 30s threshold.
- [x] Story tests for recorder + worker (pending → sent, transient → retry, terminal → dead-letter) — `tests/stories/email-outbox*.story.test.ts`.
- [x] E2E: `tests/email-outbox-flow.e2e-spec.ts` queues 3 mails, ticks the worker, asserts they all transition to SENT.

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)