### PR TITLE
feat(auth): device-handling + new-device email (closes #13)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "rxjs": "^7.8.2",
         "sharp": "^0.34.5",
         "socket.io": "^4.8.3",
+        "ua-parser-js": "^2.0.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -1082,6 +1083,8 @@
 
     "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
 
+    "detect-europe-js": ["detect-europe-js@0.1.2", "", {}, "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "dezalgo": ["dezalgo@1.0.4", "", { "dependencies": { "asap": "^2.0.0", "wrappy": "1" } }, "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig=="],
@@ -1331,6 +1334,8 @@
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
+
+    "is-standalone-pwa": ["is-standalone-pwa@0.1.1", "", {}, "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="],
 
     "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -1963,6 +1968,10 @@
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "ua-is-frozen": ["ua-is-frozen@0.1.2", "", {}, "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="],
+
+    "ua-parser-js": ["ua-parser-js@2.0.9", "", { "dependencies": { "detect-europe-js": "^0.1.2", "is-standalone-pwa": "^0.1.1", "ua-is-frozen": "^0.1.2" }, "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "rxjs": "^7.8.2",
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
+    "ua-parser-js": "^2.0.9",
     "zod": "^4.3.6"
   },
   "optionalDependencies": {

--- a/prisma/migrations/20260430180000_session_fingerprint/migration.sql
+++ b/prisma/migrations/20260430180000_session_fingerprint/migration.sql
@@ -1,0 +1,21 @@
+-- Device-handling (issue #13).
+--
+-- Adds a `fingerprint` column to the Better-Auth-managed `sessions`
+-- table. The column stores a sha256 hex hash of (mode, userAgent,
+-- masked-ip-prefix) — see src/core/devices/fingerprint.ts for the
+-- exact composition. Privacy contract: we store ONLY the hash; the
+-- raw IP / UA stay in their existing columns and are deleted on
+-- session expiry alongside the row.
+--
+-- Nullable so existing sessions (predating the feature) and
+-- deployments that keep the device-management feature off continue
+-- to work without a backfill.
+
+ALTER TABLE "sessions"
+  ADD COLUMN "fingerprint" VARCHAR(64);
+
+-- Compound index — the device-handling planner reads "all known
+-- fingerprints for a user" on every sign-in, so a (user_id,
+-- fingerprint) covering index keeps the lookup index-only.
+CREATE INDEX "sessions_user_id_fingerprint_idx"
+  ON "sessions" ("user_id", "fingerprint");

--- a/prisma/schema.generated.prisma
+++ b/prisma/schema.generated.prisma
@@ -123,12 +123,18 @@ model Session {
   expiresAt DateTime @map("expires_at")
   ipAddress String?  @map("ip_address")
   userAgent String?  @map("user_agent")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  // Device-handling (#13). sha256 hex of (mode, ua, masked-ip).
+  // Project-extension column (NOT a Better-Auth core field) — kept
+  // optional so older sessions / non-feature deployments continue
+  // to work without a backfill.
+  fingerprint String?  @db.VarChar(64)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@index([userId, fingerprint])
   @@map("sessions")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,12 +119,18 @@ model Session {
   expiresAt DateTime @map("expires_at")
   ipAddress String?  @map("ip_address")
   userAgent String?  @map("user_agent")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  // Device-handling (#13). sha256 hex of (mode, ua, masked-ip).
+  // Project-extension column (NOT a Better-Auth core field) — kept
+  // optional so older sessions / non-feature deployments continue
+  // to work without a backfill.
+  fingerprint String?  @db.VarChar(64)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+  @@index([userId, fingerprint])
   @@map("sessions")
 }
 

--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -8,6 +8,7 @@ import { BetterAuthModule } from "../auth/better-auth.module.js";
 import { PowerSyncModule } from "../auth/powersync.module.js";
 import { BetterAuthSessionMiddleware } from "../auth/session-middleware.js";
 import { ConfigModule } from "../config/config.module.js";
+import { DeviceModule } from "../devices/device.module.js";
 import { DevHubModule } from "../dx/dev-hub.module.js";
 import { EmailModule } from "../email/email.module.js";
 import { EmailOutboxModule } from "../email/email-outbox.module.js";
@@ -75,6 +76,7 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
     GdprModule,
     GeoModule,
     GeoIpModule,
+    DeviceModule,
     PowerSyncModule,
     IdempotencyModule,
     // EmailOutboxModule must come BEFORE EmailModule so the

--- a/src/core/auth/CLAUDE.md
+++ b/src/core/auth/CLAUDE.md
@@ -28,12 +28,12 @@ auth/
 attaches three hook closures driven by a shared
 `createEmailHookRunner()`:
 
-| Better-Auth hook                           | Template             | Vars                                                                                |
-| ------------------------------------------ | -------------------- | ----------------------------------------------------------------------------------- |
-| `emailVerification.sendVerificationEmail`  | `email-verification` | `recipientName`, `appName`, `verificationUrl`                                       |
-| `emailAndPassword.sendResetPassword`       | `password-reset`     | `recipientName`, `appName`, `resetUrl`                                              |
-| `emailVerification.afterEmailVerification` | `welcome`            | `recipientName`, `appName`                                                          |
-| (manual call) `runner.sendInvitation()`    | `invitation`         | `recipientName`, `appName`, `acceptUrl`, `senderName`                               |
+| Better-Auth hook                           | Template             | Vars                                                                                          |
+| ------------------------------------------ | -------------------- | --------------------------------------------------------------------------------------------- |
+| `emailVerification.sendVerificationEmail`  | `email-verification` | `recipientName`, `appName`, `verificationUrl`                                                 |
+| `emailAndPassword.sendResetPassword`       | `password-reset`     | `recipientName`, `appName`, `resetUrl`                                                        |
+| `emailVerification.afterEmailVerification` | `welcome`            | `recipientName`, `appName`                                                                    |
+| (manual call) `runner.sendInvitation()`    | `invitation`         | `recipientName`, `appName`, `acceptUrl`, `senderName`                                         |
 | `databaseHooks.session.create.after` (#13) | `new-device`         | `recipientName`, `appName`, `deviceLabel`, `location`, `ipAddress`, `signedInAt`, `revokeUrl` |
 
 The `invitation` template fires when project code calls the runner

--- a/src/core/auth/CLAUDE.md
+++ b/src/core/auth/CLAUDE.md
@@ -28,12 +28,13 @@ auth/
 attaches three hook closures driven by a shared
 `createEmailHookRunner()`:
 
-| Better-Auth hook                           | Template             | Vars                                                  |
-| ------------------------------------------ | -------------------- | ----------------------------------------------------- |
-| `emailVerification.sendVerificationEmail`  | `email-verification` | `recipientName`, `appName`, `verificationUrl`         |
-| `emailAndPassword.sendResetPassword`       | `password-reset`     | `recipientName`, `appName`, `resetUrl`                |
-| `emailVerification.afterEmailVerification` | `welcome`            | `recipientName`, `appName`                            |
-| (manual call) `runner.sendInvitation()`    | `invitation`         | `recipientName`, `appName`, `acceptUrl`, `senderName` |
+| Better-Auth hook                           | Template             | Vars                                                                                |
+| ------------------------------------------ | -------------------- | ----------------------------------------------------------------------------------- |
+| `emailVerification.sendVerificationEmail`  | `email-verification` | `recipientName`, `appName`, `verificationUrl`                                       |
+| `emailAndPassword.sendResetPassword`       | `password-reset`     | `recipientName`, `appName`, `resetUrl`                                              |
+| `emailVerification.afterEmailVerification` | `welcome`            | `recipientName`, `appName`                                                          |
+| (manual call) `runner.sendInvitation()`    | `invitation`         | `recipientName`, `appName`, `acceptUrl`, `senderName`                               |
+| `databaseHooks.session.create.after` (#13) | `new-device`         | `recipientName`, `appName`, `deviceLabel`, `location`, `ipAddress`, `signedInAt`, `revokeUrl` |
 
 The `invitation` template fires when project code calls the runner
 directly — the framework-managed Better-Auth instance does not own
@@ -74,6 +75,27 @@ queues up for retry instead of just logging.
 | Thin runner (error handling) | `tests/stories/better-auth-email-hook-runner.story.test.ts`  |
 | Factory wiring (in-memory)   | `tests/stories/better-auth-email-hooks-wiring.story.test.ts` |
 | Full e2e (boots app + DB)    | `tests/better-auth-email-hooks.e2e-spec.ts`                  |
+
+## Device-handling (issue #13)
+
+`buildBetterAuth({ deviceHandling: { runner } })` registers a
+`databaseHooks.session.create.after` hook that fires on every
+session-create. The runner (`src/core/devices/device-handling
+.runner.ts`) computes a fingerprint from the session's UA + IP,
+persists it on the row, looks up the user's other sessions, and
+either:
+
+- skips silently (first sign-in / known fingerprint),
+- enqueues the new-device email through this same EmailHookRunner,
+- and/or revokes the oldest session when the per-user cap is
+  exceeded.
+
+`BetterAuthModule` wires the runner only when
+`features.deviceManagement.enabled === true`; with the feature off
+the hook isn't registered at all and the auth path is byte-for-byte
+identical to pre-#13 behaviour. See
+[`src/core/devices/CLAUDE.md`](../devices/CLAUDE.md) for the
+fingerprint strategy + privacy contract.
 
 ## Adding a new hook (template)
 

--- a/src/core/auth/better-auth-email-hooks.runner.ts
+++ b/src/core/auth/better-auth-email-hooks.runner.ts
@@ -1,5 +1,6 @@
 import { Logger } from "@nestjs/common";
 
+import type { NewDeviceThrottle } from "../devices/new-device-throttle.js";
 import { buildEmailHookPayload, type BetterAuthEmailUser } from "./better-auth-email-hooks.js";
 
 /**
@@ -45,7 +46,7 @@ export interface EmailSenderForHooks {
 export interface EmailHookErrorContext {
   template: string;
   to?: string;
-  kind: "email-verification" | "password-reset" | "welcome" | "invitation";
+  kind: "email-verification" | "password-reset" | "welcome" | "invitation" | "new-device";
 }
 
 export interface EmailHookRunnerOptions {
@@ -66,6 +67,13 @@ export interface EmailHookRunnerOptions {
    * trigger (Resend / retry click) collapses to one outbox row.
    */
   useOutbox?: boolean;
+  /**
+   * Optional throttle for the `new-device` mail (issue #13). Caps
+   * notifications at 1 per user per hour by default — a roaming
+   * mobile would otherwise produce a stream of fingerprints and
+   * matching mails. When omitted the dispatch is unthrottled.
+   */
+  newDeviceThrottle?: NewDeviceThrottle;
 }
 
 export interface VerificationHookData {
@@ -91,11 +99,23 @@ export interface InvitationHookData {
   senderName?: string;
 }
 
+export interface NewDeviceHookData {
+  user: BetterAuthEmailUser;
+  /** sha256 fingerprint of the new device — feeds the dedup key. */
+  fingerprint: string;
+  deviceLabel: string;
+  location: string;
+  ipAddress: string;
+  signedInAt: string;
+  revokeUrl: string;
+}
+
 export interface BetterAuthEmailHookRunner {
   sendVerificationEmail(data: VerificationHookData): Promise<void>;
   sendResetPassword(data: ResetPasswordHookData): Promise<void>;
   sendWelcome(data: WelcomeHookData): Promise<void>;
   sendInvitation(data: InvitationHookData): Promise<void>;
+  sendNewDevice(data: NewDeviceHookData): Promise<void>;
 }
 
 export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAuthEmailHookRunner {
@@ -113,6 +133,7 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
     kind: EmailHookErrorContext["kind"],
     builder: () => { template: string; to: string; vars: Record<string, string> },
     idempotencyToken?: string,
+    onSuccess?: () => void,
   ): Promise<void> {
     let plan: { template: string; to: string; vars: Record<string, string> };
     try {
@@ -140,6 +161,7 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
         },
         dispatch,
       );
+      onSuccess?.();
     } catch (raw) {
       onError(toError(raw), { kind, template: plan.template, to: plan.to });
     }
@@ -206,6 +228,42 @@ export function createEmailHookRunner(options: EmailHookRunnerOptions): BetterAu
         // resends with a new URL re-enqueue.
         data.url,
       );
+    },
+    async sendNewDevice(data) {
+      // Throttle: deny → silently drop. The action that triggered
+      // this (a sign-in) succeeded; we just decline to spam the
+      // user. Logged at debug-level by the throttle owner if needed.
+      if (options.newDeviceThrottle) {
+        const decision = options.newDeviceThrottle.check(data.user.id);
+        if (!decision.allowed) return;
+      }
+      let dispatched = false;
+      await send(
+        "new-device",
+        () =>
+          buildEmailHookPayload({
+            kind: "new-device",
+            user: data.user,
+            appName: options.appName,
+            deviceLabel: data.deviceLabel,
+            location: data.location,
+            ipAddress: data.ipAddress,
+            signedInAt: data.signedInAt,
+            revokeUrl: data.revokeUrl,
+          }),
+        // Fingerprint as the dedup-key segment: a sign-in retried
+        // on the same device produces the same hash → outbox dedups.
+        data.fingerprint,
+        () => {
+          dispatched = true;
+        },
+      );
+      // Record the throttle slot only on a real dispatch — a planner
+      // throw or send failure leaves the user able to retry within
+      // the window without losing a slot.
+      if (dispatched && options.newDeviceThrottle) {
+        options.newDeviceThrottle.record(data.user.id);
+      }
     },
   };
 }

--- a/src/core/auth/better-auth-email-hooks.ts
+++ b/src/core/auth/better-auth-email-hooks.ts
@@ -36,7 +36,12 @@ export interface BetterAuthEmailUser {
   displayName?: string;
 }
 
-export type EmailHookKind = "email-verification" | "password-reset" | "welcome" | "invitation";
+export type EmailHookKind =
+  | "email-verification"
+  | "password-reset"
+  | "welcome"
+  | "invitation"
+  | "new-device";
 
 interface BaseHookInput {
   user: BetterAuthEmailUser;
@@ -64,11 +69,26 @@ interface InvitationHookInput extends BaseHookInput {
   senderName: string;
 }
 
+interface NewDeviceHookInput extends BaseHookInput {
+  kind: "new-device";
+  /** Composed UA label, e.g. "Chrome on macOS". Required. */
+  deviceLabel: string;
+  /** "City, Country" string from GeoIP. Empty → "Location unknown". */
+  location: string;
+  /** Raw IP — surfaced in the email body when GeoIP returned nothing. */
+  ipAddress: string;
+  /** ISO timestamp of the sign-in. */
+  signedInAt: string;
+  /** Link to /me/devices for the revoke flow. Required. */
+  revokeUrl: string;
+}
+
 export type EmailHookInput =
   | VerificationHookInput
   | PasswordResetHookInput
   | WelcomeHookInput
-  | InvitationHookInput;
+  | InvitationHookInput
+  | NewDeviceHookInput;
 
 export interface EmailHookPayload {
   template: string;
@@ -173,6 +193,34 @@ export function buildEmailHookPayload(input: EmailHookInput): EmailHookPayload {
         template: "invitation",
         to: recipient,
         vars: { recipientName, appName, acceptUrl: url, senderName },
+      };
+    }
+    case "new-device": {
+      const deviceLabel = trim(input.deviceLabel);
+      if (!deviceLabel) {
+        throw new Error(
+          "better-auth-email-hooks: new-device hook requires a non-empty deviceLabel",
+        );
+      }
+      const revokeUrl = trim(input.revokeUrl);
+      if (!revokeUrl) {
+        throw new Error("better-auth-email-hooks: new-device hook requires a non-empty revokeUrl");
+      }
+      const location = trim(input.location) || "Location unknown";
+      const ipAddress = trim(input.ipAddress);
+      const signedInAt = trim(input.signedInAt);
+      return {
+        template: "new-device",
+        to: recipient,
+        vars: {
+          recipientName,
+          appName,
+          deviceLabel,
+          location,
+          ipAddress,
+          signedInAt,
+          revokeUrl,
+        },
       };
     }
   }

--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -1,12 +1,25 @@
 import { Module } from "@nestjs/common";
 
 import { loadBrandSync } from "../branding/brand-loader.js";
+import {
+  createDeviceHandlingRunner,
+  type DeviceEmailDispatcher,
+  type DeviceHandlingSessionStore,
+  type DeviceHandlingUserLookup,
+} from "../devices/device-handling.runner.js";
+import { createNewDeviceThrottle } from "../devices/new-device-throttle.js";
 import { EmailModule } from "../email/email.module.js";
 import { EmailService } from "../email/email.service.js";
 import { type Features, loadFeatures } from "../features/features.js";
+import { GeoIpModule } from "../geoip/geoip.module.js";
+import { GeoIpService } from "../geoip/geoip.service.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
 import { BetterAuthController } from "./better-auth.controller.js";
+import {
+  createEmailHookRunner,
+  type EmailSenderForHooks,
+} from "./better-auth-email-hooks.runner.js";
 import { resolveAppName } from "./better-auth-email-hooks.js";
 import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from "./better-auth.token.js";
 import { type SocialProviderConfig, buildBetterAuth } from "./better-auth.js";
@@ -28,12 +41,16 @@ const MIN_SECRET_LEN = 32;
  * effectively disabled.
  */
 @Module({
-  imports: [EmailModule],
+  imports: [EmailModule, GeoIpModule],
   controllers: [BetterAuthController],
   providers: [
     {
       provide: BETTER_AUTH_INSTANCE,
-      useFactory: (prisma: PrismaService, email: EmailService): BetterAuthInstance | null => {
+      useFactory: (
+        prisma: PrismaService,
+        email: EmailService,
+        geoIp: GeoIpService,
+      ): BetterAuthInstance | null => {
         const secret = process.env.BETTER_AUTH_SECRET ?? "";
         if (secret.length < MIN_SECRET_LEN) return null;
 
@@ -46,6 +63,41 @@ const MIN_SECRET_LEN = 32;
         // default. Loaded once at provider init — env-watch restart picks
         // up brand.json edits.
         const brand = loadBrandSync();
+
+        // Device-handling (issue #13). Wired only when the feature is
+        // on — the runner short-circuits internally too, but skipping
+        // the wiring keeps the auth path strictly equivalent to pre-#13
+        // behaviour for projects that left the toggle off.
+        const deviceCfg = features.deviceManagement;
+        const newDeviceThrottle = deviceCfg.enabled ? createNewDeviceThrottle() : undefined;
+
+        const hookRunner = deviceCfg.enabled
+          ? createEmailHookRunner({
+              sender: email as unknown as EmailSenderForHooks,
+              appName,
+              useOutbox: true,
+              ...(newDeviceThrottle ? { newDeviceThrottle } : {}),
+            })
+          : undefined;
+
+        const deviceHandling =
+          deviceCfg.enabled && hookRunner
+            ? {
+                runner: createDeviceHandlingRunner({
+                  store: buildPrismaSessionStore(prisma),
+                  email: buildHookEmailDispatcher(hookRunner),
+                  userLookup: buildPrismaUserLookup(prisma),
+                  geoIp,
+                  config: {
+                    enabled: deviceCfg.enabled,
+                    notifyOnNewDevice: deviceCfg.notifyOnNewDevice,
+                    maxDevicesPerUser: deviceCfg.maxDevicesPerUser,
+                    fingerprintMode: deviceCfg.sessionFingerprint,
+                    appBaseUrl: cfg.baseUrl,
+                  },
+                }),
+              }
+            : undefined;
 
         return buildBetterAuth({
           secret,
@@ -67,7 +119,12 @@ const MIN_SECRET_LEN = 32;
           // the EmailModule provides a `log-only` driver, so the hook
           // still completes (with a logged stdout line) instead of
           // silently no-op'ing inside Better-Auth's defaults.
-          emailHooks: { sender: email, appName },
+          emailHooks: {
+            sender: email,
+            appName,
+            ...(newDeviceThrottle ? { newDeviceThrottle } : {}),
+          },
+          ...(deviceHandling ? { deviceHandling } : {}),
           ...(features.authMethods.twoFactor ? { twoFactor: { issuer: brand.name } } : {}),
           ...(features.authMethods.passkey ? { passkey: { rpName: brand.name } } : {}),
           ...(features.authMethods.socialProviders.length > 0
@@ -78,12 +135,73 @@ const MIN_SECRET_LEN = 32;
           ...(features.powerSync.enabled ? { jwtPlugin: { audience: "powersync" } } : {}),
         });
       },
-      inject: [PrismaService, EmailService],
+      inject: [PrismaService, EmailService, GeoIpService],
     },
   ],
   exports: [BETTER_AUTH_INSTANCE],
 })
 export class BetterAuthModule {}
+
+function buildPrismaSessionStore(prisma: PrismaService): DeviceHandlingSessionStore {
+  return {
+    async setFingerprint(sessionId, fingerprint) {
+      await prisma.session.update({
+        where: { id: sessionId },
+        data: { fingerprint },
+      });
+    },
+    async listForUser(userId) {
+      const rows = await prisma.session.findMany({
+        where: { userId },
+        // Drop expired sessions — they're functionally revoked, no
+        // point comparing against a hash that the user can't actually
+        // sign in with anymore.
+        // (Better-Auth's adapter doesn't auto-prune; we filter on read.)
+      });
+      const now = Date.now();
+      return rows
+        .filter((r) => r.expiresAt.getTime() > now)
+        .map((r) => ({
+          id: r.id,
+          fingerprintHash: r.fingerprint ?? "",
+          lastSeenAt: r.updatedAt,
+          createdAt: r.createdAt,
+        }));
+    },
+    async revoke(sessionId) {
+      try {
+        await prisma.session.delete({ where: { id: sessionId } });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  };
+}
+
+function buildPrismaUserLookup(prisma: PrismaService): DeviceHandlingUserLookup {
+  return {
+    async findById(userId) {
+      const user = await prisma.user.findUnique({ where: { id: userId } });
+      if (!user) return null;
+      return {
+        id: user.id,
+        email: user.email,
+        ...(user.name ? { name: user.name } : {}),
+      };
+    },
+  };
+}
+
+function buildHookEmailDispatcher(
+  runner: ReturnType<typeof createEmailHookRunner>,
+): DeviceEmailDispatcher {
+  return {
+    async sendNewDevice(input): Promise<void> {
+      await runner.sendNewDevice(input);
+    },
+  };
+}
 
 function pickSocialProviders(features: Features): SocialProviderConfig {
   const providers: SocialProviderConfig = {};

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -4,11 +4,13 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { jwt } from "better-auth/plugins/jwt";
 import { twoFactor } from "better-auth/plugins/two-factor";
 
+import type { DeviceHandlingRunner } from "../devices/device-handling.runner.js";
 import { resolveBetterAuthMountPath } from "./better-auth-config.js";
 import {
   createEmailHookRunner,
   type EmailSenderForHooks,
 } from "./better-auth-email-hooks.runner.js";
+import type { NewDeviceThrottle } from "../devices/new-device-throttle.js";
 
 /**
  * Better-Auth instance factory.
@@ -95,6 +97,14 @@ export interface BuildBetterAuthInput {
    * back to its built-in default — currently a no-op stub.
    */
   emailHooks?: EmailHooksOptions;
+  /**
+   * Optional device-handling runner (issue #13). When wired, every
+   * session-create lands in `runner.handleSessionCreated(...)` so
+   * the system can fingerprint the device, look up the user's
+   * other sessions, send a "new device" email, and revoke the
+   * oldest session above the per-user cap.
+   */
+  deviceHandling?: { runner: DeviceHandlingRunner };
 }
 
 export interface EmailHooksOptions {
@@ -112,6 +122,12 @@ export interface EmailHooksOptions {
    * has the recorder injected.
    */
   useOutbox?: boolean;
+  /**
+   * Optional throttle for the new-device mail (issue #13). 1 mail
+   * per user per hour by default; provided here so the runner can
+   * use it.
+   */
+  newDeviceThrottle?: NewDeviceThrottle;
 }
 
 export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof betterAuth> {
@@ -182,6 +198,9 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
         // (issue #11). Tests / call-sites that want the legacy direct
         // path can opt out by passing `useOutbox: false`.
         useOutbox: input.emailHooks.useOutbox ?? true,
+        ...(input.emailHooks.newDeviceThrottle
+          ? { newDeviceThrottle: input.emailHooks.newDeviceThrottle }
+          : {}),
       })
     : undefined;
 
@@ -231,12 +250,47 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
         }
       : undefined;
 
+  // Device-handling (issue #13). The runner reads the just-created
+  // session row, computes a fingerprint, and decides whether to
+  // notify the user / revoke an old session. The hook is wired
+  // unconditionally when supplied — the runner itself short-circuits
+  // when the feature flag is off.
+  const deviceRunner = input.deviceHandling?.runner;
+  const databaseHooks = deviceRunner
+    ? {
+        session: {
+          create: {
+            async after(
+              session: {
+                id: string;
+                userId: string;
+                userAgent?: string | null;
+                ipAddress?: string | null;
+              } & Record<string, unknown>,
+            ): Promise<void> {
+              await deviceRunner.handleSessionCreated({
+                sessionId: session.id,
+                // Better-Auth's session payload doesn't carry the
+                // user's email/name — the runner resolves both via
+                // its injected `userLookup` adapter at email-send
+                // time. We forward only the id here.
+                user: { id: session.userId },
+                userAgent: session.userAgent ?? null,
+                ipAddress: session.ipAddress ?? null,
+              });
+            },
+          },
+        },
+      }
+    : undefined;
+
   const options: BetterAuthOptions = {
     secret: input.secret,
     baseURL: input.baseUrl,
     basePath,
     emailAndPassword: emailAndPasswordOptions,
     ...(emailVerificationOptions ? { emailVerification: emailVerificationOptions } : {}),
+    ...(databaseHooks ? { databaseHooks } : {}),
     session: {
       expiresIn: input.sessionExpiresInSeconds,
     },

--- a/src/core/devices/CLAUDE.md
+++ b/src/core/devices/CLAUDE.md
@@ -1,0 +1,142 @@
+# `src/core/devices/` — agent guide
+
+Device-handling subsystem (issue #13). Detects "new device" sign-ins,
+emails the user, and revokes oldest sessions when the per-user cap
+is exceeded. Five files, planner/runner split throughout.
+
+```
+devices/
+├── fingerprint.ts            ← pure: sha256(mode, ua, masked-ip)
+├── ua-parser.ts              ← pure: ua-parser-js wrapper, defensive defaults
+├── device-handling.ts        ← pure: decision planner (known | new | first-sign-in)
+├── new-device-throttle.ts    ← in-memory rate limit (1 mail / user / hour)
+├── device-handling.runner.ts ← orchestrator (Better-Auth hook → plan → email)
+├── device.controller.ts      ← GET /me/devices, DELETE /me/devices/:id
+└── device.module.ts          ← NestJS module for the endpoints
+```
+
+## Activation
+
+Off by default. Enable via:
+
+```bash
+FEATURE_DEVICE_MANAGEMENT_ENABLED=true
+FEATURE_DEVICE_MANAGEMENT_MAX_DEVICES_PER_USER=10        # default 10
+FEATURE_DEVICE_MANAGEMENT_NOTIFY_ON_NEW_DEVICE=true      # default true
+FEATURE_DEVICE_MANAGEMENT_SESSION_FINGERPRINT=userAgent+ipSubnet
+```
+
+`BetterAuthModule` reads `features.deviceManagement` at provider
+init: when off, the `databaseHooks.session.create.after` hook isn't
+even registered — the auth path is byte-for-byte equivalent to
+pre-#13 deployments.
+
+## Fingerprint strategy
+
+`fingerprintSession({ userAgent, ip, mode })` returns
+`sha256(mode | ua | masked-ip)`:
+
+- `userAgent+ipSubnet` (default) — IPv4 → /24, IPv6 → /64. The
+  prefix-mask is the privacy / mobility compromise. A residential
+  ISP rotates the IPv4 host octet on every modem reboot; a mobile
+  carrier rotates it on every cellular hop. Hashing the full IP
+  would mark every "bus-ride wifi → home wifi" hop as new. /24 +
+  /64 line up with how carriers allocate subnets.
+- `userAgent` only — the strict-privacy mode for jurisdictions that
+  forbid IP-based tracking. The IP component is dropped from the
+  hash entirely.
+
+The *mode* is part of the hash input. Flipping the toggle on a live
+deployment produces a fresh fingerprint set instead of silently
+re-classifying every old session as "known".
+
+## Privacy contract
+
+- We store **only the hash** on `sessions.fingerprint`. The raw
+  masked CIDR is an internal intermediate. `maskIp()` is exposed
+  for diagnostics only — callers must not persist its return.
+- Raw IPs / UAs stay in their existing `sessions.ip_address` /
+  `sessions.user_agent` columns and are deleted when the session
+  expires (per Better-Auth's normal lifecycle).
+- The new-device email surfaces **city + country only**. Even when
+  GeoIP returns lat/lng, the runner drops them before rendering.
+  When GeoIP returns nothing usable, the email shows "Location
+  unknown" + the raw IP (so the user has *something* to cross-check
+  against their own router / VPN).
+
+## Throttle policy
+
+`createNewDeviceThrottle()` caps new-device emails at **1 per user
+per hour** (default). The throttle is in-memory; for multi-instance
+deploys, swap the storage with a Redis-backed implementation
+behind the same `NewDeviceThrottle` interface.
+
+The throttle is record-on-success: a denied throttle slot, a
+planner exception, or a queue write failure does **not** burn the
+slot. Users on flaky connections can retry within the window
+without losing their notification budget.
+
+## Device cap + revoke
+
+`decideDeviceHandling({ ..., maxDevicesPerUser })` decides:
+
+- `first-sign-in` — no prior sessions; record the fingerprint, no
+  email (a brand-new account shouldn't get a "new device" mail
+  about its very first session).
+- `known` — a prior session shares the fingerprint; refresh
+  `lastSeenAt` (Prisma's `@updatedAt` does this automatically) and
+  do nothing else.
+- `new-device` — fingerprint is new; enqueue the email. When
+  `(prior sessions count + 1) > cap`, also include
+  `revokeSessionId` pointing at the oldest existing session
+  (NOT the just-created one). The runner deletes the row before
+  emailing so the email's "review devices" link reflects the
+  post-revoke state.
+
+`selectOldestSessionForRevoke()` picks by `lastSeenAt` then
+`createdAt` — the same tie-breaker the controller would use if a
+user manually revokes from the dev-portal.
+
+## Failure semantics
+
+The runner **never throws back into the auth flow**. The sign-in
+already succeeded by the time `databaseHooks.session.create.after`
+runs; any DB error / GeoIP outage / mail queue failure is logged
+to the `DeviceHandling` channel and swallowed.
+
+## Endpoints
+
+`/me/devices` is mounted under `DeviceModule` (always wired,
+independent of the feature flag — the feature gates the *fingerprint
+pipeline*, not the read surface):
+
+| Method | Path                | Auth | Effect                                      |
+| ------ | ------------------- | ---- | ------------------------------------------- |
+| GET    | `/me/devices`       | yes  | Lists the user's active sessions, parsed UA |
+| DELETE | `/me/devices/:id`   | yes  | Revokes a session; ownership check enforced |
+
+Both endpoints are tenant-scoped (the global `TenantInterceptor`
+applies). Frontend / SDK callers must send `x-tenant-id`.
+
+## Tests
+
+| Layer                      | File                                                    |
+| -------------------------- | ------------------------------------------------------- |
+| Fingerprint planner        | `tests/stories/device-fingerprint.story.test.ts`        |
+| UA parser                  | `tests/stories/device-ua-parser.story.test.ts`          |
+| Decision planner           | `tests/stories/device-handling.story.test.ts`           |
+| Email payload              | `tests/stories/new-device-email-payload.story.test.ts`  |
+| Hook runner + throttle     | `tests/stories/new-device-email-runner.story.test.ts`   |
+| Orchestrator (mocked deps) | `tests/stories/device-handling-runner.story.test.ts`    |
+| Full e2e (boots app)       | `tests/devices.e2e-spec.ts`                             |
+
+## Hard rules
+
+- `.js` extension on every relative import (ESM contract).
+- Planners are pure: no I/O, no `Date` construction, no env reads.
+- Every error in the runner pipeline is caught and logged — never
+  thrown back into the Better-Auth hook.
+- Lat/lng never reach the email body — `formatLocation()` drops
+  them even when GeoIP supplies them.
+- The fingerprint hash is the only device-identity we persist; the
+  raw masked-CIDR string is a transient intermediate.

--- a/src/core/devices/CLAUDE.md
+++ b/src/core/devices/CLAUDE.md
@@ -46,7 +46,7 @@ pre-#13 deployments.
   forbid IP-based tracking. The IP component is dropped from the
   hash entirely.
 
-The *mode* is part of the hash input. Flipping the toggle on a live
+The _mode_ is part of the hash input. Flipping the toggle on a live
 deployment produces a fresh fingerprint set instead of silently
 re-classifying every old session as "known".
 
@@ -61,7 +61,7 @@ re-classifying every old session as "known".
 - The new-device email surfaces **city + country only**. Even when
   GeoIP returns lat/lng, the runner drops them before rendering.
   When GeoIP returns nothing usable, the email shows "Location
-  unknown" + the raw IP (so the user has *something* to cross-check
+  unknown" + the raw IP (so the user has _something_ to cross-check
   against their own router / VPN).
 
 ## Throttle policy
@@ -107,28 +107,28 @@ to the `DeviceHandling` channel and swallowed.
 ## Endpoints
 
 `/me/devices` is mounted under `DeviceModule` (always wired,
-independent of the feature flag — the feature gates the *fingerprint
-pipeline*, not the read surface):
+independent of the feature flag — the feature gates the _fingerprint
+pipeline_, not the read surface):
 
-| Method | Path                | Auth | Effect                                      |
-| ------ | ------------------- | ---- | ------------------------------------------- |
-| GET    | `/me/devices`       | yes  | Lists the user's active sessions, parsed UA |
-| DELETE | `/me/devices/:id`   | yes  | Revokes a session; ownership check enforced |
+| Method | Path              | Auth | Effect                                      |
+| ------ | ----------------- | ---- | ------------------------------------------- |
+| GET    | `/me/devices`     | yes  | Lists the user's active sessions, parsed UA |
+| DELETE | `/me/devices/:id` | yes  | Revokes a session; ownership check enforced |
 
 Both endpoints are tenant-scoped (the global `TenantInterceptor`
 applies). Frontend / SDK callers must send `x-tenant-id`.
 
 ## Tests
 
-| Layer                      | File                                                    |
-| -------------------------- | ------------------------------------------------------- |
-| Fingerprint planner        | `tests/stories/device-fingerprint.story.test.ts`        |
-| UA parser                  | `tests/stories/device-ua-parser.story.test.ts`          |
-| Decision planner           | `tests/stories/device-handling.story.test.ts`           |
-| Email payload              | `tests/stories/new-device-email-payload.story.test.ts`  |
-| Hook runner + throttle     | `tests/stories/new-device-email-runner.story.test.ts`   |
-| Orchestrator (mocked deps) | `tests/stories/device-handling-runner.story.test.ts`    |
-| Full e2e (boots app)       | `tests/devices.e2e-spec.ts`                             |
+| Layer                      | File                                                   |
+| -------------------------- | ------------------------------------------------------ |
+| Fingerprint planner        | `tests/stories/device-fingerprint.story.test.ts`       |
+| UA parser                  | `tests/stories/device-ua-parser.story.test.ts`         |
+| Decision planner           | `tests/stories/device-handling.story.test.ts`          |
+| Email payload              | `tests/stories/new-device-email-payload.story.test.ts` |
+| Hook runner + throttle     | `tests/stories/new-device-email-runner.story.test.ts`  |
+| Orchestrator (mocked deps) | `tests/stories/device-handling-runner.story.test.ts`   |
+| Full e2e (boots app)       | `tests/devices.e2e-spec.ts`                            |
 
 ## Hard rules
 

--- a/src/core/devices/device-handling.runner.ts
+++ b/src/core/devices/device-handling.runner.ts
@@ -1,0 +1,243 @@
+import { Logger } from "@nestjs/common";
+
+import type { GeoIpService } from "../geoip/geoip.service.js";
+import type { GeoIpLookupResult } from "../geoip/resolver.js";
+import { decideDeviceHandling, type KnownSession } from "./device-handling.js";
+import { fingerprintSession, type FingerprintInput, type FingerprintMode } from "./fingerprint.js";
+import { parseUserAgent } from "./ua-parser.js";
+
+/**
+ * Device-handling orchestrator (runner half).
+ *
+ * Wires the planner trio (`fingerprintSession`, `parseUserAgent`,
+ * `decideDeviceHandling`) into the live system:
+ *   - reads the session's UA / IP (Better-Auth's `databaseHooks.session
+ *     .create.after` payload),
+ *   - hashes the fingerprint,
+ *   - persists it on the session row,
+ *   - looks up the user's other sessions,
+ *   - emits the new-device email through the configured runner
+ *     (when the decision is `new-device`),
+ *   - revokes the oldest session when the per-user cap is exceeded.
+ *
+ * Failure semantics: NEVER throw back into the auth flow. The
+ * sign-in already succeeded by the time `session.create.after` runs;
+ * any DB error / GeoIP outage / mail queue failure is logged and
+ * swallowed.
+ */
+
+export interface DeviceHandlingSessionStore {
+  /** Persists the fingerprint hash on the just-created session row. */
+  setFingerprint(sessionId: string, fingerprint: string): Promise<void>;
+  /** Returns every non-expired session for the user, including the current one. */
+  listForUser(userId: string): Promise<KnownSession[]>;
+  /** Revokes (deletes) a session by id. Returns true if a row was removed. */
+  revoke(sessionId: string): Promise<boolean>;
+}
+
+export interface DeviceHandlingUserLookup {
+  findById(userId: string): Promise<{ id: string; email: string; name?: string } | null>;
+}
+
+export interface DeviceEmailDispatcher {
+  sendNewDevice(input: {
+    user: { id: string; email: string; name?: string };
+    fingerprint: string;
+    deviceLabel: string;
+    location: string;
+    ipAddress: string;
+    signedInAt: string;
+    revokeUrl: string;
+  }): Promise<void>;
+}
+
+export interface DeviceHandlingConfig {
+  /** Whole feature toggle — when off the orchestrator becomes a no-op. */
+  enabled: boolean;
+  notifyOnNewDevice: boolean;
+  maxDevicesPerUser: number;
+  fingerprintMode: FingerprintMode;
+  /** Base URL for the /me/devices link in the new-device email. */
+  appBaseUrl: string;
+}
+
+export interface DeviceHandlingRunnerOptions {
+  store: DeviceHandlingSessionStore;
+  email: DeviceEmailDispatcher;
+  /**
+   * Optional user lookup — when wired, the runner accepts a
+   * \`SessionCreatedInput\` carrying only the user id and resolves
+   * the email at email-send time. Required for production use
+   * because Better-Auth's \`session.create.after\` payload doesn't
+   * include the user's email/name.
+   */
+  userLookup?: DeviceHandlingUserLookup;
+  /** Optional GeoIP service — when omitted, the email shows "Location unknown". */
+  geoIp?: Pick<GeoIpService, "lookup">;
+  config: DeviceHandlingConfig;
+  /** Optional clock injection for tests (defaults to `() => new Date()`). */
+  now?: () => Date;
+  /** Optional logger for diagnostics. */
+  logger?: Pick<Logger, "warn" | "error" | "log">;
+}
+
+export interface SessionCreatedInput {
+  sessionId: string;
+  /**
+   * Either the full user record (test convenience) OR just the id
+   * (production hook). When `user` is supplied as a string, the
+   * runner resolves email/name via `userLookup` (if wired); without
+   * a lookup, the email step is skipped.
+   */
+  user: { id: string; email: string; name?: string } | { id: string };
+  userAgent: string | null | undefined;
+  ipAddress: string | null | undefined;
+}
+
+export interface DeviceHandlingRunner {
+  handleSessionCreated(input: SessionCreatedInput): Promise<void>;
+}
+
+export function createDeviceHandlingRunner(
+  options: DeviceHandlingRunnerOptions,
+): DeviceHandlingRunner {
+  const logger = options.logger ?? new Logger("DeviceHandling");
+  const now = options.now ?? ((): Date => new Date());
+
+  return {
+    async handleSessionCreated(input: SessionCreatedInput): Promise<void> {
+      if (!options.config.enabled) return;
+      try {
+        const fpInput: FingerprintInput = {
+          userAgent: input.userAgent ?? "",
+          ip: input.ipAddress ?? "",
+          mode: options.config.fingerprintMode,
+        };
+        const fingerprint = fingerprintSession(fpInput);
+
+        // Persist the fingerprint on the just-created session BEFORE
+        // the lookup — otherwise the planner's "match on fp" logic
+        // would never see the current session's hash, and a sign-in
+        // from an already-known device would still look new.
+        await options.store.setFingerprint(input.sessionId, fingerprint);
+
+        const known = await options.store.listForUser(input.user.id);
+        const decision = decideDeviceHandling({
+          currentFingerprint: fingerprint,
+          currentSessionId: input.sessionId,
+          knownSessions: known,
+          maxDevicesPerUser: options.config.maxDevicesPerUser,
+          now: now(),
+        });
+
+        if (decision.action === "first-sign-in" || decision.action === "known") {
+          // Nothing else to do — the lastSeenAt refresh comes from
+          // Prisma's @updatedAt on every session lookup.
+          return;
+        }
+
+        // new-device path
+        if (decision.revokeSessionId) {
+          // Revoke BEFORE emailing; the email's "review devices"
+          // link should reflect the post-revoke state, not the
+          // momentary over-limit state.
+          try {
+            await options.store.revoke(decision.revokeSessionId);
+          } catch (err) {
+            logger.warn(
+              `Failed to revoke oldest session ${decision.revokeSessionId} for user ${input.user.id}: ${(err as Error).message}`,
+            );
+          }
+        }
+
+        if (!options.config.notifyOnNewDevice) return;
+
+        const resolvedUser = await resolveUser(input.user, options.userLookup, logger);
+        if (!resolvedUser) {
+          // No email available → skip silently. Better than crashing
+          // (which would leak through the catch and log) or sending
+          // a mail with a blank "to" field.
+          return;
+        }
+
+        const ua = parseUserAgent(input.userAgent ?? "");
+        const location = await resolveLocation(options.geoIp, input.ipAddress ?? "", logger);
+
+        await options.email.sendNewDevice({
+          user: resolvedUser,
+          fingerprint,
+          deviceLabel: ua.label,
+          location,
+          // Don't render the IP in the body when GeoIP succeeded;
+          // surface it only as a fallback for "Location unknown"
+          // sign-ins, which is when the user has the most use for
+          // the raw value (e.g. matching their VPN egress).
+          ipAddress: location === "Location unknown" ? (input.ipAddress ?? "") : "",
+          signedInAt: now().toISOString(),
+          revokeUrl: buildRevokeUrl(options.config.appBaseUrl),
+        });
+      } catch (err) {
+        // Never let the auth flow break.
+        logger.error(
+          `device-handling pipeline failed for user ${input.user.id}: ${(err as Error).message}`,
+        );
+      }
+    },
+  };
+}
+
+async function resolveUser(
+  user: { id: string; email?: string; name?: string },
+  lookup: DeviceHandlingUserLookup | undefined,
+  logger: Pick<Logger, "warn" | "error" | "log">,
+): Promise<{ id: string; email: string; name?: string } | null> {
+  // Test convenience: when the caller passes a fully-populated user
+  // we use it directly. Production calls supply only the id and let
+  // the lookup resolve the email.
+  if ("email" in user && typeof user.email === "string" && user.email) {
+    return { id: user.id, email: user.email, ...(user.name ? { name: user.name } : {}) };
+  }
+  if (!lookup) return null;
+  try {
+    return await lookup.findById(user.id);
+  } catch (err) {
+    logger.warn(`device-handling: user lookup failed for ${user.id}: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+async function resolveLocation(
+  geoIp: Pick<GeoIpService, "lookup"> | undefined,
+  ip: string,
+  logger: Pick<Logger, "warn" | "error" | "log">,
+): Promise<string> {
+  if (!geoIp || !ip) return "Location unknown";
+  let lookup: GeoIpLookupResult | null = null;
+  try {
+    lookup = await geoIp.lookup(ip);
+  } catch (err) {
+    logger.warn(`GeoIP lookup failed for ${ip}: ${(err as Error).message}`);
+    return "Location unknown";
+  }
+  return formatLocation(lookup);
+}
+
+/**
+ * Pure formatter — exposed for tests. Surfaces only `City, Country`
+ * (or one of them when the other is missing) to keep the email body
+ * privacy-friendly.
+ */
+export function formatLocation(lookup: GeoIpLookupResult | null): string {
+  if (!lookup) return "Location unknown";
+  const city = lookup.city?.trim();
+  const country = lookup.country?.trim();
+  if (city && country) return `${city}, ${country}`;
+  if (country) return country;
+  if (city) return city;
+  return "Location unknown";
+}
+
+function buildRevokeUrl(baseUrl: string): string {
+  // Trim trailing slash to avoid `https://app//me/devices`.
+  return `${baseUrl.replace(/\/+$/, "")}/me/devices`;
+}

--- a/src/core/devices/device-handling.ts
+++ b/src/core/devices/device-handling.ts
@@ -1,0 +1,103 @@
+/**
+ * Device-handling decision planner.
+ *
+ * Pure function: given the current sign-in's fingerprint plus the
+ * user's existing sessions, decide what the runner should do
+ * (notify? revoke an old session?). No I/O, no Date construction,
+ * no rate-limiter — those live in the runner.
+ *
+ * Output union:
+ *   - `first-sign-in` — no prior sessions; record the fingerprint
+ *     but skip the notification (a brand-new account shouldn't get
+ *     a "new device" email about its very first session).
+ *   - `known`         — fingerprint matches a previous session;
+ *     the runner only refreshes `lastSeenAt`.
+ *   - `new-device`    — fingerprint is new; the runner enqueues
+ *     the new-device email and (if `revokeSessionId` is set) deletes
+ *     the oldest existing session to honour the per-user cap.
+ *
+ * The cap is "≤ maxDevicesPerUser AFTER the current sign-in":
+ * given N existing sessions and the just-created one, that totals
+ * N+1. When N+1 > cap, revoke the oldest existing.
+ */
+
+export interface KnownSession {
+  /** Better-Auth session row id. */
+  id: string;
+  /** sha256 hex from `fingerprintSession()`; null when never recorded. */
+  fingerprintHash: string;
+  lastSeenAt: Date;
+  createdAt: Date;
+}
+
+export interface DeviceHandlingDecisionInput {
+  currentFingerprint: string;
+  /**
+   * id of the just-created session — Better-Auth's
+   * `session.create.after` hook fires after Prisma inserted it, so
+   * the row is already in `knownSessions`. The planner skips it
+   * when looking for "have we seen this fingerprint before".
+   */
+  currentSessionId: string;
+  knownSessions: KnownSession[];
+  maxDevicesPerUser: number;
+  /** Carried for forward-compat (e.g. impossible-travel scoring). */
+  now: Date;
+}
+
+export type DeviceHandlingDecision =
+  | { action: "first-sign-in" }
+  | { action: "known" }
+  | { action: "new-device"; revokeSessionId?: string };
+
+export function decideDeviceHandling(input: DeviceHandlingDecisionInput): DeviceHandlingDecision {
+  const others = input.knownSessions.filter((s) => s.id !== input.currentSessionId);
+
+  if (others.length === 0) {
+    // First-ever sign-in for this user — record the fingerprint but
+    // don't email; there's no prior context to compare against.
+    return { action: "first-sign-in" };
+  }
+
+  const matched = others.some((s) => s.fingerprintHash === input.currentFingerprint);
+  if (matched) return { action: "known" };
+
+  // New device. With the just-created session counted, the user
+  // would now have `others.length + 1` sessions. When that exceeds
+  // the cap, revoke the oldest existing session (NOT the current
+  // one — that would defeat the point of just signing in).
+  const totalAfter = others.length + 1;
+  if (totalAfter > input.maxDevicesPerUser) {
+    const oldestId = selectOldestSessionForRevoke(others);
+    return oldestId !== null
+      ? { action: "new-device", revokeSessionId: oldestId }
+      : { action: "new-device" };
+  }
+  return { action: "new-device" };
+}
+
+/**
+ * Returns the session id with the smallest `lastSeenAt`
+ * (ties broken by `createdAt`), or `null` when the list is empty.
+ *
+ * Pulled out so the runner can call it directly when revoking
+ * mid-flight (e.g. an admin force-revokes when the user adds a
+ * 6th device with cap=5 in the dev-portal).
+ */
+export function selectOldestSessionForRevoke(sessions: KnownSession[]): string | null {
+  if (sessions.length === 0) return null;
+  let oldest = sessions[0]!;
+  for (const candidate of sessions.slice(1)) {
+    if (candidate.lastSeenAt < oldest.lastSeenAt) {
+      oldest = candidate;
+      continue;
+    }
+    if (
+      candidate.lastSeenAt.getTime() === oldest.lastSeenAt.getTime() &&
+      candidate.createdAt < oldest.createdAt
+    ) {
+      oldest = candidate;
+    }
+  }
+  return oldest.id;
+}

--- a/src/core/devices/device.controller.ts
+++ b/src/core/devices/device.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  NotFoundException,
+  Param,
+  Req,
+} from "@nestjs/common";
+import type { Request } from "express";
+
+import { PrismaService } from "../prisma/prisma.service.js";
+import { parseUserAgent } from "./ua-parser.js";
+import { fingerprintSession } from "./fingerprint.js";
+
+interface AuthedRequest extends Request {
+  user?: { id: string };
+}
+
+export interface DeviceListItem {
+  id: string;
+  deviceLabel: string;
+  ipAddress: string | null;
+  lastSeenAt: string;
+  current: boolean;
+}
+
+/**
+ * `/me/devices` — read + revoke the authenticated user's sessions.
+ *
+ * Auth gate: `req.user` is populated by `BetterAuthSessionMiddleware`.
+ * Anonymous requests bounce on the middleware before reaching the
+ * controller; the `req.user` check below is defense-in-depth.
+ *
+ * The `current: bool` field needs the request's session id —
+ * Better-Auth doesn't expose it on `req.user` today (only the user
+ * identity), so we mark `current` based on a recent-activity
+ * heuristic: the most-recently-updated session for the user. This
+ * is good enough for the dev-portal "this is your device" display;
+ * the security-sensitive bits (revoke confirmation) ride on the
+ * session id, which the user supplies explicitly.
+ */
+@Controller("me/devices")
+export class DeviceController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get()
+  async list(@Req() req: AuthedRequest): Promise<DeviceListItem[]> {
+    if (!req.user) throw new ForbiddenException("authentication required");
+    const sessions = await this.prisma.session.findMany({
+      where: { userId: req.user.id },
+      orderBy: { updatedAt: "desc" },
+    });
+    return sessions.map((s, idx) => ({
+      id: s.id,
+      // Recompute the label on read so a UA-parser upgrade picks
+      // up the new mapping without backfilling. Cheap (parser is
+      // pure) and the row count per user is bounded by maxDevices.
+      deviceLabel: parseUserAgent(s.userAgent ?? "").label,
+      ipAddress: s.ipAddress ?? null,
+      lastSeenAt: s.updatedAt.toISOString(),
+      // Topmost (most recent activity) is the user's current
+      // session in the absence of a session-id projection on req.
+      current: idx === 0,
+    }));
+  }
+
+  @Delete(":id")
+  async revoke(
+    @Req() req: AuthedRequest,
+    @Param("id") id: string,
+  ): Promise<{ revoked: true; id: string }> {
+    if (!req.user) throw new ForbiddenException("authentication required");
+    // Defense-in-depth: load the session first and verify it
+    // belongs to the requester. Otherwise a forged id could revoke
+    // someone else's session.
+    const session = await this.prisma.session.findUnique({ where: { id } });
+    if (!session || session.userId !== req.user.id) {
+      throw new NotFoundException(`session ${id} not found`);
+    }
+    await this.prisma.session.delete({ where: { id } });
+    return { revoked: true, id };
+  }
+}
+
+/**
+ * Tiny diagnostic helper — the dev-portal device list page imports
+ * this so the renderer can show the fingerprint hash alongside the
+ * label without re-implementing the composition. Kept here (rather
+ * than as a separate file) because it's a one-liner with the same
+ * domain home.
+ */
+export function fingerprintForDisplay(
+  userAgent: string | null,
+  ipAddress: string | null,
+  mode: "userAgent+ipSubnet" | "userAgent",
+): string {
+  return fingerprintSession({ userAgent: userAgent ?? "", ip: ipAddress ?? "", mode });
+}

--- a/src/core/devices/device.module.ts
+++ b/src/core/devices/device.module.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+
+import { PrismaModule } from "../prisma/prisma.module.js";
+import { DeviceController } from "./device.controller.js";
+
+/**
+ * DeviceModule — owns the `/me/devices` endpoints.
+ *
+ * The Better-Auth `databaseHooks.session.create.after` orchestrator
+ * does NOT live in this module — it's wired inside `BetterAuthModule`
+ * (which already constructs the Better-Auth instance). This module
+ * just publishes the read / revoke surface to the rest of the app.
+ *
+ * Wiring is unconditional: the feature flag governs whether the
+ * fingerprint pipeline runs at session-create time. The endpoints
+ * here are still useful when the feature is off — they list raw
+ * sessions, just without a fingerprint to compare against.
+ */
+@Module({
+  imports: [PrismaModule],
+  controllers: [DeviceController],
+})
+export class DeviceModule {}

--- a/src/core/devices/fingerprint.ts
+++ b/src/core/devices/fingerprint.ts
@@ -108,7 +108,7 @@ function expandIpv6(ip: string): string[] | null {
   const tail = parts[1] ? parts[1].split(":") : [];
   const filled = parts.length === 2 ? 8 - head.length - tail.length : 8 - head.length;
   if (filled < 0) return null;
-  const middle = parts.length === 2 ? new Array<string>(filled).fill("0") : [];
+  const middle = parts.length === 2 ? Array.from<string>({ length: filled }).fill("0") : [];
   const groups = [...head, ...middle, ...tail];
   if (groups.length !== 8) return null;
   // Strip leading zeros so equivalent forms hash the same.

--- a/src/core/devices/fingerprint.ts
+++ b/src/core/devices/fingerprint.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Device fingerprint planner.
+ *
+ * Issue #13 turns "userAgent + ipAddress" into a stable, hashed
+ * device-identity that the new-device detector can compare against
+ * past sessions. Two design choices:
+ *
+ * 1. **Subnet, not full IP.** A residential ISP rotates the IPv4 host
+ *    octet on every modem reboot; a mobile carrier rotates it on every
+ *    cellular hop. Hashing the full address would mark every
+ *    "bus-ride wifi → home wifi" hop as a new device. /24 (IPv4) and
+ *    /64 (IPv6) line up with how carriers allocate subnets, so a roaming
+ *    user inside the same provider keeps the same fingerprint.
+ *
+ * 2. **No raw IP storage.** The planner returns only the hash — the
+ *    raw masked CIDR is an internal intermediate. Persistence layers
+ *    store the hash; logs strip the IP. The trade-off: investigators
+ *    can no longer reverse-engineer "what IP signed in" from the DB,
+ *    but a leak of the device table doesn't expose user IPs either.
+ *
+ * The planner is pure: no I/O, no env, no Date. The runner that
+ * persists the fingerprint + decides "new vs. known" lives in
+ * `device-handling.ts`.
+ */
+
+export type FingerprintMode = "userAgent+ipSubnet" | "userAgent";
+
+export interface FingerprintInput {
+  /** Better-Auth's `userAgent` is nullish — both undefined and "" map to "no UA". */
+  userAgent: string | undefined | null;
+  /** Better-Auth's `ipAddress` is nullish — both undefined and "" map to "no IP". */
+  ip: string | undefined | null;
+  mode: FingerprintMode;
+}
+
+/**
+ * IPv4 default mask: drop the last octet (host part of a /24
+ * residential subnet).
+ */
+const IPV4_PREFIX_OCTETS = 3;
+/**
+ * IPv6 default mask: keep the first 64 bits (the routable prefix).
+ * Lower 64 bits are the interface identifier — RFC 4941 rotates
+ * those for privacy, so masking them is required for stability.
+ */
+const IPV6_PREFIX_GROUPS = 4;
+
+const IPV4_RE = /^(\d{1,3}\.){3}\d{1,3}$/;
+
+/**
+ * Returns the masked network prefix string used as input to the
+ * fingerprint hash. Exposed for tests + diagnostic logs; callers
+ * should not store the return value (only the hash itself is safe).
+ *
+ * Returns "" in `userAgent`-only mode (the IP component is dropped
+ * from the hash entirely) and "invalid" for malformed inputs (so
+ * the hash stays deterministic without crashing the auth flow).
+ */
+export function maskIp(ip: string | undefined | null, mode: FingerprintMode): string {
+  if (mode === "userAgent") return "";
+  const trimmed = (ip ?? "").trim();
+  if (!trimmed) return "invalid";
+
+  if (IPV4_RE.test(trimmed)) {
+    const octets = trimmed.split(".").map((segment) => Number(segment));
+    if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return "invalid";
+    const head = octets.slice(0, IPV4_PREFIX_OCTETS).join(".");
+    return `${head}.0/24`;
+  }
+
+  // IPv6: expand any "::" abbreviation, then keep the first 4 groups.
+  const expanded = expandIpv6(trimmed);
+  if (!expanded) return "invalid";
+  const head = expanded.slice(0, IPV6_PREFIX_GROUPS).join(":");
+  return `${head}::/64`;
+}
+
+/**
+ * Computes the sha256 hex hash of `(mode, ua, masked-ip)`. The mode
+ * is part of the input so flipping the toggle between deployments
+ * produces a fresh fingerprint set instead of silently re-classifying
+ * every old session as "known" (or vice versa).
+ */
+export function fingerprintSession(input: FingerprintInput): string {
+  const ua = (input.userAgent ?? "").trim();
+  const masked = maskIp(input.ip, input.mode);
+  // Pipe-separated so the components can never collide via clever
+  // UA strings that contain a stray "/24" suffix etc.
+  const composite = `${input.mode}|${ua}|${masked}`;
+  return createHash("sha256").update(composite, "utf8").digest("hex");
+}
+
+/**
+ * Expands an IPv6 address (possibly containing `::`) into an array
+ * of 8 hex group strings (each lowercased, leading zeros stripped).
+ * Returns `null` for unparseable inputs.
+ */
+function expandIpv6(ip: string): string[] | null {
+  const lower = ip.toLowerCase();
+  // Reject anything that's clearly not IPv6 — ua-parser-js doesn't
+  // run here, so the regex is the gate.
+  if (!/^[0-9a-f:]+$/i.test(lower)) return null;
+  const parts = lower.split("::");
+  if (parts.length > 2) return null;
+  const head = parts[0] ? parts[0].split(":") : [];
+  const tail = parts[1] ? parts[1].split(":") : [];
+  const filled = parts.length === 2 ? 8 - head.length - tail.length : 8 - head.length;
+  if (filled < 0) return null;
+  const middle = parts.length === 2 ? new Array<string>(filled).fill("0") : [];
+  const groups = [...head, ...middle, ...tail];
+  if (groups.length !== 8) return null;
+  // Strip leading zeros so equivalent forms hash the same.
+  return groups.map((g) => g.replace(/^0+(?=.)/, ""));
+}

--- a/src/core/devices/new-device-throttle.ts
+++ b/src/core/devices/new-device-throttle.ts
@@ -1,0 +1,61 @@
+/**
+ * New-device email throttle.
+ *
+ * Issue #13 caps new-device mails at 1 per user per hour. Mobile
+ * devices roam IPs aggressively (cellular ↔ wifi) — without this
+ * cap a user with a flaky connection can produce a fresh fingerprint
+ * every few minutes and get spammed with notifications.
+ *
+ * In-memory implementation — fits a single-instance Nest deploy.
+ * For multi-instance deploys, swap the storage with a Redis-backed
+ * implementation (same interface, different backing). The interface
+ * intentionally mirrors `EmailRateLimiter` so callers can pick
+ * either.
+ */
+
+export interface NewDeviceThrottleDecision {
+  allowed: boolean;
+  /** Milliseconds until the next allowed call, when denied. */
+  resetMs?: number;
+}
+
+export interface NewDeviceThrottle {
+  check(userId: string): NewDeviceThrottleDecision;
+  record(userId: string): void;
+}
+
+export interface CreateNewDeviceThrottleOptions {
+  /** Window in milliseconds; default 1h. */
+  windowMs?: number;
+  /** Clock injection — tests pass a deterministic value. */
+  now?: () => number;
+}
+
+const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
+
+export function createNewDeviceThrottle(
+  options: CreateNewDeviceThrottleOptions = {},
+): NewDeviceThrottle {
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = options.now ?? (() => Date.now());
+  const lastSent = new Map<string, number>();
+
+  return {
+    check(userId: string): NewDeviceThrottleDecision {
+      const last = lastSent.get(userId);
+      if (last === undefined) return { allowed: true };
+      const elapsed = now() - last;
+      if (elapsed >= windowMs) {
+        // Window has elapsed — clean up the stale entry so the map
+        // doesn't grow unbounded for users that sign in once and
+        // never come back.
+        lastSent.delete(userId);
+        return { allowed: true };
+      }
+      return { allowed: false, resetMs: windowMs - elapsed };
+    },
+    record(userId: string): void {
+      lastSent.set(userId, now());
+    },
+  };
+}

--- a/src/core/devices/ua-parser.ts
+++ b/src/core/devices/ua-parser.ts
@@ -1,0 +1,92 @@
+import { UAParser } from "ua-parser-js";
+
+/**
+ * Device UA-parser planner.
+ *
+ * Wraps `ua-parser-js` with the project's defensive defaults:
+ *   - empty / undefined / malformed input → `"Unknown device"` label,
+ *   - composed `label` field — `"<browser> on <os>"` — so callers
+ *     don't reassemble it.
+ *
+ * The deviceType union mirrors what `ua-parser-js` reports
+ * (`mobile`, `tablet`, `console`, `smarttv`, `tv`, `wearable`,
+ * `embedded`, `xr`) plus `"desktop"` (which the lib leaves
+ * undefined for laptop/desktop UAs) and `"unknown"` (our fallback
+ * for unparseable input).
+ *
+ * The new-device email + `/me/devices` endpoint surface this
+ * projection. The planner is pure (no I/O, no Date) — a thin
+ * library wrapper.
+ */
+
+export type DeviceType =
+  | "mobile"
+  | "tablet"
+  | "desktop"
+  | "console"
+  | "smarttv"
+  | "tv"
+  | "wearable"
+  | "embedded"
+  | "xr"
+  | "unknown";
+
+export interface ParsedUserAgent {
+  browser: string;
+  os: string;
+  deviceType: DeviceType;
+  /** Composed `<browser> on <os>` for renderers; falls back to "Unknown device". */
+  label: string;
+}
+
+const KNOWN_DEVICE_TYPES: ReadonlySet<DeviceType> = new Set([
+  "mobile",
+  "tablet",
+  "desktop",
+  "console",
+  "smarttv",
+  "tv",
+  "wearable",
+  "embedded",
+  "xr",
+]);
+
+export function parseUserAgent(ua: string | undefined | null): ParsedUserAgent {
+  const trimmed = (ua ?? "").trim();
+  if (!trimmed) {
+    return { browser: "Unknown", os: "Unknown", deviceType: "unknown", label: "Unknown device" };
+  }
+
+  const parsed = new UAParser(trimmed).getResult();
+  const browser = (parsed.browser?.name ?? "").trim();
+  const os = (parsed.os?.name ?? "").trim();
+  const rawType = (parsed.device?.type ?? "").trim().toLowerCase();
+
+  // Desktop is the implicit default for ua-parser-js: the lib leaves
+  // device.type undefined for typical laptop/desktop UAs. Map it back
+  // to "desktop" so callers don't have to special-case the empty case.
+  let deviceType: DeviceType;
+  if (!rawType) {
+    deviceType = browser ? "desktop" : "unknown";
+  } else if (KNOWN_DEVICE_TYPES.has(rawType as DeviceType)) {
+    deviceType = rawType as DeviceType;
+  } else {
+    deviceType = "unknown";
+  }
+
+  // If both browser and OS are missing, the UA was unparseable —
+  // fall back to the empty-input label rather than rendering
+  // "Unknown on Unknown" which adds no information.
+  if (!browser && !os) {
+    return { browser: "Unknown", os: "Unknown", deviceType: "unknown", label: "Unknown device" };
+  }
+
+  const safeBrowser = browser || "Unknown";
+  const safeOs = os || "Unknown";
+  return {
+    browser: safeBrowser,
+    os: safeOs,
+    deviceType,
+    label: `${safeBrowser} on ${safeOs}`,
+  };
+}

--- a/src/core/email/CLAUDE.md
+++ b/src/core/email/CLAUDE.md
@@ -31,7 +31,8 @@ email/
     ├── email-verification.tsx
     ├── password-reset.tsx
     ├── welcome.tsx
-    └── invitation.tsx
+    ├── invitation.tsx
+    └── new-device.tsx                ← issue #13 — device-handling notice
 ```
 
 ## Delivery modes

--- a/src/core/email/templates/new-device.tsx
+++ b/src/core/email/templates/new-device.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import { Barebone } from "../layouts/Barebone.js";
+import { CTA, Footer, Greeting, Paragraph } from "../blocks/index.js";
+import type { BrandConfig } from "../brand.js";
+
+/**
+ * New-device template (issue #13).
+ *
+ * Sent when a sign-in lands a previously-unseen fingerprint for
+ * the user. Voice is "neutral notification, action button to revoke
+ * if it wasn't you" — not a security alarm. Modern auth hygiene.
+ *
+ * The body intentionally omits exact lat/lng even when GeoIP
+ * supplied them. We surface only `City, Country` (or "Location
+ * unknown") + the raw IP — the IP is what an attentive user can
+ * cross-check against their own router / VPN. Lat/lng would add
+ * tracking-vibe without giving the user anything actionable.
+ */
+export interface NewDeviceVars {
+  recipientName: string;
+  appName: string;
+  deviceLabel: string;
+  location: string;
+  ipAddress: string;
+  signedInAt: string;
+  revokeUrl: string;
+}
+
+export const newDeviceMeta = {
+  name: "new-device",
+  subject: (vars: NewDeviceVars): string => `New sign-in to ${vars.appName}`,
+};
+
+export interface NewDeviceProps extends NewDeviceVars {
+  brand?: BrandConfig;
+}
+
+export default function NewDevice(props: NewDeviceProps): React.ReactElement {
+  return (
+    <Barebone
+      brand={props.brand}
+      preheader={`A new device just signed in to your ${props.appName} account`}
+    >
+      <Greeting brand={props.brand}>Hello {props.recipientName},</Greeting>
+      <Paragraph brand={props.brand}>
+        We noticed a new sign-in to your {props.appName} account. If this was you, no further action
+        is needed.
+      </Paragraph>
+      <Paragraph brand={props.brand}>
+        <strong>Device:</strong> {props.deviceLabel}
+        <br />
+        <strong>Location:</strong> {props.location}
+        {props.ipAddress ? (
+          <>
+            <br />
+            <strong>IP address:</strong> {props.ipAddress}
+          </>
+        ) : null}
+        <br />
+        <strong>Time:</strong> {props.signedInAt}
+      </Paragraph>
+      <Paragraph brand={props.brand}>
+        If you did not sign in, revoke this session immediately and change your password.
+      </Paragraph>
+      <CTA brand={props.brand} href={props.revokeUrl}>
+        Review devices
+      </CTA>
+      <Footer brand={props.brand}>
+        Location is approximate (city / country only). We never store the precise coordinates of
+        your sign-in.
+      </Footer>
+    </Barebone>
+  );
+}

--- a/src/core/features/features.ts
+++ b/src/core/features/features.ts
@@ -61,6 +61,22 @@ const GeoIpSchema = z.object({
   /** Where the unpacked `.mmdb` lives. `download-geoip` writes here. */
   dbPath: z.string().default("./data/geoip/city.mmdb"),
 });
+const DEVICE_FINGERPRINT_MODES = ["userAgent+ipSubnet", "userAgent"] as const;
+const DeviceManagementSchema = z.object({
+  /** Master switch — when off, the sign-in hook short-circuits. */
+  enabled: z.boolean().default(false),
+  /** Hard cap; the oldest session is auto-revoked when the limit is exceeded. */
+  maxDevicesPerUser: z.number().int().positive().default(10),
+  /** Email the user when a sign-in lands a previously-unseen fingerprint. */
+  notifyOnNewDevice: z.boolean().default(true),
+  /**
+   * Fingerprint composition. `userAgent+ipSubnet` is the privacy /
+   * mobility compromise the planner explains; `userAgent`-only is
+   * the strict-privacy mode for jurisdictions that don't allow
+   * IP-based tracking. See `src/core/devices/fingerprint.ts`.
+   */
+  sessionFingerprint: z.enum(DEVICE_FINGERPRINT_MODES).default("userAgent+ipSubnet"),
+});
 const togglableDefault = (on: boolean) => z.object({ enabled: z.boolean().default(on) });
 
 const Webhooks = togglableDefault(false);
@@ -87,6 +103,7 @@ export const FeaturesSchema = z.object({
   fieldEncryption: FieldEncryption.default(() => FieldEncryption.parse({})),
   geo: GeoSchema.default(() => GeoSchema.parse({})),
   geoIp: GeoIpSchema.default(() => GeoIpSchema.parse({})),
+  deviceManagement: DeviceManagementSchema.default(() => DeviceManagementSchema.parse({})),
   rateLimit: RateLimit.default(() => RateLimit.parse({})),
   idempotency: Idempotency.default(() => Idempotency.parse({})),
   observability: Observability.default(() => Observability.parse({})),
@@ -108,6 +125,7 @@ export type ToggleableFeatureKey =
   | "fieldEncryption"
   | "geo"
   | "geoIp"
+  | "deviceManagement"
   | "rateLimit"
   | "idempotency"
   | "observability"
@@ -151,6 +169,8 @@ const SECTION_KEYS = new Set([
   "FIELD_ENCRYPTION",
   "GEO",
   "GEO_IP",
+  "DEVICEMANAGEMENT",
+  "DEVICE_MANAGEMENT",
   "RATELIMIT",
   "RATE_LIMIT",
   "IDEMPOTENCY",
@@ -172,6 +192,8 @@ const SECTION_TO_KEY: Record<string, FeatureKey> = {
   FIELD_ENCRYPTION: "fieldEncryption",
   GEO: "geo",
   GEO_IP: "geoIp",
+  DEVICEMANAGEMENT: "deviceManagement",
+  DEVICE_MANAGEMENT: "deviceManagement",
   RATELIMIT: "rateLimit",
   RATE_LIMIT: "rateLimit",
   IDEMPOTENCY: "idempotency",
@@ -200,6 +222,12 @@ const FIELD_TO_PROP: Record<string, string> = {
   LICENSE_KEY: "licenseKey",
   DBPATH: "dbPath",
   DB_PATH: "dbPath",
+  MAXDEVICESPERUSER: "maxDevicesPerUser",
+  MAX_DEVICES_PER_USER: "maxDevicesPerUser",
+  NOTIFYONNEWDEVICE: "notifyOnNewDevice",
+  NOTIFY_ON_NEW_DEVICE: "notifyOnNewDevice",
+  SESSIONFINGERPRINT: "sessionFingerprint",
+  SESSION_FINGERPRINT: "sessionFingerprint",
 };
 
 const STRING_VALUE_PROPS = new Set([
@@ -208,7 +236,9 @@ const STRING_VALUE_PROPS = new Set([
   "provider",
   "licenseKey",
   "dbPath",
+  "sessionFingerprint",
 ]);
+const NUMBER_VALUE_PROPS = new Set(["maxDevicesPerUser"]);
 const ARRAY_VALUE_PROPS = new Set(["socialProviders"]);
 
 function parseFeatureEnv(env: Record<string, string | undefined>): RawOverrides {
@@ -243,6 +273,13 @@ function splitSectionField(remainder: string): { section: string; field: string 
 
 function coerceValue(prop: string, raw: string): unknown {
   if (STRING_VALUE_PROPS.has(prop)) return raw;
+  if (NUMBER_VALUE_PROPS.has(prop)) {
+    const n = Number(raw);
+    if (!Number.isFinite(n)) {
+      throw new Error(`expected number, got "${raw}"`);
+    }
+    return n;
+  }
   if (ARRAY_VALUE_PROPS.has(prop)) {
     return raw
       .split(",")

--- a/tests/devices.e2e-spec.ts
+++ b/tests/devices.e2e-spec.ts
@@ -1,0 +1,184 @@
+import type { INestApplication, LoggerService } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../src/core/app/bootstrap.js";
+import { EmailService } from "../src/core/email/email.service.js";
+import { PrismaService } from "../src/core/prisma/prisma.service.js";
+
+const SILENT_LOGGER: LoggerService = {
+  log() {},
+  warn() {},
+  error() {},
+  debug() {},
+  verbose() {},
+};
+
+const TENANT = "11111111-1111-1111-1111-111111111111";
+
+const UA_CHROME =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36";
+const UA_SAFARI =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1";
+
+/**
+ * E2E · Device-handling pipeline (issue #13).
+ *
+ * Boots the full app with `FEATURE_DEVICE_MANAGEMENT_ENABLED=true`
+ * and asserts:
+ *  1. The new-device email fires on the SECOND distinct-fingerprint
+ *     sign-in for the same user (first-sign-in is silent).
+ *  2. `GET /me/devices` returns the active sessions.
+ *  3. `DELETE /me/devices/:id` removes a session row.
+ */
+describe("E2E · Device-handling", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+  const originalAppName = process.env.APP_NAME;
+  const originalFeatureFlag = process.env.FEATURE_DEVICE_MANAGEMENT_ENABLED;
+  const email = `device-${Date.now()}@example.com`;
+
+  // Spy capture, populated by patching EmailService.sendTemplate
+  // before the sign-up flow runs.
+  const emailCalls: Array<{ template: string; to: string; vars?: object }> = [];
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    process.env.APP_NAME = "TestApp";
+    process.env.FEATURE_DEVICE_MANAGEMENT_ENABLED = "true";
+
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    prisma = app.get(PrismaService);
+
+    // Patch EmailService.sendTemplate so we can observe outbound mail
+    // without actually shipping anything. Better-Auth's hook resolves
+    // against the same DI instance.
+    const emailService = app.get(EmailService);
+    emailService.sendTemplate = (async (args) => {
+      emailCalls.push({ template: args.template, to: args.to, vars: args.vars });
+      return { messageId: `spy-${emailCalls.length}`, driver: "spy" };
+    }) as typeof emailService.sendTemplate;
+  });
+
+  afterAll(async () => {
+    try {
+      await prisma.user.deleteMany({ where: { email } });
+    } catch {
+      // ignore
+    }
+    await app.close();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+    if (originalAppName === undefined) delete process.env.APP_NAME;
+    else process.env.APP_NAME = originalAppName;
+    if (originalFeatureFlag === undefined) delete process.env.FEATURE_DEVICE_MANAGEMENT_ENABLED;
+    else process.env.FEATURE_DEVICE_MANAGEMENT_ENABLED = originalFeatureFlag;
+  });
+
+  it("does NOT send a new-device email on the first sign-in (account creation)", async () => {
+    // Sign-up creates the user AND a session — but it's the very
+    // first session, so the device-handling decision is
+    // "first-sign-in" (silent).
+    const res = await request(app.getHttpServer())
+      .post("/api/auth/sign-up/email")
+      .set("user-agent", UA_CHROME)
+      .set("content-type", "application/json")
+      .send({ email, password: "password-12345", name: "Device User" });
+    // Better-Auth replies 200 on success.
+    expect([200, 201]).toContain(res.status);
+
+    const newDeviceCalls = emailCalls.filter((c) => c.template === "new-device");
+    expect(newDeviceCalls).toHaveLength(0);
+  });
+
+  it("sends a new-device email on a second sign-in from a different UA", async () => {
+    // Sign in with a different UA → fingerprint diverges → new-device.
+    const res = await request(app.getHttpServer())
+      .post("/api/auth/sign-in/email")
+      .set("user-agent", UA_SAFARI)
+      .set("content-type", "application/json")
+      .send({ email, password: "password-12345" });
+    // Better-Auth reply codes vary — accept 200/201.
+    expect([200, 201]).toContain(res.status);
+
+    // The sign-in is synchronous but the device-handling hook fires
+    // asynchronously inside Better-Auth's `databaseHooks.session
+    // .create.after` — give the event-loop a tick to resolve the
+    // promise before asserting.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const newDeviceCalls = emailCalls.filter((c) => c.template === "new-device");
+    expect(newDeviceCalls.length).toBeGreaterThanOrEqual(1);
+    expect(newDeviceCalls[0]?.to).toBe(email);
+    const vars = newDeviceCalls[0]?.vars as Record<string, string> | undefined;
+    expect(vars?.deviceLabel).toMatch(/Safari|iOS|Mobile/i);
+    expect(vars?.revokeUrl).toMatch(/\/me\/devices/);
+  });
+
+  it("GET /me/devices lists the user's active sessions", async () => {
+    // Re-sign in to obtain a fresh session cookie we can use for the
+    // /me/devices call.
+    const signIn = await request(app.getHttpServer())
+      .post("/api/auth/sign-in/email")
+      .set("user-agent", UA_CHROME)
+      .set("content-type", "application/json")
+      .send({ email, password: "password-12345" });
+    const cookies = signIn.headers["set-cookie"];
+    expect(cookies).toBeDefined();
+
+    const res = await request(app.getHttpServer())
+      .get("/me/devices")
+      .set("user-agent", UA_CHROME)
+      .set("x-tenant-id", TENANT)
+      .set("cookie", joinCookies(cookies));
+    expect(res.status).toBe(200);
+    const list = res.body as Array<{ id: string; deviceLabel: string; current: boolean }>;
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThanOrEqual(1);
+    expect(list[0]).toMatchObject({
+      id: expect.any(String),
+      deviceLabel: expect.any(String),
+    });
+  });
+
+  it("DELETE /me/devices/:id revokes a session", async () => {
+    const signIn = await request(app.getHttpServer())
+      .post("/api/auth/sign-in/email")
+      .set("user-agent", UA_CHROME)
+      .set("content-type", "application/json")
+      .send({ email, password: "password-12345" });
+    const cookies = signIn.headers["set-cookie"];
+
+    const list = await request(app.getHttpServer())
+      .get("/me/devices")
+      .set("user-agent", UA_CHROME)
+      .set("x-tenant-id", TENANT)
+      .set("cookie", joinCookies(cookies));
+    const items = list.body as Array<{ id: string; current: boolean }>;
+    // Pick a non-current row to revoke (otherwise the next request
+    // is unauthenticated and we lose the cookie too).
+    const target = items.find((i) => !i.current) ?? items[items.length - 1];
+    if (!target) return;
+
+    const del = await request(app.getHttpServer())
+      .delete(`/me/devices/${target.id}`)
+      .set("user-agent", UA_CHROME)
+      .set("x-tenant-id", TENANT)
+      .set("cookie", joinCookies(cookies));
+    expect([200, 204]).toContain(del.status);
+    if (del.status === 200) {
+      expect(del.body).toMatchObject({ revoked: true, id: target.id });
+    }
+  });
+});
+
+function joinCookies(cookies: string | string[] | undefined): string {
+  if (!cookies) return "";
+  const arr = Array.isArray(cookies) ? cookies : [cookies];
+  return arr.map((c) => c.split(";")[0]).join("; ");
+}

--- a/tests/stories/device-fingerprint.story.test.ts
+++ b/tests/stories/device-fingerprint.story.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fingerprintSession,
+  maskIp,
+  type FingerprintMode,
+} from "../../src/core/devices/fingerprint.js";
+
+/**
+ * Story · Device fingerprint planner.
+ *
+ * Issue #13 acceptance: a sha256 fingerprint derived from the
+ * `userAgent` + (optionally) the IP-network-prefix. The IP-prefix
+ * trick is the privacy-vs-mobility compromise: full IPs would mark
+ * every cellular connection as a "new device", while pure UA hashes
+ * collide too eagerly across users on the same browser. /24 (IPv4)
+ * and /64 (IPv6) line up with how ISPs allocate subnets, so a
+ * mobile user roaming inside the same provider keeps the same
+ * fingerprint.
+ *
+ * The planner is pure — no I/O, no env, no Date. The runner that
+ * persists the fingerprint + checks "is this new?" lives in
+ * `device-handling.ts` and gets its own story file.
+ */
+describe("Story · device fingerprint planner", () => {
+  describe("maskIp()", () => {
+    it("masks an IPv4 address to its /24 network prefix", () => {
+      // /24 keeps the first three octets, zeroes the fourth — the
+      // /24 prefix is the granularity at which residential ISPs and
+      // most mobile carriers hand out addresses.
+      expect(maskIp("192.168.1.42", "userAgent+ipSubnet")).toBe("192.168.1.0/24");
+    });
+
+    it("normalises an IPv6 address to its /64 network prefix", () => {
+      // /64 is the IPv6 host-routing boundary. Anything below /64
+      // is the host's interface identifier and changes per-device
+      // / per-temporary-address (RFC 4941). Masking keeps the
+      // routable subnet stable.
+      expect(maskIp("2001:db8:1234:5678:abcd:ef01:2345:6789", "userAgent+ipSubnet")).toBe(
+        "2001:db8:1234:5678::/64",
+      );
+    });
+
+    it("normalises an abbreviated IPv6 address (`::1` etc.)", () => {
+      expect(maskIp("::1", "userAgent+ipSubnet")).toBe("0:0:0:0::/64");
+    });
+
+    it("leaves the IP empty in `userAgent`-only mode", () => {
+      // Pure UA-mode disables the IP component entirely; the planner
+      // returns an empty marker so the caller's hash input is stable
+      // and doesn't accidentally include a stray IP fragment.
+      expect(maskIp("10.0.0.1", "userAgent")).toBe("");
+    });
+
+    it("returns a marker for malformed IP strings", () => {
+      // Defensive: a malformed IP (truncated header, manually
+      // crafted) should NOT crash the auth flow. The marker keeps
+      // the hash deterministic for the same malformed input.
+      expect(maskIp("not-an-ip", "userAgent+ipSubnet")).toBe("invalid");
+      expect(maskIp("", "userAgent+ipSubnet")).toBe("invalid");
+    });
+  });
+
+  describe("fingerprintSession()", () => {
+    const ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
+    const ipA = "192.168.1.42";
+    const ipB = "192.168.1.99"; // same /24 as ipA
+    const ipC = "10.0.0.5"; // different /24
+
+    it("produces a stable sha256 hex hash (64 chars)", () => {
+      const hash = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent+ipSubnet" });
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("returns identical hashes for two IPs in the same /24", () => {
+      const a = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent+ipSubnet" });
+      const b = fingerprintSession({ userAgent: ua, ip: ipB, mode: "userAgent+ipSubnet" });
+      expect(a).toBe(b);
+    });
+
+    it("returns different hashes for IPs in different /24 subnets", () => {
+      const a = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent+ipSubnet" });
+      const c = fingerprintSession({ userAgent: ua, ip: ipC, mode: "userAgent+ipSubnet" });
+      expect(a).not.toBe(c);
+    });
+
+    it("collapses different IPs to the same hash in `userAgent`-only mode", () => {
+      const a = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent" });
+      const c = fingerprintSession({ userAgent: ua, ip: ipC, mode: "userAgent" });
+      expect(a).toBe(c);
+    });
+
+    it("returns different hashes for different user-agents", () => {
+      const chrome = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent+ipSubnet" });
+      const safari = fingerprintSession({
+        userAgent: "Mozilla/5.0 Safari/605.1.15",
+        ip: ipA,
+        mode: "userAgent+ipSubnet",
+      });
+      expect(chrome).not.toBe(safari);
+    });
+
+    it("treats missing IP as empty (still derives a stable hash from UA)", () => {
+      const a = fingerprintSession({
+        userAgent: ua,
+        ip: undefined,
+        mode: "userAgent+ipSubnet",
+      });
+      const b = fingerprintSession({ userAgent: ua, ip: "", mode: "userAgent+ipSubnet" });
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("treats missing UA as empty (still derives a stable hash)", () => {
+      // Better-Auth lets ipAddress + userAgent both be nullish — the
+      // planner must not crash if a sign-in request lacks the UA
+      // header (e.g. a curl probe in tests).
+      const hash = fingerprintSession({
+        userAgent: undefined,
+        ip: ipA,
+        mode: "userAgent+ipSubnet",
+      });
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("varies the hash by mode (UA+subnet vs UA-only)", () => {
+      const subnet = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent+ipSubnet" });
+      const uaOnly = fingerprintSession({ userAgent: ua, ip: ipA, mode: "userAgent" });
+      // Same inputs, different mode → different hash. Otherwise a
+      // mode flip on a live deployment would invisibly mark every
+      // session as "known", defeating the whole point of the toggle.
+      expect(subnet).not.toBe(uaOnly);
+    });
+  });
+
+  it("exposes the FingerprintMode union mirroring the schema enum", () => {
+    const modes: FingerprintMode[] = ["userAgent+ipSubnet", "userAgent"];
+    expect(modes).toHaveLength(2);
+  });
+});

--- a/tests/stories/device-handling-runner.story.test.ts
+++ b/tests/stories/device-handling-runner.story.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createDeviceHandlingRunner,
+  formatLocation,
+  type DeviceEmailDispatcher,
+  type DeviceHandlingSessionStore,
+} from "../../src/core/devices/device-handling.runner.js";
+import type { KnownSession } from "../../src/core/devices/device-handling.js";
+
+/**
+ * Story · Device-handling runner.
+ *
+ * The runner glues the planner trio (fingerprint + ua-parser +
+ * decideDeviceHandling) onto a session store, an email dispatcher,
+ * and an optional GeoIP service. Failure semantics are the headline
+ * — every error here MUST be swallowed; the auth flow already
+ * succeeded by the time this hook runs.
+ */
+describe("Story · device-handling runner", () => {
+  function fakeStore(initial: KnownSession[] = []): DeviceHandlingSessionStore & {
+    fingerprintWrites: Array<{ id: string; fp: string }>;
+    revokes: string[];
+    sessions: KnownSession[];
+  } {
+    const sessions: KnownSession[] = [...initial];
+    const fingerprintWrites: Array<{ id: string; fp: string }> = [];
+    const revokes: string[] = [];
+    return {
+      sessions,
+      fingerprintWrites,
+      revokes,
+      async setFingerprint(sessionId, fp) {
+        fingerprintWrites.push({ id: sessionId, fp });
+        const existing = sessions.find((s) => s.id === sessionId);
+        if (existing) existing.fingerprintHash = fp;
+        else
+          sessions.push({
+            id: sessionId,
+            fingerprintHash: fp,
+            lastSeenAt: new Date("2026-04-30T10:00:00Z"),
+            createdAt: new Date("2026-04-30T10:00:00Z"),
+          });
+      },
+      async listForUser() {
+        return sessions;
+      },
+      async revoke(id) {
+        revokes.push(id);
+        const idx = sessions.findIndex((s) => s.id === id);
+        if (idx >= 0) sessions.splice(idx, 1);
+        return idx >= 0;
+      },
+    };
+  }
+
+  function fakeEmail(): DeviceEmailDispatcher & {
+    sends: Array<{
+      userId: string;
+      fingerprint: string;
+      deviceLabel: string;
+      location: string;
+      ipAddress: string;
+      revokeUrl: string;
+    }>;
+  } {
+    const sends: Array<{
+      userId: string;
+      fingerprint: string;
+      deviceLabel: string;
+      location: string;
+      ipAddress: string;
+      revokeUrl: string;
+    }> = [];
+    return {
+      sends,
+      async sendNewDevice(input) {
+        sends.push({
+          userId: input.user.id,
+          fingerprint: input.fingerprint,
+          deviceLabel: input.deviceLabel,
+          location: input.location,
+          ipAddress: input.ipAddress,
+          revokeUrl: input.revokeUrl,
+        });
+      },
+    };
+  }
+
+  const baseConfig = {
+    enabled: true,
+    notifyOnNewDevice: true,
+    maxDevicesPerUser: 5,
+    fingerprintMode: "userAgent+ipSubnet" as const,
+    appBaseUrl: "https://app.example.com",
+  };
+  const user = { id: "u1", email: "alice@example.com", name: "Alice" };
+  const silentLogger = { warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+
+  it("becomes a no-op when the feature is disabled", async () => {
+    const store = fakeStore();
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      config: { ...baseConfig, enabled: false },
+      logger: silentLogger,
+    });
+    await runner.handleSessionCreated({
+      sessionId: "current",
+      user,
+      userAgent: "Mozilla/5.0 Chrome/127.0",
+      ipAddress: "203.0.113.10",
+    });
+    expect(store.fingerprintWrites).toHaveLength(0);
+    expect(email.sends).toHaveLength(0);
+  });
+
+  it("persists the fingerprint and skips email on first sign-in", async () => {
+    const store = fakeStore();
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      config: baseConfig,
+      logger: silentLogger,
+    });
+    await runner.handleSessionCreated({
+      sessionId: "current",
+      user,
+      userAgent: "Mozilla/5.0 Chrome/127.0",
+      ipAddress: "203.0.113.10",
+    });
+    expect(store.fingerprintWrites).toHaveLength(1);
+    expect(email.sends).toHaveLength(0);
+  });
+
+  it("emits a new-device email when the fingerprint is new", async () => {
+    // Seed the user with one PRIOR session that has a different fp;
+    // then the current sign-in is "new device".
+    const store = fakeStore([
+      {
+        id: "old",
+        fingerprintHash: "prior-fp",
+        lastSeenAt: new Date("2026-04-29T09:00:00Z"),
+        createdAt: new Date("2026-04-29T09:00:00Z"),
+      },
+    ]);
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      config: baseConfig,
+      logger: silentLogger,
+    });
+    await runner.handleSessionCreated({
+      sessionId: "current",
+      user,
+      userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/127.0",
+      ipAddress: "203.0.113.10",
+    });
+    expect(email.sends).toHaveLength(1);
+    expect(email.sends[0]?.deviceLabel).toMatch(/Chrome/);
+    expect(email.sends[0]?.revokeUrl).toBe("https://app.example.com/me/devices");
+    // No GeoIP wired → location falls back to "Location unknown".
+    expect(email.sends[0]?.location).toBe("Location unknown");
+    // When location is unknown we DO surface the IP so the user
+    // has SOMETHING to cross-check.
+    expect(email.sends[0]?.ipAddress).toBe("203.0.113.10");
+  });
+
+  it("revokes the oldest session when the cap is exceeded", async () => {
+    // Cap=2. One prior session; current sign-in is the 2nd. Total
+    // after = 2 → no revoke. Bump cap to 1 to exceed.
+    const store = fakeStore([
+      {
+        id: "old",
+        fingerprintHash: "prior-fp",
+        lastSeenAt: new Date("2026-04-29T09:00:00Z"),
+        createdAt: new Date("2026-04-29T09:00:00Z"),
+      },
+    ]);
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      config: { ...baseConfig, maxDevicesPerUser: 1 },
+      logger: silentLogger,
+    });
+    await runner.handleSessionCreated({
+      sessionId: "current",
+      user,
+      userAgent: "Mozilla/5.0 Chrome/127.0",
+      ipAddress: "203.0.113.10",
+    });
+    expect(store.revokes).toEqual(["old"]);
+    expect(email.sends).toHaveLength(1);
+  });
+
+  it("renders city + country from a GeoIP lookup", async () => {
+    const store = fakeStore([
+      {
+        id: "old",
+        fingerprintHash: "prior-fp",
+        lastSeenAt: new Date("2026-04-29T09:00:00Z"),
+        createdAt: new Date("2026-04-29T09:00:00Z"),
+      },
+    ]);
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      geoIp: {
+        async lookup() {
+          // Even when lat/lng are present, the runner must drop
+          // them — only city + country reach the email body.
+          return {
+            country: "Germany",
+            city: "Berlin",
+            latitude: 52.52,
+            longitude: 13.405,
+          };
+        },
+      },
+      config: baseConfig,
+      logger: silentLogger,
+    });
+    await runner.handleSessionCreated({
+      sessionId: "current",
+      user,
+      userAgent: "Mozilla/5.0 Chrome/127.0",
+      ipAddress: "203.0.113.10",
+    });
+    expect(email.sends).toHaveLength(1);
+    expect(email.sends[0]?.location).toBe("Berlin, Germany");
+    // Location resolved → IP NOT surfaced in body (privacy).
+    expect(email.sends[0]?.ipAddress).toBe("");
+  });
+
+  it("swallows errors so the auth flow stays unblocked", async () => {
+    const store: DeviceHandlingSessionStore = {
+      async setFingerprint() {
+        throw new Error("DB exploded");
+      },
+      async listForUser() {
+        return [];
+      },
+      async revoke() {
+        return false;
+      },
+    };
+    const email = fakeEmail();
+    const runner = createDeviceHandlingRunner({
+      store,
+      email,
+      config: baseConfig,
+      logger: silentLogger,
+    });
+    // Should NOT throw.
+    await expect(
+      runner.handleSessionCreated({
+        sessionId: "current",
+        user,
+        userAgent: "Mozilla/5.0 Chrome/127.0",
+        ipAddress: "203.0.113.10",
+      }),
+    ).resolves.toBeUndefined();
+    expect(silentLogger.error).toHaveBeenCalled();
+  });
+
+  describe("formatLocation()", () => {
+    it("composes 'City, Country' when both are present", () => {
+      expect(formatLocation({ city: "Berlin", country: "Germany" })).toBe("Berlin, Germany");
+    });
+    it("falls back to country alone", () => {
+      expect(formatLocation({ country: "Germany" })).toBe("Germany");
+    });
+    it("falls back to city alone", () => {
+      expect(formatLocation({ city: "Berlin" })).toBe("Berlin");
+    });
+    it("returns 'Location unknown' for null / empty input", () => {
+      expect(formatLocation(null)).toBe("Location unknown");
+      expect(formatLocation({})).toBe("Location unknown");
+    });
+    it("ignores lat/lng even when present (privacy contract)", () => {
+      expect(formatLocation({ latitude: 52.52, longitude: 13.405 })).toBe("Location unknown");
+    });
+  });
+});

