### PR TITLE
feat(permissions): @Public() decorator + route-gating policy (prep for #47)

### DIFF
--- a/.claude/skills/wiring-permissions.md
+++ b/.claude/skills/wiring-permissions.md
@@ -4,6 +4,89 @@ How permissions flow through the request, from authenticated user to
 gated handler to filtered response. Reference for when you're adding
 or debugging an `@Can()` decorator.
 
+## Decision flow — gate, public, or allowlist?
+
+Before writing the route body, decide which the handler is. The
+project rule (see "Route gating policy" in
+[`CLAUDE.md`](../../CLAUDE.md)) is: every controller method is exactly
+one of these three. A handler that is none of them is a bug — Issue
+#47 will add a CI check that fails on this.
+
+```
+new route?
+  ├── touches user/tenant data, mutates state, or reads anything
+  │   permission-shaped
+  │     → @Can(action, subject)        ← default. pick existing subject.
+  ├── intentionally callable without auth (health, OAS, error
+  │   catalogue, anonymous webhook with own HMAC verification)
+  │     → @Public("<one-sentence reason>")
+  └── part of a subsystem-wide pattern (`/health/*`, `/api/auth/*`,
+      `/dev/*`, `/me/*`) where every route in the subtree is public
+        → path-allowlist in `src/core/auth/jwt-middleware.ts`
+          (`PUBLIC_PREFIXES` / `PUBLIC_EXACT`) and/or
+          `src/core/multi-tenancy/tenant-guard.ts` (`EXEMPT_*`)
+```
+
+If you cannot decide between `@Can()` and `@Public()`: stop, default
+to `@Can()`. Never delete an `@Can()` "to fix a 403" — fix the policy
+or storage adapter instead.
+
+### When `@Public()` is appropriate
+
+A short checklist. If your route is none of these, it probably wants
+`@Can()`:
+
+- Health / readiness probes consumed by an orchestrator
+- OAS / SDK-discovery catalogues meant to be fetched anonymously
+  (e.g. `/errors`, the public OpenAPI doc)
+- Anonymous webhooks that bring their own HMAC / signature verification
+  (the gate is the signature, not CASL)
+- Marketing / docs landing pages served from the same NestJS app
+
+`@Public()` requires a non-empty reason string — write *why*, not
+*what*:
+
+```typescript
+import { Public } from "../../core/permissions/public.decorator.js";
+
+@Get("/health")
+@Public("k8s readiness probe — must answer without auth")
+health(): { ok: true } {
+  return { ok: true };
+}
+```
+
+### Migrating an existing ungated route
+
+Two options when an audit (or `/dev/routes`) flags a handler as
+`unguarded`:
+
+```diff
+ // Option A — gate it (default)
++import { Can } from "../../core/permissions/can.guard.js";
+
+ @Get()
++@Can("read", "Project")
+ list(@Req() req: AuthedRequest) {
+   return this.service.list(req.user.tenantId);
+ }
+```
+
+```diff
+ // Option B — declare it intentionally public
++import { Public } from "../../core/permissions/public.decorator.js";
+
+ @Get("/openapi")
++@Public("public OpenAPI catalogue consumed by SDK generators")
+ openapi(): OpenAPIObject {
+   return this.builder.build();
+ }
+```
+
+Always commit both changes — the metadata-bearing decorator AND a
+test that asserts the metadata is in place (see "Testing permission
+rules" below). Don't lean on grep.
+
 ## The model
 
 See [`docs/architecture.md`](../../docs/architecture.md) "Permission
@@ -73,6 +156,10 @@ async list(@Req() req: AuthedRequest) {
 For mutating endpoints, the gate **must** fire before the service runs
 — don't lean on the pipeline to deny a write retroactively.
 
+Note: under the route-gating policy, "no `@Can()`" still requires
+either `@Public()` or a path-allowlist match — the Output-Pipeline
+filter is defence in depth, not a substitute for the consent token.
+
 ## The CASL conditions wire to record fields
 
 When you persist a permission like:
@@ -122,6 +209,22 @@ it("a viewer ability rejects create", () => {
 });
 ```
 
+For `@Public()`-decorated handlers the equivalent assertion uses
+`PUBLIC_ROUTE_METADATA_KEY` from `public.decorator.js`:
+
+```typescript
+import {
+  PUBLIC_ROUTE_METADATA_KEY,
+  isPublicRoute,
+} from "../../src/core/permissions/public.decorator.js";
+
+it("GET /health is explicitly public with a reason", () => {
+  const meta = Reflect.getMetadata(PUBLIC_ROUTE_METADATA_KEY, HealthController.prototype.health);
+  expect(isPublicRoute(meta)).toBe(true);
+  expect(meta.reason).toMatch(/probe/);
+});
+```
+
 E2E-level — run the request with a fixture user that has the right /
 wrong policies:
 
@@ -159,6 +262,8 @@ admin tooling.
   builder strips `fields: []` before passing to CASL. Don't pass
   `fields: []` and expect "deny all fields" — that's the open
   question above.
+- **`@Public("")` is a bug**: the decorator throws at decoration time
+  if the reason is empty / whitespace. Write the *why*, not the *what*.
 
 ## Don't reinvent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,47 @@ For the user, the slash command [`/add-feature <key> "<description>"`](./.claude
 - **Realtime** — `src/core/realtime/`
 - **MCP** — `src/core/mcp/`
 
+## Route gating policy — every route is gated or @Public()
+
+Every HTTP-handler method on a controller in `src/core/**` and
+`src/modules/**` MUST be one of:
+
+1. **Gated** with `@Can(action, subject)` — the default. The handler
+   runs only if `CanGuard` resolves a CASL ability that allows the
+   action on the subject for the request's `(userId, tenantId)`.
+
+2. **Explicitly public** with `@Public("<one-sentence reason>")` —
+   the route is intentionally callable without auth or permissions
+   (health checks, SDK-discovery endpoints, public catalogues like
+   `/errors`). The reason string is required and shows up in the
+   route audit (Issue #47).
+
+3. **Path-allowlisted** in `src/core/auth/jwt-middleware.ts`
+   `PUBLIC_PREFIXES`/`PUBLIC_EXACT` and/or
+   `src/core/multi-tenancy/tenant-guard.ts` `EXEMPT_*` — for
+   subsystem-wide patterns (`/health/*`, `/api/auth/*`, `/dev/*`,
+   `/me/*`). Adding a path here is a deliberate cross-cutting
+   decision; prefer `@Public()` for individual routes.
+
+**No fourth option.** A handler with neither `@Can()` nor `@Public()`
+nor a matching allowlist entry is a bug — Issue #47 introduces a
+build-time gate that fails CI on this.
+
+When porting a route or adding a new one:
+
+- If you can't decide between `@Can()` and `@Public()`, default to
+  `@Can()` and stop. Pick a CASL subject that already exists or talk
+  to the architecture before inventing a new one.
+- Never delete `@Can()` "to fix a 403" — fix the policy or the
+  storage adapter, not the gate.
+- `@Public()` without a reason is a lint error. Don't write
+  `@Public("")` or `@Public("public")` — explain *why* ("public OAS
+  catalogue for SDK consumers", "health probe for k8s", etc.).
+
+The decorator lives at `src/core/permissions/public.decorator.ts`.
+The skill [`wiring-permissions`](./.claude/skills/wiring-permissions.md)
+has the decision flow + worked examples.
+
 ## Quality bar
 
 - Bun-only commands; never shell out to `node`/`npm` from scripts

--- a/src/core/permissions/public.decorator.ts
+++ b/src/core/permissions/public.decorator.ts
@@ -1,0 +1,56 @@
+import { SetMetadata } from "@nestjs/common";
+
+/**
+ * `@Public()` — explicit consent that an HTTP handler does not need
+ * permission gating.
+ *
+ * Use sparingly. The default for every controller route is `@Can(action,
+ * subject)`; the only acceptable alternatives are `@Public()` (with a
+ * comment / reason explaining why) or having the path on the auth-
+ * middleware / tenant-guard public allowlist (e.g. `/health/*`,
+ * `/api/auth/*`, `/me/*`, `/dev/*`). Anything else is a bug — see
+ * Issue #47 for the audit + CI gate.
+ *
+ * The decorator only sets metadata (`is_public_route: true`) — runtime
+ * gating remains enforced by the existing middleware + `CanGuard`.
+ * Future Issue #47 introduces a build-time check that asserts every
+ * controller method is either `@Can()`, `@Public()`, or path-allowlisted.
+ *
+ * The required `reason` argument is the consent forced at the
+ * decoration site. An agent or human writing `@Public()` MUST explain
+ * why ("health probe for k8s", "public OAS catalogue for SDK consumers",
+ * etc.). The audit gate will surface these reasons in its report.
+ */
+
+export const PUBLIC_ROUTE_METADATA_KEY = "is_public_route";
+
+export interface PublicRouteMetadata {
+  isPublic: true;
+  reason: string;
+}
+
+export const Public = (reason: string): MethodDecorator & ClassDecorator => {
+  if (!reason || reason.trim().length === 0) {
+    throw new Error("@Public() requires a non-empty reason string");
+  }
+  return SetMetadata(PUBLIC_ROUTE_METADATA_KEY, {
+    isPublic: true,
+    reason,
+  } satisfies PublicRouteMetadata);
+};
+
+/**
+ * Type-guard that recognises the `@Public()` metadata shape. Used by
+ * the future audit / CI gate (Issue #47) to assert that every
+ * controller handler is either `@Can()`-gated or carries explicit
+ * `@Public()` consent. Stays defensive — only the literal boolean
+ * `true` qualifies, so a stray JSON-roundtripped value cannot pose as
+ * consent.
+ */
+export function isPublicRoute(metadata: unknown): metadata is PublicRouteMetadata {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    (metadata as { isPublic?: unknown }).isPublic === true
+  );
+}

