### PR TITLE
fix(setup): probe free port + sync DATABASE_URL (LLM-test regression)

### DIFF
--- a/src/core/setup/find-free-port.ts
+++ b/src/core/setup/find-free-port.ts
@@ -2,18 +2,26 @@ import { createServer } from "node:net";
 
 /**
  * `findFreePort(start, [maxScan])` — returns the first TCP port at or
- * after `start` that the host can bind on the loopback. Used by the
- * setup wizard to pick a per-workspace Postgres host-port so two
+ * after `start` that the host can bind on the wildcard address. Used by
+ * the setup wizard to pick a per-workspace Postgres host-port so two
  * `--next` workspaces don't collide on `5432:5432`.
  *
- * - Probes synchronously by attempting `createServer().listen(port,
- *   '127.0.0.1')` and tearing it down immediately.
+ * - Probes by binding `createServer().listen(port, '0.0.0.0')` and
+ *   tearing it down immediately. The wildcard probe matters: Docker /
+ *   Compose forwards `<host>:<container>` on the wildcard address, so a
+ *   loopback-only probe (`127.0.0.1`) reports the port as free even
+ *   when `docker compose up` will later fail with `EADDRINUSE` (kernels
+ *   on Linux/macOS allow `127.0.0.1:p` to coexist with `0.0.0.0:p`).
+ *   Friction-log run `2026-05-02-18-44-43` hit exactly this regression:
+ *   another container was bound on `*:5432`, the loopback probe found
+ *   it free, the wizard wrote `POSTGRES_HOST_PORT=5432`, and the
+ *   subsequent Compose up failed.
  * - Returns `start` itself if free; otherwise scans `start+1`,
  *   `start+2`, … up to `start + maxScan` (default 100).
  * - Throws `FreePortNotFoundError` if the entire window is busy.
  *
  * Pure async function with no global side-effects beyond brief
- * loopback bind attempts.
+ * wildcard bind attempts.
  */
 
 export class FreePortNotFoundError extends Error {
@@ -32,7 +40,10 @@ export async function isPortFree(port: number): Promise<boolean> {
     server.once("listening", () => {
       server.close(() => resolve(true));
     });
-    server.listen(port, "127.0.0.1");
+    // Wildcard bind matches what `docker compose up -d` does with
+    // `${POSTGRES_HOST_PORT}:5432` — required to detect collisions
+    // against another Docker container holding `*:<port>` (see header).
+    server.listen(port, "0.0.0.0");
   });
 }
 

--- a/tests/stories/find-free-port.story.test.ts
+++ b/tests/stories/find-free-port.story.test.ts
@@ -1,0 +1,125 @@
+import { createServer, type Server } from "node:net";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  findFreePort,
+  FreePortNotFoundError,
+  isPortFree,
+} from "../../src/core/setup/find-free-port.js";
+
+/**
+ * Story · `findFreePort` must detect collisions with Docker / Compose.
+ *
+ * Background — friction-log run 2026-05-02-18-44-43:
+ *   `bun run setup` wrote `POSTGRES_HOST_PORT=5432` even though another
+ *   Docker postgres container was already bound on `0.0.0.0:5432`. Cause:
+ *   the previous fix (`deacf3c`) probed only the loopback address
+ *   (`127.0.0.1`). Docker's port forwarding binds at the wildcard, so a
+ *   loopback probe always sees the port as free even though Compose's
+ *   subsequent `5432:5432` binding will collide.
+ *
+ * Pin the contract: `isPortFree` / `findFreePort` must return false
+ * (resp. skip) for any port that another process holds on the *wildcard*
+ * binding, because that is what `docker compose up` competes with.
+ */
+describe("Story · findFreePort detects Docker-style wildcard binds", () => {
+  const servers: Server[] = [];
+
+  /**
+   * Bind a TCP server on the wildcard (`0.0.0.0`) for the duration of one
+   * test and return the chosen port. Mirrors how `docker compose up`
+   * holds the host port.
+   */
+  async function holdPortOnWildcard(): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      const server = createServer();
+      server.once("error", reject);
+      server.once("listening", () => {
+        const addr = server.address();
+        if (typeof addr === "object" && addr) {
+          servers.push(server);
+          resolve(addr.port);
+        } else {
+          reject(new Error("no address bound"));
+        }
+      });
+      // 0 = let the kernel pick a free port
+      server.listen(0, "0.0.0.0");
+    });
+  }
+
+  beforeEach(() => {
+    servers.length = 0;
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map(
+        (s) =>
+          new Promise<void>((resolve) => {
+            s.close(() => resolve());
+          }),
+      ),
+    );
+    servers.length = 0;
+  });
+
+  it("isPortFree returns false when the port is bound on 0.0.0.0 (Docker case)", async () => {
+    const occupied = await holdPortOnWildcard();
+    // Same port on the wildcard is in use; the helper must report busy
+    // even though loopback would still bind successfully (kernel allows
+    // 127.0.0.1:<p> alongside 0.0.0.0:<p> on Linux/macOS).
+    const free = await isPortFree(occupied);
+    expect(free).toBe(false);
+  });
+
+  it("findFreePort skips a wildcard-bound port and returns the next free one", async () => {
+    const start = await holdPortOnWildcard();
+    const chosen = await findFreePort(start);
+    expect(chosen).toBeGreaterThan(start);
+  });
+
+  it("findFreePort returns the start port when nothing is bound there", async () => {
+    // Pick an unlikely-to-collide range above the ephemeral floor.
+    // Bind+release to discover a port the kernel currently considers free,
+    // then ask the helper for it. (The probe is racy by nature, but a
+    // single-digit-millisecond window is enough for this assertion.)
+    const probe = createServer();
+    const port: number = await new Promise((resolve, reject) => {
+      probe.once("listening", () => {
+        const addr = probe.address();
+        if (typeof addr === "object" && addr) resolve(addr.port);
+        else reject(new Error("no address"));
+      });
+      probe.once("error", reject);
+      probe.listen(0, "0.0.0.0");
+    });
+    await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+    const chosen = await findFreePort(port);
+    expect(chosen).toBe(port);
+  });
+
+  it("FreePortNotFoundError is thrown when the entire scan window is busy", async () => {
+    // Hold a contiguous block on the wildcard so every probe fails.
+    const start = await holdPortOnWildcard();
+    // Hold 4 more directly above start. Some may already be in use,
+    // which is fine — those probe attempts will also fail and the scan
+    // window will exhaust.
+    const window = 5;
+    for (let i = 1; i < window; i++) {
+      await new Promise<void>((resolve) => {
+        const s = createServer();
+        s.once("error", () => resolve()); // ignore, already busy is fine
+        s.once("listening", () => {
+          servers.push(s);
+          resolve();
+        });
+        s.listen(start + i, "0.0.0.0");
+      });
+    }
+    // Scan only the held block; expect failure.
+    await expect(findFreePort(start, window)).rejects.toBeInstanceOf(FreePortNotFoundError);
+  });
+});

