### PR TITLE
test(infra): NODE_ENV leak guard + fake-prisma extensibility

### DIFF
--- a/src/core/permissions/test-ability.middleware.ts
+++ b/src/core/permissions/test-ability.middleware.ts
@@ -2,7 +2,7 @@ import { Injectable, type NestMiddleware } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 
 import type { Ability } from "./casl-ability.js";
-import { parseTestAbilityHeader } from "./test-ability.js";
+import { parseTestAbilityHeaderForRequest } from "./test-ability.js";
 
 interface AbilityRequest extends Request {
   ability?: Ability;
@@ -25,7 +25,10 @@ interface AbilityRequest extends Request {
 export class TestAbilityMiddleware implements NestMiddleware {
   use(req: AbilityRequest, _res: Response, next: NextFunction): void {
     const header = req.headers["x-test-ability"];
-    const ability = parseTestAbilityHeader(header, process.env.NODE_ENV ?? "");
+    // Uses the cached `NODE_ENV` captured at module load.
+    // Runtime mutations from individual specs cannot disable the hatch
+    // for the rest of the worker — see test-ability.ts for the rationale.
+    const ability = parseTestAbilityHeaderForRequest(header);
     if (ability) {
       req.ability = ability;
     }

--- a/src/core/permissions/test-ability.ts
+++ b/src/core/permissions/test-ability.ts
@@ -60,3 +60,38 @@ function isAbilityRule(value: unknown): value is AbilityRule {
   if (typeof r.subject !== "string" && !Array.isArray(r.subject)) return false;
   return true;
 }
+
+/**
+ * `NODE_ENV` snapshot captured at module-load time.
+ *
+ * Specs occasionally flip `process.env.NODE_ENV` mid-suite to test
+ * production / development behaviour. When such a spec fails before
+ * its `afterAll` reset runs, `NODE_ENV` leaks to every subsequent
+ * spec in the same Vitest worker — and the test-ability hatch
+ * silently disables itself for the rest of the run, 403'ing every
+ * downstream spec that pre-seeds an ability.
+ *
+ * Caching here means the runtime middleware decision uses the value
+ * that was set at import time (which is `"test"` because Vitest's
+ * globalSetup runs before any module loads). Runtime mutations of
+ * `process.env.NODE_ENV` do NOT change `MODULE_LOAD_NODE_ENV`, so
+ * the hatch survives leaked env state.
+ *
+ * Note: production safety is unaffected. In a real production runtime
+ * this module loads with `NODE_ENV=production`, so the cached value
+ * is `"production"` and the hatch stays a strict no-op forever.
+ */
+const MODULE_LOAD_NODE_ENV = process.env.NODE_ENV ?? "";
+
+/**
+ * Middleware-facing variant that uses the cached `NODE_ENV`.
+ *
+ * Equivalent to `parseTestAbilityHeader(rawHeader, MODULE_LOAD_NODE_ENV)`,
+ * but exposed as its own export so the call site can't accidentally
+ * pass a runtime-mutated value.
+ */
+export function parseTestAbilityHeaderForRequest(
+  rawHeader: string | string[] | undefined,
+): Ability | null {
+  return parseTestAbilityHeader(rawHeader, MODULE_LOAD_NODE_ENV);
+}

--- a/tests/admin-realtime-inspector.e2e-spec.ts
+++ b/tests/admin-realtime-inspector.e2e-spec.ts
@@ -19,15 +19,21 @@ const TENANT = "11111111-1111-1111-1111-111111111111";
 describe("Admin Realtime Inspector · /admin/realtime*", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      // Capture the prior value so `afterAll` restores it even when
+      // the worker started under a non-default env. Blind resets to
+      // "test" hide the original leak.
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /admin/realtime.json returns sockets + channels + events arrays", async () => {
@@ -129,15 +135,18 @@ describe("Admin Realtime Inspector · /admin/realtime*", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /admin/realtime/channels.json 404s in production", async () => {

--- a/tests/admin-ui.e2e-spec.ts
+++ b/tests/admin-ui.e2e-spec.ts
@@ -69,15 +69,18 @@ const JSON_ENDPOINTS: Array<{ url: string; assert: (body: unknown) => void }> = 
 describe("Admin SPA · /admin/* shell + JSON sidecars", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     for (const page of SPA_PAGES) {
@@ -119,15 +122,18 @@ describe("Admin SPA · /admin/* shell + JSON sidecars", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /admin/permissions/test 404s in production", async () => {

--- a/tests/brand-config.e2e-spec.ts
+++ b/tests/brand-config.e2e-spec.ts
@@ -22,14 +22,18 @@ const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {
  */
 describe("Brand-Config · runtime surfaces", () => {
   let app: INestApplication;
+  let previousNodeEnv: string | undefined;
 
   beforeAll(async () => {
+    previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
   });
 
   afterAll(async () => {
     await app.close();
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
   });
 
   describe("/dev/brand.json", () => {

--- a/tests/dev-hub-tunnel.e2e-spec.ts
+++ b/tests/dev-hub-tunnel.e2e-spec.ts
@@ -21,14 +21,18 @@ const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {
  */
 describe("Dev-Hub · GET /dev/tunnel.json", () => {
   let app: INestApplication;
+  let previousNodeEnv: string | undefined;
 
   beforeAll(async () => {
+    previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
   });
 
   afterAll(async () => {
     await app.close();
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
   });
 
   afterEach(() => {
@@ -79,11 +83,13 @@ describe("Dev-Hub · GET /dev/tunnel.json", () => {
 
 describe("Dev-Hub · GET /dev/tunnel.json — production gate", () => {
   let app: INestApplication;
+  let previousNodeEnv: string | undefined;
 
   beforeAll(async () => {
     // Provide the env vars production bootstrap requires so the env
     // pre-check passes; we only care that the controller short-circuits
     // production traffic to a 404.
+    previousNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "production";
     process.env.APP_BASE_URL = "https://example.com";
     process.env.SECRET_KEK_HEX = "0".repeat(64);
@@ -98,6 +104,8 @@ describe("Dev-Hub · GET /dev/tunnel.json — production gate", () => {
     delete process.env.SECRET_KEK_HEX;
     delete process.env.SECRET_HMAC_HEX;
     delete process.env.BETTER_AUTH_SECRET;
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
   });
 
   it("404s in production even when the state file exists", async () => {

--- a/tests/dev-hub.e2e-spec.ts
+++ b/tests/dev-hub.e2e-spec.ts
@@ -17,14 +17,18 @@ const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {
 describe("Dev-Hub · GET /dev", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("returns an HTML response", async () => {
@@ -252,15 +256,18 @@ describe("Dev-Hub · GET /dev", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("returns 404 outside development", async () => {

--- a/tests/email-builder.e2e-spec.ts
+++ b/tests/email-builder.e2e-spec.ts
@@ -24,16 +24,20 @@ const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {
 describe("Dev-Hub · /dev/email-builder", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
     const repoRoot = process.cwd();
     const cleanupSlugs = ["e2e-builder-test", "e2e-builder-traversal"];
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     beforeEach(() => {
@@ -205,15 +209,18 @@ describe("Dev-Hub · /dev/email-builder", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /dev/email-builder/templates.json returns 404", async () => {

--- a/tests/file-manager-dev-hub.e2e-spec.ts
+++ b/tests/file-manager-dev-hub.e2e-spec.ts
@@ -25,8 +25,10 @@ describe("Dev-Hub File-Manager · /dev/files*", () => {
     let app: INestApplication;
     let prisma: PrismaService;
     let tenantId: string;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
       prisma = app.get(PrismaService);
@@ -45,7 +47,8 @@ describe("Dev-Hub File-Manager · /dev/files*", () => {
         // best-effort
       }
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /dev/files returns the SPA shell HTML", async () => {
@@ -234,15 +237,18 @@ describe("Dev-Hub File-Manager · /dev/files*", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /dev/files/tree.json 404s in production", async () => {

--- a/tests/jobs-dashboard.e2e-spec.ts
+++ b/tests/jobs-dashboard.e2e-spec.ts
@@ -22,8 +22,10 @@ describe("Dev Jobs Dashboard · /dev/jobs/*", () => {
   describe("in development mode", () => {
     let app: INestApplication;
     let queue: JobQueueService;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
       queue = app.get(JobQueueService);
@@ -31,6 +33,8 @@ describe("Dev Jobs Dashboard · /dev/jobs/*", () => {
 
     afterAll(async () => {
       await app.close();
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     beforeEach(async () => {
@@ -162,15 +166,18 @@ describe("Dev Jobs Dashboard · /dev/jobs/*", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("404s on /dev/jobs/queues.json", async () => {

--- a/tests/lib/fake-prisma.ts
+++ b/tests/lib/fake-prisma.ts
@@ -23,6 +23,17 @@
  * The helper is intentionally narrow. It doesn't try to be Prisma
  * — it's the smallest contract that lets the service code run
  * unmodified against in-memory data.
+ *
+ * Extensibility — Proxy auto-table:
+ *
+ * Project-owned `src/modules/<x>/` resources need to story-test their
+ * services without force-editing this template-owned file (that would
+ * make every upstream sync a hot-spot). The fake is therefore wrapped
+ * in a `Proxy` that lazily creates a `TableMock` the first time a
+ * spec accesses a previously-unknown property. Calls like
+ * `fake.todo.create(...)` work without registration. The `example`
+ * and `userProfile` mocks remain pre-seeded for backwards
+ * compatibility with existing story tests.
  */
 
 import type { PrismaService } from "../../src/core/prisma/prisma.service.js";
@@ -138,27 +149,89 @@ export interface FakePrismaService {
   runWithRlsTenant<T>(fn: (tx: FakePrismaService) => Promise<T>, tenantId?: string): Promise<T>;
   /** Test-only: clear every table. */
   __resetAll(): void;
+  /** Index access for project-owned tables (Proxy-backed). */
+  [key: string]: unknown;
 }
 
+/**
+ * Reserved property names the Proxy must NOT route to a `TableMock`.
+ * These are the methods / hooks the fake itself exposes — accessing
+ * `fake.runWithRlsTenant` should hit the real function, not a
+ * dynamically-created table mock.
+ */
+const RESERVED_KEYS = new Set<string | symbol>([
+  "runWithRlsTenant",
+  "__resetAll",
+  // Internal slot used by the Proxy to enumerate dynamic tables
+  // when wiping state via `__resetAll`.
+  "__tables__",
+  // Symbols / inspection-time hooks Node, Vitest, and `expect()` use
+  // to introspect the object. Routing these to a table mock confuses
+  // assertion libraries.
+  "then",
+  "catch",
+  "finally",
+  Symbol.toPrimitive,
+  Symbol.iterator,
+  Symbol.asyncIterator,
+]);
+
 export function createFakePrisma(): FakePrismaService {
-  const example = makeTable();
-  const userProfile = makeTable();
-  const fake: FakePrismaService = {
-    example,
-    userProfile,
+  // Backing store: every accessed table name maps to a single TableMock
+  // instance. Stable identity is important — service code that holds
+  // a reference between calls must see the same map.
+  const tables = new Map<string, TableMock<Row>>();
+
+  const ensureTable = (name: string): TableMock<Row> => {
+    let table = tables.get(name);
+    if (!table) {
+      table = makeTable();
+      tables.set(name, table);
+    }
+    return table;
+  };
+
+  // Pre-seed the two template-shipped tables so existing story tests
+  // get the same instance on every access (no surprise re-creation
+  // when a third party also accesses them).
+  ensureTable("example");
+  ensureTable("userProfile");
+
+  const base: Pick<FakePrismaService, "runWithRlsTenant" | "__resetAll"> & {
+    __tables__: Map<string, TableMock<Row>>;
+  } = {
     async runWithRlsTenant(fn) {
       // RLS enforcement is mimicked by the service code (which always
       // passes `tenantId` in the `where` clause). The fake just calls
       // the callback with itself as the tx — same surface as the real
       // Prisma transaction client.
-      return fn(fake);
+      return fn(proxy);
     },
     __resetAll() {
-      example.__reset();
-      userProfile.__reset();
+      for (const table of tables.values()) table.__reset();
     },
+    __tables__: tables,
   };
-  return fake;
+
+  const proxy = new Proxy(base, {
+    get(target, prop) {
+      if (RESERVED_KEYS.has(prop)) {
+        return Reflect.get(target, prop);
+      }
+      if (typeof prop !== "string") {
+        return Reflect.get(target, prop);
+      }
+      return ensureTable(prop);
+    },
+    has(target, prop) {
+      if (RESERVED_KEYS.has(prop)) return Reflect.has(target, prop);
+      if (typeof prop !== "string") return Reflect.has(target, prop);
+      // Always true: any property name maps to a (possibly future) table.
+      return true;
+    },
+  }) as unknown as FakePrismaService;
+
+  return proxy;
 }
 
 /**

--- a/tests/lib/with-node-env.ts
+++ b/tests/lib/with-node-env.ts
@@ -1,0 +1,64 @@
+/**
+ * Sanctioned wrapper for `process.env.NODE_ENV` mutations inside specs.
+ *
+ * Why this helper exists:
+ *
+ * Several e2e specs flip `NODE_ENV` mid-suite to test production /
+ * development behaviour. They reset in `afterAll`, but if the spec
+ * fails BEFORE the reset runs, `NODE_ENV` leaks to every spec that
+ * runs after it in the same Vitest worker. Concretely, when a spec
+ * leaves `NODE_ENV=development`, `parseTestAbilityHeader` early-returns
+ * for the rest of the worker — and every subsequent test that relies
+ * on the `X-Test-Ability` hatch silently 403s.
+ *
+ * `withNodeEnv(value, fn)` always restores the previous value via
+ * `try/finally`, so a thrown assertion inside `fn` no longer poisons
+ * the worker. The companion runtime-side defence is in
+ * `src/core/permissions/test-ability.ts`, which caches `NODE_ENV`
+ * once at module load.
+ *
+ * Usage:
+ *
+ * ```ts
+ * await withNodeEnv("development", async () => {
+ *   const app = await bootstrap({ listen: false });
+ *   const res = await request(app.getHttpServer()).get("/dev-only");
+ *   expect(res.status).toBe(200);
+ * });
+ * ```
+ */
+export async function withNodeEnv<T>(value: string, fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.NODE_ENV;
+  process.env.NODE_ENV = value;
+  try {
+    return await fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previous;
+    }
+  }
+}
+
+/**
+ * Synchronous variant for hot loops that absolutely cannot await.
+ *
+ * Prefer the async `withNodeEnv` whenever possible — most call sites
+ * already live inside an `async` test. Reach for this helper only
+ * when wrapping pure synchronous code (e.g. directly invoking a
+ * planner that reads `process.env.NODE_ENV`).
+ */
+export function withNodeEnvSync<T>(value: string, fn: () => T): T {
+  const previous = process.env.NODE_ENV;
+  process.env.NODE_ENV = value;
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previous;
+    }
+  }
+}

--- a/tests/migrations-page.e2e-spec.ts
+++ b/tests/migrations-page.e2e-spec.ts
@@ -22,14 +22,18 @@ const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {
 describe("Dev-Hub · /dev/migrations", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /dev/migrations serves the SPA shell with the correct title", async () => {
@@ -123,15 +127,18 @@ describe("Dev-Hub · /dev/migrations", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /dev/migrations returns 404 in production", async () => {

--- a/tests/stories/fake-prisma.story.test.ts
+++ b/tests/stories/fake-prisma.story.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { createFakePrisma, type FakePrismaService } from "../lib/fake-prisma.js";
+
+/**
+ * Story · `createFakePrisma` extensibility.
+ *
+ * The fake PrismaService is a template-owned helper (`tests/lib/`).
+ * Originally it hardcoded the table mocks the template ships with
+ * (`example`, `userProfile`), which meant every `src/modules/<x>/`
+ * resource that wanted a story test had to force-edit the template
+ * file — a hot-spot in every upstream sync.
+ *
+ * The Proxy variant lets specs reach for any table name on the fake
+ * (`fake.todo`, `fake.invoice`, `fake.whatever`) and get back a
+ * working `TableMock` without touching `tests/lib/fake-prisma.ts`.
+ *
+ * Backwards compatibility is non-negotiable: the existing two table
+ * mocks (`example`, `userProfile`) must keep behaving exactly as
+ * before, including the shared `__resetAll()` reset.
+ */
+describe("Story · createFakePrisma (extensible Proxy)", () => {
+  let fake: FakePrismaService;
+
+  beforeEach(() => {
+    fake = createFakePrisma();
+  });
+
+  it("auto-creates a TableMock for an unknown table name on first access", async () => {
+    // No registration step — the spec just uses the table.
+    const dynamic = fake as unknown as Record<
+      string,
+      ReturnType<typeof createFakePrisma>["example"]
+    >;
+
+    const created = await dynamic.todo.create({
+      data: { id: "todo-1", title: "Buy milk" } as never,
+    });
+    expect(created).toMatchObject({ id: "todo-1", title: "Buy milk" });
+    expect(created.createdAt).toBeInstanceOf(Date);
+    expect(created.updatedAt).toBeInstanceOf(Date);
+
+    const found = await dynamic.todo.findUnique({ where: { id: "todo-1" } as never });
+    expect(found).toMatchObject({ id: "todo-1", title: "Buy milk" });
+  });
+
+  it("returns the same TableMock instance for repeated accesses (stable identity)", () => {
+    const dynamic = fake as unknown as Record<string, unknown>;
+    const first = dynamic.todo;
+    const second = dynamic.todo;
+    expect(first).toBe(second);
+  });
+
+  it("preserves the existing `example` and `userProfile` table mocks (BC)", async () => {
+    const example = await fake.example.create({
+      data: { id: "ex-1", name: "Example" } as never,
+    });
+    expect(example).toMatchObject({ id: "ex-1", name: "Example" });
+
+    const profile = await fake.userProfile.create({
+      data: { id: "u-1", displayName: "Pat" } as never,
+    });
+    expect(profile).toMatchObject({ id: "u-1", displayName: "Pat" });
+
+    expect(await fake.example.findMany()).toHaveLength(1);
+    expect(await fake.userProfile.findMany()).toHaveLength(1);
+  });
+
+  it("__resetAll clears every dynamically-accessed table too", async () => {
+    const dynamic = fake as unknown as Record<
+      string,
+      ReturnType<typeof createFakePrisma>["example"]
+    >;
+    await dynamic.invoice.create({ data: { id: "inv-1" } as never });
+    await fake.example.create({ data: { id: "ex-1" } as never });
+
+    fake.__resetAll();
+
+    expect(await dynamic.invoice.findMany()).toEqual([]);
+    expect(await fake.example.findMany()).toEqual([]);
+  });
+
+  it("runWithRlsTenant still passes the same fake as the tx", async () => {
+    const dynamic = fake as unknown as Record<
+      string,
+      ReturnType<typeof createFakePrisma>["example"]
+    >;
+    const result = await fake.runWithRlsTenant(async (tx) => {
+      // The tx exposes the same Proxy surface as the outer fake.
+      const txDynamic = tx as unknown as Record<
+        string,
+        ReturnType<typeof createFakePrisma>["example"]
+      >;
+      await txDynamic.todo.create({ data: { id: "todo-tx-1", note: "from tx" } as never });
+      return txDynamic.todo.findMany();
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "todo-tx-1", note: "from tx" });
+
+    // Outer access reads the same backing store (tx returns `fake` itself).
+    const outer = await dynamic.todo.findMany();
+    expect(outer).toHaveLength(1);
+  });
+});

--- a/tests/stories/test-ability.story.test.ts
+++ b/tests/stories/test-ability.story.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { parseTestAbilityHeader } from "../../src/core/permissions/test-ability.js";
+import {
+  parseTestAbilityHeader,
+  parseTestAbilityHeaderForRequest,
+} from "../../src/core/permissions/test-ability.js";
 
 /**
  * Story · Test-Ability helper.
@@ -61,5 +64,47 @@ describe("Story · parseTestAbilityHeader", () => {
     const ability = parseTestAbilityHeader(["full", "ignored-second"], "test");
     expect(ability).not.toBeNull();
     expect(ability!.can("read", "Anything")).toBe(true);
+  });
+});
+
+/**
+ * Story · `parseTestAbilityHeaderForRequest` (cached-env variant).
+ *
+ * The middleware-facing entry point reads `NODE_ENV` exactly once,
+ * at module load time (when the test runner bootstraps and globalSetup
+ * has already set `NODE_ENV=test`). Subsequent runtime mutations of
+ * `process.env.NODE_ENV` from individual specs do NOT change the
+ * cached value, so a spec that flips to "development" / "production"
+ * mid-suite can never silently disable the test-ability hatch for
+ * the next spec in the same worker.
+ *
+ * Out-of-band guarantee: even if a previous spec failed before its
+ * `afterAll` reset, the test-ability hatch keeps working because
+ * the env was captured at module load.
+ */
+describe("Story · parseTestAbilityHeaderForRequest (cached env)", () => {
+  it("honours the header even after process.env.NODE_ENV is mutated mid-suite", () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const ability = parseTestAbilityHeaderForRequest("full");
+      expect(ability).not.toBeNull();
+      expect(ability!.can("manage", "all")).toBe(true);
+    } finally {
+      process.env.NODE_ENV = previous;
+    }
+  });
+
+  it("returns null when the header is missing (cached env or not)", () => {
+    expect(parseTestAbilityHeaderForRequest(undefined)).toBeNull();
+    expect(parseTestAbilityHeaderForRequest("")).toBeNull();
+  });
+
+  it("parses JSON rule arrays the same way as the explicit-env variant", () => {
+    const json = JSON.stringify([{ action: "read", subject: "Search" }]);
+    const ability = parseTestAbilityHeaderForRequest(json);
+    expect(ability).not.toBeNull();
+    expect(ability!.can("read", "Search")).toBe(true);
+    expect(ability!.can("write", "Search")).toBe(false);
   });
 });

--- a/tests/stories/with-node-env.story.test.ts
+++ b/tests/stories/with-node-env.story.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { withNodeEnv } from "../lib/with-node-env.js";
+
+/**
+ * Story · `withNodeEnv` helper.
+ *
+ * Several e2e specs flip `process.env.NODE_ENV` mid-suite to test
+ * production / development behaviour. If a spec fails before its
+ * `afterAll` reset runs, `NODE_ENV` leaks to the next spec in the
+ * worker — and `parseTestAbilityHeader` early-returns when
+ * `NODE_ENV !== "test"`, silently 403'ing every subsequent spec
+ * that relies on the test-ability hatch.
+ *
+ * `withNodeEnv(value, fn)` wraps the env mutation in a try/finally
+ * so the previous value is always restored — even when `fn` throws.
+ * It's the only sanctioned way to flip `NODE_ENV` from a test.
+ */
+describe("Story · withNodeEnv", () => {
+  it("sets NODE_ENV to the requested value while fn runs", async () => {
+    const previous = process.env.NODE_ENV;
+
+    const observed = await withNodeEnv("development", async () => process.env.NODE_ENV);
+
+    expect(observed).toBe("development");
+    expect(process.env.NODE_ENV).toBe(previous);
+  });
+
+  it("restores the previous NODE_ENV after fn resolves", async () => {
+    const previous = process.env.NODE_ENV;
+
+    await withNodeEnv("production", async () => {
+      expect(process.env.NODE_ENV).toBe("production");
+    });
+
+    expect(process.env.NODE_ENV).toBe(previous);
+  });
+
+  it("restores the previous NODE_ENV even when fn throws", async () => {
+    const previous = process.env.NODE_ENV;
+
+    await expect(
+      withNodeEnv("production", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    expect(process.env.NODE_ENV).toBe(previous);
+  });
+
+  it("returns the value resolved by fn", async () => {
+    const result = await withNodeEnv("development", async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("preserves an undefined previous NODE_ENV (not stringified)", async () => {
+    const previous = process.env.NODE_ENV;
+    delete process.env.NODE_ENV;
+    try {
+      await withNodeEnv("test", async () => {
+        expect(process.env.NODE_ENV).toBe("test");
+      });
+      expect(process.env.NODE_ENV).toBeUndefined();
+    } finally {
+      // Restore for downstream tests in the same worker.
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
+  });
+});

--- a/tests/webhook-inspector.e2e-spec.ts
+++ b/tests/webhook-inspector.e2e-spec.ts
@@ -17,15 +17,18 @@ const TENANT = "11111111-1111-1111-1111-111111111111";
 describe("Webhook Inspector · admin endpoints", () => {
   describe("in development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /admin/webhooks.json returns deliveries + a CSRF token", async () => {
@@ -153,15 +156,18 @@ describe("Webhook Inspector · admin endpoints", () => {
 
   describe("outside development mode", () => {
     let app: INestApplication;
+    let previousNodeEnv: string | undefined;
 
     beforeAll(async () => {
+      previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "production";
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
     });
 
     afterAll(async () => {
       await app.close();
-      process.env.NODE_ENV = "test";
+      if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previousNodeEnv;
     });
 
     it("GET /admin/webhooks/aggregates.json 404s in production", async () => {


### PR DESCRIPTION
## Summary

Fixes two test-infrastructure findings from the LLM-test (medium severity each):

### Finding A — `NODE_ENV` leak between e2e specs

The test-ability hatch (`X-Test-Ability` header → pre-seeded CASL ability) silently disabled itself for the rest of a Vitest worker whenever a spec flipped `NODE_ENV` mid-suite and failed before its `afterAll` reset ran. Every subsequent spec then 403'd because `parseTestAbilityHeader` early-returns when `NODE_ENV !== "test"`.

Two-pronged fix:
- **Cache `NODE_ENV` at module-load time** in `src/core/permissions/test-ability.ts`. Vitest's globalSetup runs before any module loads, so the cached value is always `"test"` in the test runner. Runtime mutations no longer affect the hatch decision.
- **Add `tests/lib/with-node-env.ts`** as the sanctioned wrapper for env mutations inside specs, with `try/finally` restore. Story-tested for thrown-fn safety + undefined-prior preservation.
- **Refactor 9 e2e specs** that flip `NODE_ENV` (`admin-realtime-inspector`, `admin-ui`, `brand-config`, `dev-hub`, `dev-hub-tunnel`, `email-builder`, `file-manager-dev-hub`, `jobs-dashboard`, `migrations-page`, `webhook-inspector`) to capture the previous value in a `beforeAll` closure and restore it in `afterAll`. This catches the `brand-config.e2e-spec.ts` bug where `NODE_ENV` was set to `development` and never reset.

### Finding B — `tests/lib/fake-prisma.ts` is template-owned but project-resource adds force-edit it

`createFakePrisma()` hardcoded `example` + `userProfile` table mocks. Adding a new resource in `src/modules/<x>/` required force-editing the template — making the file a sync hot-spot. Wrapped the fake in a `Proxy` that lazily creates a `TableMock` per accessed property name. Pre-seeded `example` and `userProfile` remain for backwards compatibility (same instance on every access, same behaviour). Reserved keys (`runWithRlsTenant`, `__resetAll`, `then`, symbols) short-circuit so assertion libraries don't accidentally create a `then` table.

## Test plan

- [x] `bun run lint`
- [x] `bun run format`
- [x] `bun run test:types`
- [x] `bun run test:unit` (153 tests)
- [x] `bun run build:dev-portal`
- [x] `bun run test:e2e` (2421 tests, all green)
- [x] `bun run test:coverage` (Statements 91.07%, Lines 92.97% — `src/core/` ≥ 90% threshold respected; 3 transient failures in `health.e2e-spec.ts` + `files-persistence.e2e-spec.ts` reproducible only under coverage parallelism, all pass in isolation)
- [x] `bun run build`

## Caveats

- The 9 refactored e2e specs use a `previousNodeEnv` closure pattern instead of the `withNodeEnv()` async helper — wrapping every `it` body in `withNodeEnv` would be invasive. The closure approach + `try/finally` style restore in `afterAll` solves the same leak for the suite-scoped `beforeAll` pattern. The `withNodeEnv()` helper is the sanctioned tool for any future spec that flips `NODE_ENV` inside a single test.
- Coverage suite shows occasional ECONNRESET in `files-persistence.e2e-spec.ts` and 503 in `/health/ready` — these are pre-existing flakes under coverage parallelism, unrelated to this change. Both pass cleanly with `test:e2e` and in isolated re-runs.