--- a/tests/stories/public-decorator.story.test.ts
+++ b/tests/stories/public-decorator.story.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PUBLIC_ROUTE_METADATA_KEY,
+  Public,
+  isPublicRoute,
+  type PublicRouteMetadata,
+} from "../../src/core/permissions/public.decorator.js";
+
+/**
+ * Story · `@Public()` decorator (route-gating guardrail, prep for #47).
+ *
+ * The decorator is metadata-only — it does NOT change runtime gating.
+ * The existing path-based public allowlists (`jwt-middleware.ts`,
+ * `tenant-guard.ts`) keep their behaviour. `@Public()` is the explicit
+ * consent token an audit / CI gate (Issue #47) will read.
+ *
+ * Two invariants this story pins:
+ *   1. The metadata shape is stable (`{ isPublic: true, reason }`) and
+ *      keyed under `PUBLIC_ROUTE_METADATA_KEY` so future tooling can
+ *      Reflect.getMetadata() it without re-importing the decorator.
+ *   2. `reason` is required and non-empty — that's the consent forced
+ *      at the decoration site. An agent that writes `@Public()` has to
+ *      explain why.
+ */
+describe("Story · @Public() decorator (route-gating guardrail)", () => {
+  it("exports a stable metadata key", () => {
+    // Stable string key — future Reflect.getMetadata() callers (CI
+    // gate in #47) MUST be able to depend on this without importing
+    // the decorator at runtime.
+    expect(PUBLIC_ROUTE_METADATA_KEY).toBe("is_public_route");
+  });
+
+  it("attaches { isPublic: true, reason } metadata when applied to a method", () => {
+    class Controller {
+      @Public("health probe for k8s")
+      health(): string {
+        return "ok";
+      }
+    }
+
+    const meta = Reflect.getMetadata(
+      PUBLIC_ROUTE_METADATA_KEY,
+      Controller.prototype.health,
+    ) as PublicRouteMetadata;
+    expect(meta).toEqual({ isPublic: true, reason: "health probe for k8s" });
+  });
+
+  it("attaches metadata when applied to a class (controller-level)", () => {
+    @Public("public OAS catalogue for SDK consumers")
+    class Controller {}
+
+    const meta = Reflect.getMetadata(PUBLIC_ROUTE_METADATA_KEY, Controller) as PublicRouteMetadata;
+    expect(meta).toEqual({ isPublic: true, reason: "public OAS catalogue for SDK consumers" });
+  });
+
+  it("throws when the reason is an empty string", () => {
+    expect(() => Public("")).toThrow(/reason/);
+  });
+
+  it("throws when the reason is whitespace-only", () => {
+    expect(() => Public("   ")).toThrow(/reason/);
+  });
+
+  describe("isPublicRoute()", () => {
+    it("returns true for the canonical metadata shape", () => {
+      expect(isPublicRoute({ isPublic: true, reason: "x" })).toBe(true);
+    });
+
+    it("returns false for undefined / null", () => {
+      expect(isPublicRoute(undefined)).toBe(false);
+      expect(isPublicRoute(null)).toBe(false);
+    });
+
+    it("returns false for objects without isPublic === true", () => {
+      expect(isPublicRoute({})).toBe(false);
+      expect(isPublicRoute({ isPublic: false, reason: "x" })).toBe(false);
+      // String "true" is not the literal boolean — guard rejects it so
+      // a stray JSON-roundtripped value cannot pose as consent.
+      expect(isPublicRoute({ isPublic: "true", reason: "x" })).toBe(false);
+    });
+
+    it("returns false for primitives", () => {
+      expect(isPublicRoute("public")).toBe(false);
+      expect(isPublicRoute(42)).toBe(false);
+      expect(isPublicRoute(true)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Lands the guardrails so AI agents (and humans) cannot ship unguarded
routes by accident:

- `@Public("<reason>")` decorator at `src/core/permissions/public.decorator.ts` —
  required-reason argument forces explicit consent at the route site
- Project-level `CLAUDE.md` "Route gating policy" — every route is gated,
  `@Public()`, or path-allowlisted; no fourth option
- Skill update `.claude/skills/wiring-permissions.md` — decision flow +
  when `@Public()` is appropriate + migration diff + test recipe

## Not in this PR

- Audit of existing controllers / fixes for ungated routes (Issue #47)
- Build-time CI gate that asserts the rule (Issue #47 Phase 3)

This PR ships the prerequisites those rely on (the decorator + the
documented policy). Issue #47 then enforces it across all controllers
and adds the CI check.

## Test plan
- [x] Story test for the decorator: metadata shape, reason required, type-guard
- [x] All quality gates pass locally: lint, format, test:types, test:unit, build:dev-portal, test:e2e (2580/2580), test:coverage (`public.decorator.ts` 100% on lines/functions/statements/branches; `core/permissions` 94.39% / 96.29% lines stays above the 90% gate), build
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)