--- a/tests/stories/setup-wizard-runner.story.test.ts
+++ b/tests/stories/setup-wizard-runner.story.test.ts
@@ -187,4 +187,52 @@ describe("Story · setup-wizard runner planner", () => {
       expect(value).not.toContain("my-app");
     });
   });
+
+  describe("postgresHostPort lockstep (POSTGRES_HOST_PORT + DATABASE_URL)", () => {
+    // Friction-log run 2026-05-02-18-44-43: Compose `.env` does not
+    // expand variables, so the wizard must bake the *same* port number
+    // into both `POSTGRES_HOST_PORT` and `DATABASE_URL=…@localhost:<port>/…`.
+    // Driving them off a single value protects against future drift.
+    const example = [
+      "POSTGRES_USER=nest-base",
+      "POSTGRES_DB=nest-base",
+      "POSTGRES_PASSWORD=change-me-strong-pass",
+      "DATABASE_URL=postgresql://nest-base:change-me-strong-pass@localhost:5432/nest-base",
+      "POSTGRES_HOST_PORT=5432",
+    ].join("\n");
+
+    it("rewrites POSTGRES_HOST_PORT to the chosen free port", () => {
+      const out = planEnvFromExample(example, {
+        randomBytes: deterministicRng(),
+        postgresHostPort: 5433,
+      });
+      expect(out).toMatch(/^POSTGRES_HOST_PORT=5433$/m);
+    });
+
+    it("rewrites the port portion of DATABASE_URL in lockstep", () => {
+      const out = planEnvFromExample(example, {
+        randomBytes: deterministicRng(),
+        postgresHostPort: 5433,
+      });
+      expect(out).toMatch(/^DATABASE_URL=postgresql:\/\/[^@]+@localhost:5433\/nest-base$/m);
+    });
+
+    it("keeps both values in sync after a project-name rewrite", () => {
+      const out = planEnvFromExample(example, {
+        randomBytes: deterministicRng(),
+        projectName: "my-app",
+        postgresHostPort: 5544,
+      });
+      expect(out).toMatch(/^POSTGRES_HOST_PORT=5544$/m);
+      expect(out).toMatch(/^DATABASE_URL=postgresql:\/\/my-app:[^@]+@localhost:5544\/my-app$/m);
+    });
+
+    it("leaves both values at 5432 when no override is provided (test fixtures)", () => {
+      const out = planEnvFromExample(example, {
+        randomBytes: deterministicRng(),
+      });
+      expect(out).toMatch(/^POSTGRES_HOST_PORT=5432$/m);
+      expect(out).toContain("@localhost:5432/nest-base");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
LLM-test (run 2026-05-02-18-44-43) found `bun run setup` still writes
`POSTGRES_HOST_PORT=5432` + `DATABASE_URL=...:5432/...` even when 5432
is bound by another Docker container. This is a regression of `deacf3c`
("fix(setup): close env-precedence leak + per-workspace Postgres port").

## What changed
- **Root cause:** `findFreePort()` bound on `127.0.0.1`, but Docker /
  Compose forwards `<host>:<container>` on the wildcard. Linux/macOS
  allow `127.0.0.1:p` to coexist with `0.0.0.0:p`, so a loopback probe
  always sees the port as free even when `docker compose up` will fail.
- **Fix:** `src/core/setup/find-free-port.ts` now probes `0.0.0.0` so
  the bind attempt competes with the same address Compose uses.
- **Lockstep update:** The `POSTGRES_HOST_PORT` + `DATABASE_URL` lockstep
  rewrite was already in place from `deacf3c` — it just never triggered
  because the input port never moved off 5432. Added regression tests in
  `setup-wizard-runner.story.test.ts` to pin the contract.
- **New story:** `tests/stories/find-free-port.story.test.ts` covers the
  wildcard-probe contract, happy path, and exhaustion case.

## Test plan
- [x] `bun run lint` clean
- [x] `bun run format` clean
- [x] `bun run test:types` clean
- [x] `bun run test:unit` 153/153 passing
- [x] `bun run test:e2e` 2371/2371 passing
- [x] `bun run test:coverage` 91.06% statements (`src/core/setup/find-free-port.ts` 100%)
- [x] `bun run build` clean
- [x] Manual smoke: occupy 5432 + 5433 (Docker), `bun run setup`,
      verified `.env` shows `POSTGRES_HOST_PORT=5434` and
      `DATABASE_URL=…@localhost:5434/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)