### PR TITLE
fix(dev-portal): restore stroke=currentColor on sidebar icons (closes #48)

### DIFF
--- a/src/core/dx/clients/layout/icons.tsx
+++ b/src/core/dx/clients/layout/icons.tsx
@@ -11,6 +11,17 @@ import type { ReactElement } from "react";
 
 const COMMON = {
   fill: "none" as const,
+  // Lucide-style stroke attributes. Without these the legacy CSS rule
+  // `.admin-nav__icon svg path { stroke: currentColor; }` (deleted in
+  // PR #41 alongside admin-layout.css) no longer paints the icons —
+  // every <path>/<line>/<circle> rendered with `fill="none"` would be
+  // invisible. `currentColor` lets the wrapper `text-…` utility on
+  // AdminShell still drive icon colour, including the active-state
+  // accent. See Issue #48.
+  stroke: "currentColor" as const,
+  strokeWidth: 1.75,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
   // The viewBox + classnames reproduce the markup the server emits.
   viewBox: "0 0 24 24",
 };

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -32,6 +32,7 @@ const ADMIN_SPA_CONTROLLER = read("src/core/dx/admin-spa.controller.ts");
 const GLOBALS_CSS = read("src/core/dx/clients/styles/globals.css");
 const TOKENS_CSS = read("src/core/dx/clients/styles/tokens.css");
 const ADMIN_SHELL = read("src/core/dx/clients/layout/AdminShell.tsx");
+const ICONS_TSX = read("src/core/dx/clients/layout/icons.tsx");
 
 describe("Story · Dev-Portal SPA route + nav contract", () => {
   describe("React route table covers every SPA-owned page", () => {
@@ -274,5 +275,28 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
         expect(NAV_TS).toContain(`id: "${id}"`);
       });
     }
+  });
+
+  describe("Sidebar icons render with stroke=currentColor (regression pin · #48)", () => {
+    // Without `stroke="currentColor"` on the shared `COMMON` props every
+    // `<path>` rendered with `fill="none"` is invisible in the DOM —
+    // exactly the regression that landed with the shadcn migration in
+    // PR #41. Pin the four Lucide-style stroke attributes so a future
+    // refactor can't silently drop them again.
+    it('icons.tsx COMMON declares stroke: "currentColor"', () => {
+      expect(ICONS_TSX).toMatch(/stroke:\s*"currentColor"/);
+    });
+
+    it("icons.tsx COMMON declares strokeWidth", () => {
+      expect(ICONS_TSX).toMatch(/strokeWidth:\s*1\.75/);
+    });
+
+    it('icons.tsx COMMON declares strokeLinecap: "round"', () => {
+      expect(ICONS_TSX).toMatch(/strokeLinecap:\s*"round"/);
+    });
+
+    it('icons.tsx COMMON declares strokeLinejoin: "round"', () => {
+      expect(ICONS_TSX).toMatch(/strokeLinejoin:\s*"round"/);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Restores visibility of dev-portal sidebar icons that broke during the shadcn migration in #41 — every inline `<svg>` was rendered with `fill="none"` but no stroke, so the `<path>` / `<line>` / `<circle>` elements painted nothing.
- Adds four Lucide-style stroke attributes to the shared `COMMON` props in `src/core/dx/clients/layout/icons.tsx`: `stroke="currentColor"`, `strokeWidth={1.75}`, `strokeLinecap="round"`, `strokeLinejoin="round"`. The wrapper `text-…` utilities on `AdminShell` already supply the colour, including the active-state accent (`text-accent`).
- Pins the regression in `tests/stories/dev-portal-pages.story.test.ts` so a future refactor can't silently drop the stroke attributes again.

## Why this works

The legacy CSS rule that compensated for the missing stroke (`.admin-nav__icon svg path { stroke: currentColor; }` in the deleted `admin-layout.css`) is gone. Adding the stroke attributes directly on the SVG closes the gap and keeps icon colour inheritance flowing through `currentColor` — exactly what `text-accent` on the active `<NavLink>` already drives.

`BRAND_LOGO` already declared its strokes inline and was unaffected.

## Acceptance criteria (Issue #48)

- [x] `COMMON` props extended with `stroke="currentColor"` + `strokeWidth={1.75}` + `strokeLinecap="round"` + `strokeLinejoin="round"`
- [x] Story-test in `tests/stories/dev-portal-pages.story.test.ts` asserts the four stroke attributes are present
- [x] Active-state (lime accent) propagates via `currentColor` inheritance — no callsite changes needed
- [ ] Visual smoke test: sidebar icons render visibly across all sections (human reviewer)

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run format` — clean
- [x] `bun run test:types` — clean
- [x] `bun run test:unit` — 153/153 passed
- [x] `bun run test:e2e` — 2412/2412 passed (story-test pin transitioned RED → GREEN)
- [x] `bun run test:coverage` — 91.09% statements / 81.88% branches / 92.96% lines, thresholds met
- [x] `bun run build:dev-portal` — 57 artifacts (971.7 kB)
- [x] `bun run build` — full server build clean
- [ ] Visual smoke test on `bun run dev` (human reviewer): every sidebar section icon visible, active-state lime tint correct

## Out of scope

- Migration to `lucide-react` (breaking — icon names + paths change)
- Adding new icons for pages without one

🤖 Generated with [Claude Code](https://claude.com/claude-code)