### PR TITLE
feat(errors): add ResourceNotFoundError base + fix Example 500→404

### DIFF
--- a/docs/code-guidelines.md
+++ b/docs/code-guidelines.md
@@ -193,8 +193,30 @@ All errors leave the system as `application/problem+json`:
   Add entries there; never inline a magic string.
 - **Translations** belong in the registry entry (`translations.de`,
   `translations.en`).
-- **Throwing** — extend the matching `ProblemException` subclass; the
-  global filter formats the response.
+- **Throwing** — always extend a NestJS `HttpException` subclass (or
+  one of the framework sentinels handled by
+  `ProblemDetailsExceptionFilter`). The global filter only recognises
+  `HttpException`, `ZodError`, and a small set of named framework
+  sentinels; a plain `class FooError extends Error` falls through to
+  the catch-all 500 + `CORE_INTERNAL` branch.
+  - For "resource not found" use the canonical
+    `ResourceNotFoundError` (in `src/core/errors/`):
+
+    ```ts
+    import { ResourceNotFoundError } from "src/core/errors/resource-not-found-error.js";
+
+    export class ExampleNotFoundError extends ResourceNotFoundError {
+      constructor(id: string) {
+        super("Example", id);
+        this.name = "ExampleNotFoundError";
+      }
+    }
+    ```
+
+    The filter maps it to 404 + `CORE_NOT_FOUND` automatically.
+  - For other shapes, extend the matching NestJS exception
+    (`BadRequestException`, `ConflictException`, `ForbiddenException`,
+    …) directly — the filter's `HttpException` branch handles them.
 
 The [`adding-error-code`](../.claude/skills/adding-error-code.md) skill
 walks through it end-to-end.

--- a/src/core/CLAUDE.md
+++ b/src/core/CLAUDE.md
@@ -83,6 +83,15 @@ The exception filter in `errors/problem-details.filter.ts` maps known
 sentinels to RFC 7807 responses; unknown errors get `CORE_INTERNAL` with
 the message redacted in production.
 
+**Crossing the HTTP boundary?** Always extend a NestJS `HttpException`
+subclass (or one of the framework sentinels the filter handles
+explicitly). `class FooError extends Error` falls through to the
+catch-all 500 + `CORE_INTERNAL` branch — even if the doc-comment says
+"throw this, get a 404". For "resource not found" use the canonical
+`errors/resource-not-found-error.ts` (`ResourceNotFoundError extends
+NotFoundException`); the filter maps it to 404 + `CORE_NOT_FOUND`
+automatically.
+
 ### Imports use `.js` extensions
 
 Even when the source is `foo.ts`. This is ESM `nodenext`; the runtime

--- a/src/core/errors/resource-not-found-error.ts
+++ b/src/core/errors/resource-not-found-error.ts
@@ -1,0 +1,65 @@
+/**
+ * Canonical "throw this, get a 404" base class for resource lookups.
+ *
+ * Why this exists: the global `ProblemDetailsExceptionFilter` only
+ * recognises `HttpException` (NestJS), `ZodError`, and a small set of
+ * framework sentinels. A module that hand-rolled
+ * `class FooNotFoundError extends Error` fell through to the catch-all
+ * branch and produced a 500 + `CORE_INTERNAL` response — even though
+ * the docs (and consumer expectation) said "extend this, get a 404".
+ *
+ * Fix: extend NestJS' `NotFoundException` (an `HttpException` subclass)
+ * so the existing 404-status branch picks it up automatically and
+ * emits `CORE_NOT_FOUND`. Module-level subclasses keep their named
+ * sentinel pattern:
+ *
+ * ```ts
+ * export class ExampleNotFoundError extends ResourceNotFoundError {
+ *   constructor(id: string) {
+ *     super("Example", id);
+ *     this.name = "ExampleNotFoundError";
+ *   }
+ * }
+ * ```
+ *
+ * The filter's `HttpException` branch then maps it to:
+ *   - `status` 404
+ *   - `code` `CORE_NOT_FOUND` (via `codeForStatus(404)`)
+ *   - `detail` `Example with id "<id>" not found`
+ *   - `title` `Not Found`
+ */
+
+import { NotFoundException } from "@nestjs/common";
+
+import { CORE_ERROR_CODES } from "./error-code.js";
+
+export interface ResourceNotFoundOptions {
+  /** Override the default `<resource> with id "<id>" not found` detail. */
+  detail?: string;
+}
+
+/**
+ * Marker base class for "resource X with id Y not found" errors.
+ *
+ * Extends `NotFoundException` so the global `ProblemDetailsExceptionFilter`
+ * maps it to RFC 7807 + 404 + `CORE_NOT_FOUND` automatically — no extra
+ * filter wiring per module.
+ */
+export class ResourceNotFoundError extends NotFoundException {
+  constructor(
+    public readonly resource: string,
+    public readonly resourceId: string,
+    options: ResourceNotFoundOptions = {},
+  ) {
+    const message = options.detail ?? `${resource} with id "${resourceId}" not found`;
+    // The filter reads `response.message` for the `detail` field and
+    // honours `response.code` if the consumer set one explicitly. We
+    // pre-fill `code: CORE_NOT_FOUND` here so subclasses inherit the
+    // right code without restating it.
+    super({
+      code: CORE_ERROR_CODES.NOT_FOUND,
+      message,
+    });
+    this.name = "ResourceNotFoundError";
+  }
+}