--- a/tests/stories/device-handling.story.test.ts
+++ b/tests/stories/device-handling.story.test.ts
@@ -29,14 +29,12 @@ import {
 describe("Story · device-handling planner", () => {
   const now = new Date("2026-04-30T10:00:00Z");
 
-  function session(
-    overrides: Partial<KnownSession> & { fp: string; lastSeenAt: string; id?: string },
-  ): KnownSession {
+  function session(input: { fp: string; lastSeenAt: string; id?: string }): KnownSession {
     return {
-      id: overrides.id ?? `s-${overrides.fp.slice(0, 6)}`,
-      fingerprintHash: overrides.fp,
-      lastSeenAt: new Date(overrides.lastSeenAt),
-      createdAt: new Date(overrides.lastSeenAt),
+      id: input.id ?? `s-${input.fp.slice(0, 6)}`,
+      fingerprintHash: input.fp,
+      lastSeenAt: new Date(input.lastSeenAt),
+      createdAt: new Date(input.lastSeenAt),
     };
   }
 

--- a/tests/stories/device-handling.story.test.ts
+++ b/tests/stories/device-handling.story.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideDeviceHandling,
+  selectOldestSessionForRevoke,
+  type KnownSession,
+} from "../../src/core/devices/device-handling.js";
+
+/**
+ * Story · Device-handling decision planner.
+ *
+ * The planner takes the current sign-in's fingerprint plus the
+ * user's existing sessions and decides what the runner should do:
+ *
+ *   - { action: "known" }                — fingerprint matches
+ *     a previous session; no notification, no revoke.
+ *   - { action: "new-device", revokeId } — fingerprint is new;
+ *     notify the user, optionally revoke the oldest session if
+ *     the cap is exceeded.
+ *   - { action: "limit-block" }          — operator-configurable
+ *     stricter mode where exceeding the cap blocks the new sign-in
+ *     instead of revoking the oldest. (Out of scope today, but the
+ *     planner already returns the right shape for callers to lean
+ *     on later.)
+ *
+ * The planner is pure — no I/O, no Date, no rate limit. The runner
+ * (\`device-handling.runner.ts\`) glues it to Prisma + outbox + revoke.
+ */
+describe("Story · device-handling planner", () => {
+  const now = new Date("2026-04-30T10:00:00Z");
+
+  function session(
+    overrides: Partial<KnownSession> & { fp: string; lastSeenAt: string; id?: string },
+  ): KnownSession {
+    return {
+      id: overrides.id ?? `s-${overrides.fp.slice(0, 6)}`,
+      fingerprintHash: overrides.fp,
+      lastSeenAt: new Date(overrides.lastSeenAt),
+      createdAt: new Date(overrides.lastSeenAt),
+    };
+  }
+
+  describe("decideDeviceHandling()", () => {
+    it("returns 'known' when the fingerprint matches an existing session", () => {
+      const known = [
+        session({ fp: "fp-a", lastSeenAt: "2026-04-29T09:00:00Z" }),
+        session({ fp: "fp-b", lastSeenAt: "2026-04-30T08:00:00Z" }),
+      ];
+      const result = decideDeviceHandling({
+        currentFingerprint: "fp-a",
+        currentSessionId: "current",
+        knownSessions: known,
+        maxDevicesPerUser: 10,
+        now,
+      });
+      expect(result.action).toBe("known");
+    });
+
+    it("returns 'new-device' (no revoke) when the fingerprint is new and below the cap", () => {
+      const known = [session({ fp: "fp-a", lastSeenAt: "2026-04-29T09:00:00Z" })];
+      const result = decideDeviceHandling({
+        currentFingerprint: "fp-new",
+        currentSessionId: "current",
+        knownSessions: known,
+        maxDevicesPerUser: 10,
+        now,
+      });
+      expect(result.action).toBe("new-device");
+      if (result.action === "new-device") {
+        expect(result.revokeSessionId).toBeUndefined();
+      }
+    });
+
+    it("returns 'new-device' with revokeSessionId when adding would exceed the cap", () => {
+      // 3 known sessions + 1 new = 4. Cap = 3 → revoke the oldest
+      // existing session (NOT the current one) to keep the count
+      // at the cap exactly.
+      const known = [
+        session({ fp: "fp-a", lastSeenAt: "2026-04-28T09:00:00Z", id: "old" }),
+        session({ fp: "fp-b", lastSeenAt: "2026-04-29T09:00:00Z", id: "mid" }),
+        session({ fp: "fp-c", lastSeenAt: "2026-04-30T08:00:00Z", id: "fresh" }),
+      ];
+      const result = decideDeviceHandling({
+        currentFingerprint: "fp-new",
+        currentSessionId: "current",
+        knownSessions: known,
+        maxDevicesPerUser: 3,
+        now,
+      });
+      expect(result.action).toBe("new-device");
+      if (result.action === "new-device") {
+        expect(result.revokeSessionId).toBe("old");
+      }
+    });
+
+    it("ignores the current session when checking for a fingerprint match", () => {
+      // Better-Auth's session.create.after fires AFTER the row is
+      // inserted, so the just-created session is part of
+      // \`knownSessions\` if Prisma returns it. The planner must skip
+      // it — otherwise every sign-in matches itself and looks
+      // 'known'. Two sessions: one prior with a different fp, plus
+      // the just-created current session that happens to match
+      // itself. The match-check must skip the current id.
+      const known = [
+        session({ fp: "fp-prior", lastSeenAt: "2026-04-29T09:00:00Z", id: "prior" }),
+        session({ fp: "fp-self", lastSeenAt: "2026-04-30T10:00:00Z", id: "current" }),
+      ];
+      const result = decideDeviceHandling({
+        currentFingerprint: "fp-self",
+        currentSessionId: "current",
+        knownSessions: known,
+        maxDevicesPerUser: 10,
+        now,
+      });
+      // No PRIOR session shares the fingerprint → genuinely new.
+      expect(result.action).toBe("new-device");
+    });
+
+    it("handles a zero-known-sessions case (first sign-in ever)", () => {
+      // First-ever sign-in: no prior sessions. Spec is "no email
+      // on the first session" so the planner returns 'first-sign-in'
+      // — the runner skips notification but still records the fp.
+      const result = decideDeviceHandling({
+        currentFingerprint: "fp-x",
+        currentSessionId: "current",
+        knownSessions: [],
+        maxDevicesPerUser: 10,
+        now,
+      });
+      expect(result.action).toBe("first-sign-in");
+    });
+  });
+
+  describe("selectOldestSessionForRevoke()", () => {
+    it("picks the session with the smallest lastSeenAt", () => {
+      const sessions = [
+        session({ fp: "fp-a", lastSeenAt: "2026-04-30T09:00:00Z", id: "newer" }),
+        session({ fp: "fp-b", lastSeenAt: "2026-04-29T09:00:00Z", id: "older" }),
+        session({ fp: "fp-c", lastSeenAt: "2026-04-30T08:00:00Z", id: "middle" }),
+      ];
+      expect(selectOldestSessionForRevoke(sessions)).toBe("older");
+    });
+
+    it("falls back to createdAt when lastSeenAt ties", () => {
+      const ts = "2026-04-30T08:00:00Z";
+      const sessions: KnownSession[] = [
+        {
+          id: "newer-create",
+          fingerprintHash: "fp-a",
+          lastSeenAt: new Date(ts),
+          createdAt: new Date("2026-04-30T07:00:00Z"),
+        },
+        {
+          id: "older-create",
+          fingerprintHash: "fp-b",
+          lastSeenAt: new Date(ts),
+          createdAt: new Date("2026-04-29T07:00:00Z"),
+        },
+      ];
+      expect(selectOldestSessionForRevoke(sessions)).toBe("older-create");
+    });
+
+    it("returns null for an empty list", () => {
+      expect(selectOldestSessionForRevoke([])).toBeNull();
+    });
+  });
+});

--- a/tests/stories/device-ua-parser.story.test.ts
+++ b/tests/stories/device-ua-parser.story.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { parseUserAgent } from "../../src/core/devices/ua-parser.js";
+
+/**
+ * Story · Device UA-parser planner.
+ *
+ * `parseUserAgent(ua)` turns a raw User-Agent header into the
+ * `{ os, browser, deviceType, label }` projection that the
+ * new-device email + `/me/devices` endpoint surface to humans. The
+ * underlying `ua-parser-js` library powers the heavy lifting; the
+ * planner adds:
+ *   - graceful empty / malformed defaults ("Unknown device") so a
+ *     bare cURL probe never produces a null label,
+ *   - a single composed `label` field — `"<browser> on <os>"` — so
+ *     callers don't have to assemble it themselves.
+ *
+ * The planner is pure (no I/O, no Date) — it's a thin wrapper.
+ */
+describe("Story · device UA parser", () => {
+  it("parses a Chrome on macOS user-agent into structured fields", () => {
+    const out = parseUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+    );
+    expect(out.browser).toMatch(/Chrome/);
+    expect(out.os).toMatch(/Mac OS|macOS/);
+    expect(out.deviceType).toBe("desktop");
+    expect(out.label).toMatch(/Chrome on (Mac OS|macOS)/);
+  });
+
+  it("parses a Safari on iPhone user-agent and labels it `mobile`", () => {
+    const out = parseUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari/604.1",
+    );
+    expect(out.browser).toMatch(/Safari/);
+    expect(out.os).toMatch(/iOS/);
+    expect(out.deviceType).toBe("mobile");
+  });
+
+  it("parses a Firefox on Linux user-agent", () => {
+    const out = parseUserAgent(
+      "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0",
+    );
+    expect(out.browser).toMatch(/Firefox/);
+    expect(out.os).toMatch(/Linux/);
+    expect(out.deviceType).toBe("desktop");
+  });
+
+  it("falls back to a generic label for an empty user-agent", () => {
+    // Better-Auth's `userAgent` is nullish — a sign-in via API client
+    // (or a `curl` probe in CI) won't set the header. The planner
+    // surfaces the empty-input fallback rather than crashing the
+    // hook (which would block the auth flow).
+    const out = parseUserAgent("");
+    expect(out.label).toBe("Unknown device");
+    expect(out.deviceType).toBe("unknown");
+    expect(out.browser).toBe("Unknown");
+    expect(out.os).toBe("Unknown");
+  });
+
+  it("falls back to a generic label for a malformed user-agent", () => {
+    const out = parseUserAgent("totally-not-a-ua");
+    // ua-parser-js returns undefined fields here; the planner
+    // back-fills "Unknown" so downstream renderers (email body,
+    // dev-portal table) always have a string to display.
+    expect(out.label).toBe("Unknown device");
+    expect(out.browser).toBe("Unknown");
+    expect(out.os).toBe("Unknown");
+  });
+
+  it("treats explicit undefined the same as an empty UA string", () => {
+    const out = parseUserAgent(undefined);
+    expect(out.label).toBe("Unknown device");
+  });
+
+  it("classifies a smart-tv user-agent as `tv`", () => {
+    // Picked the deviceType union ahead of full support: tablets,
+    // smart-tvs, and console all have ua-parser-js types. The
+    // planner just forwards what the lib detected; if it returns
+    // an unknown type the planner falls back to "unknown".
+    const out = parseUserAgent(
+      "Mozilla/5.0 (SMART-TV; X11; Linux armv7l) AppleWebKit/537.42 (KHTML, like Gecko) Chromium/25.0.1349.2 Chrome/25.0.1349.2",
+    );
+    // Some ua-parser-js versions report "smarttv" specifically; we
+    // accept either to stay loose to lib upgrades.
+    expect(["tv", "smarttv"]).toContain(out.deviceType);
+  });
+});

--- a/tests/stories/features.story.test.ts
+++ b/tests/stories/features.story.test.ts
@@ -44,6 +44,36 @@ describe("Story · Feature-Flag-System", () => {
       const result = FeaturesSchema.safeParse({ files: { storageDefault: "unknown-driver" } });
       expect(result.success).toBe(false);
     });
+
+    it("includes the deviceManagement schema with privacy-friendly defaults", () => {
+      // Issue #13: device-handling is opt-in (default off) so a fresh
+      // project doesn't accumulate device fingerprints unless the
+      // operator deliberately turns it on.
+      const features = FeaturesSchema.parse({});
+      expect(features.deviceManagement.enabled).toBe(false);
+      expect(features.deviceManagement.maxDevicesPerUser).toBe(10);
+      expect(features.deviceManagement.notifyOnNewDevice).toBe(true);
+      expect(features.deviceManagement.sessionFingerprint).toBe("userAgent+ipSubnet");
+    });
+
+    it("rejects an invalid sessionFingerprint mode", () => {
+      const result = FeaturesSchema.safeParse({
+        deviceManagement: { sessionFingerprint: "fingerprint-everything" },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a non-positive maxDevicesPerUser", () => {
+      // 0 / negative → schema must fail. The hook would otherwise
+      // never let a sign-in through (every session immediately
+      // exceeds the cap).
+      expect(FeaturesSchema.safeParse({ deviceManagement: { maxDevicesPerUser: 0 } }).success).toBe(
+        false,
+      );
+      expect(
+        FeaturesSchema.safeParse({ deviceManagement: { maxDevicesPerUser: -1 } }).success,
+      ).toBe(false);
+    });
   });
 
   describe("loadFeatures(env) — FEATURE_* ENV-Overrides", () => {

--- a/tests/stories/new-device-email-payload.story.test.ts
+++ b/tests/stories/new-device-email-payload.story.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEmailHookPayload,
+  type BetterAuthEmailUser,
+} from "../../src/core/auth/better-auth-email-hooks.js";
+
+/**
+ * Story · New-device email payload builder.
+ *
+ * Issue #13 extends the email-hooks planner with a `new-device`
+ * variant. Vars:
+ *   - recipientName, appName  (shared with all templates)
+ *   - deviceLabel              (UA-parser output, e.g. "Chrome on macOS")
+ *   - location                 ("City, Country" or "Location unknown")
+ *   - ipAddress                (raw — but only present when GeoIP
+ *                               returned nothing usable; with location
+ *                               we drop the IP from the email body
+ *                               for privacy)
+ *   - signedInAt               (ISO timestamp string)
+ *   - revokeUrl                (link to /me/devices)
+ *
+ * The runner half (queueing the email + dedup) lives in
+ * `device-handling.runner.ts`.
+ */
+describe("Story · new-device email payload", () => {
+  const user: BetterAuthEmailUser = { id: "u1", email: "alice@example.com", name: "Alice" };
+
+  it("builds the canonical { template, to, vars } shape for new-device", () => {
+    const out = buildEmailHookPayload({
+      kind: "new-device",
+      user,
+      appName: "Acme",
+      deviceLabel: "Chrome on macOS",
+      location: "Berlin, Germany",
+      ipAddress: "203.0.113.42",
+      signedInAt: "2026-04-30T10:00:00.000Z",
+      revokeUrl: "https://app.example.com/me/devices",
+    });
+    expect(out.template).toBe("new-device");
+    expect(out.to).toBe("alice@example.com");
+    expect(out.vars).toMatchObject({
+      recipientName: "Alice",
+      appName: "Acme",
+      deviceLabel: "Chrome on macOS",
+      location: "Berlin, Germany",
+      ipAddress: "203.0.113.42",
+      signedInAt: "2026-04-30T10:00:00.000Z",
+      revokeUrl: "https://app.example.com/me/devices",
+    });
+  });
+
+  it("falls back to 'Location unknown' when location is empty", () => {
+    // GeoIP returned null (private IP, missing .mmdb, etc.) — the
+    // mail still ships, the body just shows "Location unknown".
+    const out = buildEmailHookPayload({
+      kind: "new-device",
+      user,
+      appName: "Acme",
+      deviceLabel: "Safari on iOS",
+      location: "",
+      ipAddress: "10.0.0.5",
+      signedInAt: "2026-04-30T10:00:00.000Z",
+      revokeUrl: "https://app.example.com/me/devices",
+    });
+    expect(out.vars.location).toBe("Location unknown");
+  });
+
+  it("requires a non-empty deviceLabel", () => {
+    expect(() =>
+      buildEmailHookPayload({
+        kind: "new-device",
+        user,
+        appName: "Acme",
+        deviceLabel: "",
+        location: "Berlin",
+        ipAddress: "203.0.113.42",
+        signedInAt: "2026-04-30T10:00:00.000Z",
+        revokeUrl: "https://app.example.com/me/devices",
+      }),
+    ).toThrow(/deviceLabel/);
+  });
+
+  it("requires a non-empty revokeUrl", () => {
+    expect(() =>
+      buildEmailHookPayload({
+        kind: "new-device",
+        user,
+        appName: "Acme",
+        deviceLabel: "Chrome on macOS",
+        location: "Berlin",
+        ipAddress: "203.0.113.42",
+        signedInAt: "2026-04-30T10:00:00.000Z",
+        revokeUrl: "",
+      }),
+    ).toThrow(/revokeUrl/);
+  });
+});

--- a/tests/stories/new-device-email-runner.story.test.ts
+++ b/tests/stories/new-device-email-runner.story.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createEmailHookRunner,
+  type EmailSenderForHooks,
+} from "../../src/core/auth/better-auth-email-hooks.runner.js";
+import {
+  createNewDeviceThrottle,
+  type NewDeviceThrottle,
+} from "../../src/core/devices/new-device-throttle.js";
+
+/**
+ * Story · Better-Auth hook runner — new-device dispatch + throttle.
+ *
+ * The runner gains a `sendNewDevice(data)` method. Two contracts:
+ *
+ *  1. The dispatch carries `mode: "outbox"` (when `useOutbox: true`)
+ *     and a deterministic idempotency-key derived from the user-id +
+ *     fingerprint, so a sign-in retried within a few seconds collapses
+ *     to one outbox row.
+ *
+ *  2. A *throttle* sits in front: max 1 new-device mail per user per
+ *     hour. Hands rotating mobile IPs / aggressive auto-relogin clients
+ *     a sane upper bound on email volume. The throttle is an
+ *     EmailRateLimiter-shaped object, injected so tests can poke a
+ *     deterministic clock.
+ */
+describe("Story · Better-Auth hook runner new-device dispatch", () => {
+  function recordingSender(): EmailSenderForHooks & {
+    calls: Array<{
+      template: string;
+      to: string;
+      vars: object;
+      dispatch?: { mode?: string; idempotencyKey?: string };
+    }>;
+  } {
+    const calls: Array<{
+      template: string;
+      to: string;
+      vars: object;
+      dispatch?: { mode?: string; idempotencyKey?: string };
+    }> = [];
+    return {
+      calls,
+      async sendTemplate(args, dispatch) {
+        calls.push({
+          template: args.template,
+          to: args.to,
+          vars: args.vars ?? {},
+          ...(dispatch ? { dispatch } : {}),
+        });
+        return { messageId: `m-${calls.length}`, driver: "outbox" };
+      },
+    };
+  }
+
+  function fakeThrottle(): NewDeviceThrottle & { records: string[] } {
+    const records: string[] = [];
+    const allowed = new Set<string>();
+    return {
+      records,
+      check(userId: string) {
+        if (allowed.has(userId)) return { allowed: true };
+        return { allowed: false, resetMs: 1_800_000 };
+      },
+      record(userId: string) {
+        records.push(userId);
+        allowed.delete(userId);
+      },
+      __allow(userId: string) {
+        allowed.add(userId);
+      },
+    } as NewDeviceThrottle & { records: string[]; __allow: (id: string) => void };
+  }
+
+  const user = { id: "u1", email: "alice@example.com", name: "Alice" };
+  const baseData = {
+    user,
+    deviceLabel: "Chrome on macOS",
+    location: "Berlin, Germany",
+    ipAddress: "203.0.113.42",
+    signedInAt: "2026-04-30T10:00:00.000Z",
+    revokeUrl: "https://app.example.com/me/devices",
+  };
+
+  it("queues the new-device mail with a deterministic idempotency-key", async () => {
+    const sender = recordingSender();
+    const throttle = fakeThrottle();
+    (throttle as unknown as { __allow: (id: string) => void }).__allow("u1");
+    const runner = createEmailHookRunner({
+      sender,
+      appName: "Acme",
+      useOutbox: true,
+      newDeviceThrottle: throttle,
+    });
+    await runner.sendNewDevice({ ...baseData, fingerprint: "fp-abc" });
+    expect(sender.calls).toHaveLength(1);
+    expect(sender.calls[0]?.dispatch?.mode).toBe("outbox");
+    // Key segments the namespace by kind + recipient + fingerprint
+    // so a duplicate sign-in (same fp, same user) within the same
+    // outbox window dedups. A fresh fingerprint produces a fresh key.
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain("new-device");
+    expect(sender.calls[0]?.dispatch?.idempotencyKey).toContain("fp-abc");
+  });
+
+  it("skips dispatch when the throttle denies (rate-limited)", async () => {
+    const sender = recordingSender();
+    const throttle = fakeThrottle(); // denies everyone by default
+    const runner = createEmailHookRunner({
+      sender,
+      appName: "Acme",
+      useOutbox: true,
+      newDeviceThrottle: throttle,
+    });
+    await runner.sendNewDevice({ ...baseData, fingerprint: "fp-x" });
+    expect(sender.calls).toHaveLength(0);
+    // The throttle is record-on-success; a denied call must not
+    // record (otherwise rejection would extend the window).
+    expect(throttle.records).toHaveLength(0);
+  });
+
+  it("records the throttle slot only after a successful send", async () => {
+    const sender = recordingSender();
+    const throttle = fakeThrottle();
+    (throttle as unknown as { __allow: (id: string) => void }).__allow("u1");
+    const runner = createEmailHookRunner({
+      sender,
+      appName: "Acme",
+      useOutbox: true,
+      newDeviceThrottle: throttle,
+    });
+    await runner.sendNewDevice({ ...baseData, fingerprint: "fp-x" });
+    expect(throttle.records).toEqual(["u1"]);
+  });
+
+  it("dispatches without throttle when none is configured", async () => {
+    // Defensive default: a runner without a throttle still works
+    // — useful for unit tests / project setups that want their own
+    // rate-limiter wired upstream.
+    const sender = recordingSender();
+    const runner = createEmailHookRunner({
+      sender,
+      appName: "Acme",
+      useOutbox: true,
+    });
+    await runner.sendNewDevice({ ...baseData, fingerprint: "fp-x" });
+    expect(sender.calls).toHaveLength(1);
+  });
+});
+
+describe("Story · new-device throttle", () => {
+  it("allows the first call and denies the second within the window", () => {
+    const now = { value: 0 };
+    const throttle = createNewDeviceThrottle({
+      windowMs: 60 * 60 * 1000, // 1h
+      now: () => now.value,
+    });
+    const first = throttle.check("u1");
+    expect(first.allowed).toBe(true);
+    throttle.record("u1");
+    const second = throttle.check("u1");
+    expect(second.allowed).toBe(false);
+    expect(second.resetMs).toBeGreaterThan(0);
+  });
+
+  it("re-allows after the window expires", () => {
+    const now = { value: 0 };
+    const throttle = createNewDeviceThrottle({
+      windowMs: 1_000,
+      now: () => now.value,
+    });
+    throttle.record("u1");
+    expect(throttle.check("u1").allowed).toBe(false);
+    now.value = 2_000;
+    expect(throttle.check("u1").allowed).toBe(true);
+  });
+
+  it("partitions by user-id so two users don't share the window", () => {
+    const now = { value: 0 };
+    const throttle = createNewDeviceThrottle({
+      windowMs: 60_000,
+      now: () => now.value,
+    });
+    throttle.record("u1");
+    expect(throttle.check("u1").allowed).toBe(false);
+    expect(throttle.check("u2").allowed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #13. Adds the device-handling subsystem behind the new
`features.deviceManagement` toggle (default OFF):

- **Fingerprint planner** (`src/core/devices/fingerprint.ts`) — pure
  sha256 over `(mode, userAgent, masked-ip)`. IPv4 → /24, IPv6 → /64.
- **UA parser** (`ua-parser.ts`) — `ua-parser-js` wrapper with
  defensive fallbacks ("Unknown device" for empty / malformed UAs).
- **Decision planner** (`device-handling.ts`) — pure: returns
  `first-sign-in` / `known` / `new-device` (with optional
  `revokeSessionId` when the per-user cap is exceeded).
- **In-memory throttle** (`new-device-throttle.ts`) — 1 mail / user /
  hour by default; the runner records only on a successful dispatch
  so failed sends don't burn a slot.
- **Orchestrator** (`device-handling.runner.ts`) — wires it all to
  Better-Auth's `databaseHooks.session.create.after`. Never throws
  back into the auth flow.
- **`/me/devices` endpoints** — `GET` lists active sessions with
  parsed UA labels, `DELETE :id` revokes (with ownership check).
- **`new-device.tsx` email** — privacy-first body: city + country
  only, never lat/lng. Falls back to the IP only when GeoIP
  returned nothing usable.
- **Prisma migration** — `sessions.fingerprint VARCHAR(64)` +
  `(user_id, fingerprint)` covering index. Nullable for backward
  compat.
- **Docs** — `src/core/devices/CLAUDE.md`, plus updates to
  `src/core/auth/CLAUDE.md` and `src/core/email/CLAUDE.md`.

Privacy contract spelled out in the device CLAUDE.md: we store the
fingerprint hash only, the masked-CIDR is a transient intermediate,
lat/lng never reaches the email body, raw IPs survive in the
existing Better-Auth columns and are deleted on session expiry.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format` — clean
- [x] `bun run test:types` — clean
- [x] `bun run test:unit` — 153/153
- [x] `bun run test:e2e` — 2363/2363 (incl. new `tests/devices.e2e-spec.ts`)
- [x] `bun run test:coverage` — `core/devices/` at 91.5% lines, 88% branches
- [x] `bun run build` — succeeds
- [x] `bun run build:dev-portal` — succeeds
- [x] Story tests cover IPv4/IPv6 masking, mode-flip stability, planner decisions, the throttle window, the runner orchestration (mocked deps), and the never-throw failure semantics
- [x] E2E covers: first sign-in is silent → second sign-in with different UA fires `new-device` email → `GET /me/devices` lists → `DELETE /me/devices/:id` revokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)