--- a/src/modules/example/README.md
+++ b/src/modules/example/README.md
@@ -68,9 +68,19 @@ the requested page.
 
 ### 4. Named error sentinels
 
-`ExampleNotFoundError` lives at the top of `example.service.ts`. The
-global `ProblemDetailsFilter` maps it to RFC 7807 with a 404 status.
-The controller never has to know about the error class.
+`ExampleNotFoundError` lives at the top of `example.service.ts` and
+extends `ResourceNotFoundError` (from `src/core/errors/`). The base
+class is a thin wrapper over NestJS' `NotFoundException`, so the
+global `ProblemDetailsFilter` maps it to RFC 7807 with a 404 status
+and `code: CORE_NOT_FOUND` automatically. The controller never has
+to know about the error class.
+
+> **Don't** roll your own `class FooNotFoundError extends Error`.
+> Plain-`Error` subclasses fall through the filter to a 500 +
+> `CORE_INTERNAL` because the filter only recognises
+> `HttpException`, `ZodError`, and a small set of framework
+> sentinels. Always extend `ResourceNotFoundError` (or the matching
+> NestJS exception, e.g. `ConflictException`, `BadRequestException`).
 
 ### 5. Zod-driven DTOs
 

--- a/src/modules/example/example.service.ts
+++ b/src/modules/example/example.service.ts
@@ -16,6 +16,7 @@
 import { Injectable } from "@nestjs/common";
 import type { Example } from "@prisma/client";
 
+import { ResourceNotFoundError } from "../../core/errors/resource-not-found-error.js";
 import {
   type CursorPage,
   type CursorRecord,
@@ -33,9 +34,16 @@ import type {
 
 // ── Errors ──────────────────────────────────────────────────────────
 
-export class ExampleNotFoundError extends Error {
+/**
+ * Named sentinel for "Example with id X does not exist (or is in
+ * another tenant)". Extends `ResourceNotFoundError` so the global
+ * `ProblemDetailsExceptionFilter` emits 404 + `CORE_NOT_FOUND`
+ * automatically. Before this class extended the framework base,
+ * the response was a 500 + `CORE_INTERNAL`.
+ */
+export class ExampleNotFoundError extends ResourceNotFoundError {
   constructor(id: string) {
-    super(`Example not found: ${id}`);
+    super("Example", id);
     this.name = "ExampleNotFoundError";
   }
 }

--- a/tests/problem-details.e2e-spec.ts
+++ b/tests/problem-details.e2e-spec.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { ProblemDetailsExceptionFilter } from "../src/core/errors/problem-details.filter.js";
+import { ResourceNotFoundError } from "../src/core/errors/resource-not-found-error.js";
 import { TenantIsolationError } from "../src/core/multi-tenancy/tenant-header.js";
 
 const Body = z.object({ name: z.string().min(2) });
@@ -87,6 +88,22 @@ class BoomController {
   @Get("tenant-missing")
   tenantMissing(): void {
     throw new TenantIsolationError("tenant header is required");
+  }
+
+  @Get("resource-not-found")
+  resourceNotFound(): void {
+    throw new ResourceNotFoundError("Example", "abc-123");
+  }
+
+  @Get("custom-not-found")
+  customNotFound(): void {
+    class WidgetNotFoundError extends ResourceNotFoundError {
+      constructor(id: string) {
+        super("Widget", id);
+        this.name = "WidgetNotFoundError";
+      }
+    }
+    throw new WidgetNotFoundError("xyz-789");
   }
 }
 
@@ -196,5 +213,33 @@ describe("Problem-Details exception filter", () => {
   it("joins HttpException array messages with commas", async () => {
     const response = await request(app.getHttpServer()).get("/boom/http-array");
     expect(response.body.detail).toBe("one, two");
+  });
+
+  it("ResourceNotFoundError becomes 404 + CORE_NOT_FOUND (not 500)", async () => {
+    // Regression: friction-log finding — module authors used to extend
+    // plain `Error` and got a 500 with "[ProblemDetailsFilter] unhandled
+    // error" logged. Extending `ResourceNotFoundError` (a
+    // `NotFoundException` subclass) now flows through the existing
+    // HttpException branch and produces a clean 404.
+    const response = await request(app.getHttpServer()).get("/boom/resource-not-found");
+    expect(response.status).toBe(404);
+    expect(response.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(response.body).toMatchObject({
+      code: "CORE_NOT_FOUND",
+      title: "Not Found",
+      status: 404,
+      detail: 'Example with id "abc-123" not found',
+      instance: "/boom/resource-not-found",
+    });
+  });
+
+  it("subclasses of ResourceNotFoundError also map to 404 + CORE_NOT_FOUND", async () => {
+    const response = await request(app.getHttpServer()).get("/boom/custom-not-found");
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      code: "CORE_NOT_FOUND",
+      status: 404,
+      detail: 'Widget with id "xyz-789" not found',
+    });
   });
 });

--- a/tests/stories/example-module.story.test.ts
+++ b/tests/stories/example-module.story.test.ts
@@ -8,8 +8,10 @@
  * tenant-isolation, list filtering, not-found errors.
  */
 
+import { NotFoundException } from "@nestjs/common";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { ResourceNotFoundError } from "../../src/core/errors/resource-not-found-error.js";
 import {
   CreateExampleSchema,
   ListExampleQuerySchema,
@@ -111,6 +113,23 @@ describe("Story · Example module", () => {
       await expect(service.findById(TENANT_A, "no-such-id")).rejects.toBeInstanceOf(
         ExampleNotFoundError,
       );
+    });
+
+    it("ExampleNotFoundError extends ResourceNotFoundError → 404 (not 500)", async () => {
+      // Regression test for the friction-log finding: the previous
+      // `extends Error` form fell through the filter to a 500 +
+      // CORE_INTERNAL. Asserting both the inheritance chain and the
+      // HTTP status pins the contract so a future refactor can't
+      // silently regress to plain Error.
+      try {
+        await service.findById(TENANT_A, "no-such-id");
+        throw new Error("expected ExampleNotFoundError to be thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ExampleNotFoundError);
+        expect(err).toBeInstanceOf(ResourceNotFoundError);
+        expect(err).toBeInstanceOf(NotFoundException);
+        expect((err as NotFoundException).getStatus()).toBe(404);
+      }
     });
   });
 

--- a/tests/stories/resource-not-found-error.story.test.ts
+++ b/tests/stories/resource-not-found-error.story.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Story tests for `ResourceNotFoundError` — the canonical "throw this,
+ * get a 404" base class for resource lookups.
+ *
+ * Why this class exists: before this slice, modules that hand-rolled
+ * `class FooNotFoundError extends Error` got a 500 response from the
+ * global `ProblemDetailsExceptionFilter` (which only knew about
+ * `HttpException`, `ZodError`, and a few framework sentinels). The
+ * filter logged "[ProblemDetailsFilter] unhandled error" and returned
+ * `CORE_INTERNAL` instead of `CORE_NOT_FOUND`. That was a strict bug:
+ * the docs (and the friction log) all said "extend this, get a 404."
+ *
+ * Fix: ship a base class that extends NestJS' `NotFoundException`
+ * (an `HttpException` subclass), so the existing filter branch for
+ * `HttpException` picks it up automatically. Module authors keep
+ * their named-sentinel pattern (`class ExampleNotFoundError extends
+ * ResourceNotFoundError`) — but now the response is correctly 404.
+ */
+
+import { HttpException, NotFoundException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { CORE_ERROR_CODES } from "../../src/core/errors/error-code.js";
+import { ResourceNotFoundError } from "../../src/core/errors/resource-not-found-error.js";
+
+describe("Story · ResourceNotFoundError", () => {
+  it("is a NotFoundException (so the filter maps it to 404)", () => {
+    const err = new ResourceNotFoundError("Example", "abc-123");
+    expect(err).toBeInstanceOf(NotFoundException);
+    expect(err).toBeInstanceOf(HttpException);
+    expect(err.getStatus()).toBe(404);
+  });
+
+  it("formats a default detail with the resource name and id", () => {
+    const err = new ResourceNotFoundError("Example", "abc-123");
+    const response = err.getResponse();
+    expect(response).toMatchObject({
+      code: CORE_ERROR_CODES.NOT_FOUND,
+      message: 'Example with id "abc-123" not found',
+    });
+  });
+
+  it("accepts an explicit detail string", () => {
+    const err = new ResourceNotFoundError("Example", "abc-123", {
+      detail: "Custom message here",
+    });
+    const response = err.getResponse() as { message?: string };
+    expect(response.message).toBe("Custom message here");
+  });
+
+  it("preserves the ResourceNotFoundError name on subclasses", () => {
+    class ExampleNotFoundError extends ResourceNotFoundError {
+      constructor(id: string) {
+        super("Example", id);
+        this.name = "ExampleNotFoundError";
+      }
+    }
+    const err = new ExampleNotFoundError("xyz");
+    expect(err.name).toBe("ExampleNotFoundError");
+    expect(err).toBeInstanceOf(ResourceNotFoundError);
+    expect(err).toBeInstanceOf(NotFoundException);
+    expect(err.getStatus()).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- Friction-log finding: the global `ProblemDetailsExceptionFilter` only
  recognises `HttpException`, `ZodError`, and a few framework sentinels.
  Modules that followed the docs (`class FooNotFoundError extends Error`)
  silently produced a 500 + `CORE_INTERNAL` response — and a
  `[ProblemDetailsFilter] unhandled error` log line — instead of the
  promised 404 + `CORE_NOT_FOUND`. The slim-module reference
  (`src/modules/example/`) had the same latent bug.
- Fix: ship a canonical `ResourceNotFoundError` in `src/core/errors/`
  that extends NestJS' `NotFoundException` (an `HttpException`
  subclass). The filter's existing 404 branch picks it up automatically
  — no extension-point changes required. Module authors keep their
  named-sentinel pattern; subclasses inherit the right code/status
  without restating it.
- Refactor `ExampleNotFoundError` to extend `ResourceNotFoundError`
  so the slim reference matches what its README and the wider docs
  promise. Update `docs/code-guidelines.md`, `src/core/CLAUDE.md`,
  and `src/modules/example/README.md` to point at the new base class
  and warn against `extends Error` for HTTP-bound errors.

## Behaviour change

Before: `GET /examples/<missing-id>` returned `500 CORE_INTERNAL` with
a redacted detail and a `[ProblemDetailsFilter] unhandled error` log
line. After: it returns `404 CORE_NOT_FOUND` with detail
`Example with id "<id>" not found` and no warning log.

Backwards-compat: any consumer that hand-rolled `*Error extends Error`
keeps producing the old 500 until they migrate. They are upgraded to
strictly more correct 404 responses by extending `ResourceNotFoundError`.

## Slices

1. `feat(errors): add ResourceNotFoundError base for 404 mapping` —
   new core class, story test, two new e2e cases in
   `problem-details.e2e-spec.ts`, doc updates.
2. `refactor(example): use ResourceNotFoundError for 404 mapping` —
   `ExampleNotFoundError` extends the new base, story test pins the
   inheritance chain + HTTP status.

## Test plan

- [x] New story `tests/stories/resource-not-found-error.story.test.ts`
      passes (inheritance chain + payload shape)
- [x] `tests/problem-details.e2e-spec.ts` regression cases pass — both
      `ResourceNotFoundError` and a user-defined subclass map to 404 +
      `CORE_NOT_FOUND`
- [x] Existing `tests/stories/example-module.story.test.ts` continues
      to pass (subclass relationship preserved); new assertion pins
      `getStatus() === 404`
- [x] `bun run lint`
- [x] `bun run format`
- [x] `bun run test:types`
- [x] `bun run test:unit` (153/153)
- [x] `bun run test:e2e` (2370/2370)
- [x] `bun run build` + `bun run build:dev-portal`
- [x] `bun run test:coverage` — coverage gate still green at 90.76%
      statements (≥ 90% threshold). Three pre-existing flaky failures
      (`tests/health.e2e-spec.ts`, `tests/email-outbox-flow.e2e-spec.ts`)
      under high parallelism — both DB-shared-state contention,
      unrelated to this change; both pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)