### PR TITLE
fix(permissions): self-service users reach @Can() routes via tenant fallback

### DIFF
--- a/src/core/multi-tenancy/prisma-tenant-self-service-storage.ts
+++ b/src/core/multi-tenancy/prisma-tenant-self-service-storage.ts
@@ -64,6 +64,12 @@ interface PrismaTxSlice {
       joinedAt: Date | null;
     }>;
   };
+  user: {
+    updateMany(input: {
+      where: { id: string; tenantId: null };
+      data: { tenantId: string };
+    }): Promise<{ count: number }>;
+  };
 }
 
 interface TenantMemberWithTenant {
@@ -83,7 +89,10 @@ interface TenantMemberWithTenant {
 
 export class PrismaTenantSelfServiceStorage implements TenantSelfServiceStorage {
   constructor(
-    private readonly prisma: Pick<PrismaClient, "tenant" | "tenantMember" | "$transaction">,
+    private readonly prisma: Pick<
+      PrismaClient,
+      "tenant" | "tenantMember" | "user" | "$transaction"
+    >,
   ) {}
 
   async findTenantByName(name: string): Promise<TenantPlanRow | null> {
@@ -114,6 +123,20 @@ export class PrismaTenantSelfServiceStorage implements TenantSelfServiceStorage 
           status: member.status,
           joinedAt,
         },
+      });
+      // Promote the just-created tenant to the user's primary
+      // tenant — but only if they don't already have one. The
+      // `tenantId: null` guard makes this a no-op for users who are
+      // creating their second/third tenant: we never silently
+      // re-primary them, otherwise their existing tenant context
+      // would flip on every POST /tenants. Closes friction-log
+      // blocker (LLM-test 2026-05-03 #4): without this update the
+      // session's `user.tenantId` stays null and `AbilityMiddleware`
+      // resolves to an empty ability, 403'ing every `@Can()` route
+      // for the freshly-onboarded user.
+      await tx.user.updateMany({
+        where: { id: member.userId, tenantId: null },
+        data: { tenantId: tenant.id },
       });
       return {
         tenant: {

--- a/src/core/permissions/ability.middleware.ts
+++ b/src/core/permissions/ability.middleware.ts
@@ -1,6 +1,7 @@
 import { Injectable, type NestMiddleware } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 
+import { PrismaService } from "../prisma/prisma.service.js";
 import { type Ability, buildAbility } from "./casl-ability.js";
 import { PermissionService } from "./permission.service.js";
 
@@ -8,6 +9,13 @@ interface AuthenticatedRequest extends Request {
   user?: { id: string; tenantId: string | null };
   ability?: Ability;
 }
+
+const TENANT_HEADER = "x-tenant-id";
+// Strict UUID — duplicates `tenant-header.ts`'s validator on purpose:
+// the middleware fallback runs BEFORE `TenantInterceptor`, so we
+// can't rely on its parsing. A bad header here MUST NOT touch the
+// DB lookup (no log-injection / typo amplification).
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * AbilityMiddleware — resolves the active CASL `Ability` per request
@@ -26,19 +34,41 @@ interface AuthenticatedRequest extends Request {
  *   - `req.user` is missing (anonymous requests get an empty
  *     ability so routes without `@Can()` still pass through and
  *     routes WITH `@Can()` deny correctly).
- *   - `req.user.tenantId` is null — same empty-ability fallback;
+ *   - `req.user.tenantId` is null AND no valid `x-tenant-id` header
+ *     identifies an ACTIVE membership — same empty-ability fallback;
  *     the user has no tenant context to resolve rules against.
+ *
+ * x-tenant-id fallback: when `req.user.tenantId` is null we look at
+ * the request header. If the header is a UUID AND the user has an
+ * `ACTIVE` `TenantMember` row for that tenant, we resolve the
+ * ability with that tenant. Closes friction-log blocker (LLM-test
+ * 2026-05-03 #4): users created BEFORE the storage-side primary
+ * patch lands still have null `User.tenantId` even after they have
+ * memberships, and users with multiple memberships need the header
+ * to switch tenant context. Trusting the header without the
+ * membership check would be a privilege-escalation, so the
+ * `findFirst({ status: "ACTIVE", ... })` lookup is non-negotiable.
  */
 @Injectable()
 export class AbilityMiddleware implements NestMiddleware {
-  constructor(private readonly permissions: PermissionService) {}
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   async use(req: AuthenticatedRequest, _res: Response, next: NextFunction): Promise<void> {
     if (req.ability) {
       next();
       return;
     }
-    if (!req.user || !req.user.tenantId) {
+    if (!req.user) {
+      req.ability = buildAbility([]);
+      next();
+      return;
+    }
+    const sessionTenant = req.user.tenantId;
+    const tenantId = sessionTenant ?? (await this.resolveHeaderTenantId(req));
+    if (!tenantId) {
       // No identity / no tenant scope — empty ability. Routes
       // without `@Can()` still pass; routes with it 403 (matches
       // the previous interceptor-only behaviour).
@@ -47,7 +77,7 @@ export class AbilityMiddleware implements NestMiddleware {
       return;
     }
     try {
-      req.ability = await this.permissions.abilityFor(req.user.id, req.user.tenantId);
+      req.ability = await this.permissions.abilityFor(req.user.id, tenantId);
     } catch {
       // Storage failure must not 500 the request — fall back to an
       // empty ability so the request fails closed (403) rather than
@@ -55,5 +85,30 @@ export class AbilityMiddleware implements NestMiddleware {
       req.ability = buildAbility([]);
     }
     next();
+  }
+
+  /**
+   * Returns the header-supplied tenant id only if the user has an
+   * ACTIVE membership row for it. Returns null on any other path
+   * (missing header, malformed UUID, no membership, INVITED /
+   * SUSPENDED status, or DB failure) so the caller can fall through
+   * to the empty-ability branch (fail-closed).
+   */
+  private async resolveHeaderTenantId(req: AuthenticatedRequest): Promise<string | null> {
+    const userId = req.user?.id;
+    if (!userId) return null;
+    const headerValue = req.headers?.[TENANT_HEADER];
+    const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    if (!raw || !UUID_RE.test(raw)) return null;
+    const tenantId = raw.toLowerCase();
+    try {
+      const member = await this.prisma.tenantMember.findFirst({
+        where: { userId, tenantId, status: "ACTIVE" },
+        select: { id: true },
+      });
+      return member ? tenantId : null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/tests/me-tenants-self-service.e2e-spec.ts
+++ b/tests/me-tenants-self-service.e2e-spec.ts
@@ -167,4 +167,51 @@ describe("E2E · /me/tenants + POST /tenants self-service", () => {
       .send({ name: "   " });
     expect(res.status).toBe(400);
   });
+
+  /**
+   * Friction-log blocker (LLM-test 2026-05-03 #4): a freshly signed-up
+   * user who creates a tenant via POST /tenants must immediately be
+   * able to reach @Can()-gated routes for that tenant. Before the fix
+   * `User.tenantId` was never patched, so `AbilityMiddleware`
+   * short-circuited to an empty ability and every route 403'd.
+   */
+  it("fresh sign-up → POST /tenants → POST /examples succeeds (no 403)", async () => {
+    const flowEmail = `me-tenants-flow-${stamp}@example.com`;
+    const agent = request.agent(app.getHttpServer());
+
+    // Sign up a brand-new user — no prior memberships, tenantId=null.
+    const signUp = await agent
+      .post("/api/auth/sign-up/email")
+      .set("content-type", "application/json")
+      .send({ email: flowEmail, password, name: "Fresh User" });
+    expect(signUp.status, JSON.stringify(signUp.body)).toBe(200);
+
+    // Bootstrap their first tenant.
+    const tenantName = `FreshAcme-${stamp}`;
+    const createTenant = await agent
+      .post("/tenants")
+      .set("content-type", "application/json")
+      .send({ name: tenantName });
+    expect([200, 201]).toContain(createTenant.status);
+    const tenantId = createTenant.body.id as string;
+    createdTenantIds.push(tenantId);
+
+    // Now hit a `@Can("create", "Example")` route. The header carries
+    // the freshly-created tenant; if either fix is missing, the
+    // ability resolves to empty and CanGuard returns 403.
+    const createExample = await agent
+      .post("/examples")
+      .set("content-type", "application/json")
+      .set("x-tenant-id", tenantId)
+      .send({ name: "First example", status: "draft" });
+
+    expect(createExample.status, JSON.stringify(createExample.body)).toBe(201);
+
+    // Cleanup the user we created in this scenario.
+    try {
+      await prisma.user.deleteMany({ where: { email: flowEmail } });
+    } catch {
+      // ignore
+    }
+  });
 });

--- a/tests/stories/ability-middleware-tenant-header-fallback.story.test.ts
+++ b/tests/stories/ability-middleware-tenant-header-fallback.story.test.ts
@@ -49,9 +49,7 @@ describe("Story · AbilityMiddleware x-tenant-id fallback", () => {
    * scenario (matches real Prisma semantics — the WHERE clause is
    * applied server-side).
    */
-  function makePrismaWithRow(
-    row: { id: string; status: string } | null,
-  ): PrismaService {
+  function makePrismaWithRow(row: { id: string; status: string } | null): PrismaService {
     const findFirst = vi.fn(async (input: { where?: Record<string, unknown> }) => {
       if (!row) return null;
       const where = input?.where ?? {};

--- a/tests/stories/ability-middleware-tenant-header-fallback.story.test.ts
+++ b/tests/stories/ability-middleware-tenant-header-fallback.story.test.ts
@@ -1,0 +1,196 @@
+import type { NextFunction, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+
+import { AbilityMiddleware } from "../../src/core/permissions/ability.middleware.js";
+import { type Ability, buildAbility } from "../../src/core/permissions/casl-ability.js";
+import { PermissionService } from "../../src/core/permissions/permission.service.js";
+import type { PrismaService } from "../../src/core/prisma/prisma.service.js";
+
+/**
+ * Story · `AbilityMiddleware` x-tenant-id header fallback
+ *
+ * Friction-log blocker (LLM-test 2026-05-03 #4): when `req.user.tenantId`
+ * is null but the user has an ACTIVE TenantMember row, the middleware
+ * MUST fall back to the `x-tenant-id` request header to compute the
+ * ability. Without this fallback, two surfaces stay broken:
+ *
+ *   1. Users created BEFORE the storage-side fix still have
+ *      `tenantId === null` in `users` even after they have memberships.
+ *   2. Users with multiple memberships need a way to pick which
+ *      tenant context to act in for a given request.
+ *
+ * Security guarantee: the middleware MUST verify the requested tenant
+ * has an ACTIVE TenantMember row for `req.user.id` BEFORE trusting
+ * the header. Skipping the check would let any signed-in user
+ * impersonate any tenant by setting the header — privilege escalation.
+ */
+describe("Story · AbilityMiddleware x-tenant-id fallback", () => {
+  const TENANT_HEADER = "x-tenant-id";
+  const VALID_TENANT = "00000000-0000-4000-8000-000000000001";
+  const OTHER_TENANT = "00000000-0000-4000-8000-000000000002";
+
+  type Req = {
+    user?: { id: string; tenantId: string | null };
+    headers?: Record<string, string | string[] | undefined>;
+    ability?: Ability;
+  };
+
+  function makeService(rules: Ability): PermissionService {
+    return {
+      abilityFor: vi.fn(async () => rules),
+    } as unknown as PermissionService;
+  }
+
+  /**
+   * Minimal Prisma stand-in. Only `tenantMember.findFirst` is used by
+   * the middleware fallback, but typed as the full PrismaService for
+   * the constructor. The stub honours the `where.status` filter so
+   * tests can exercise the "INVITED row exists but is filtered out"
+   * scenario (matches real Prisma semantics — the WHERE clause is
+   * applied server-side).
+   */
+  function makePrismaWithRow(
+    row: { id: string; status: string } | null,
+  ): PrismaService {
+    const findFirst = vi.fn(async (input: { where?: Record<string, unknown> }) => {
+      if (!row) return null;
+      const where = input?.where ?? {};
+      if (where.status !== undefined && row.status !== where.status) return null;
+      return row;
+    });
+    return {
+      tenantMember: { findFirst },
+    } as unknown as PrismaService;
+  }
+
+  function makePrismaThrowing(): PrismaService {
+    return {
+      tenantMember: {
+        findFirst: vi.fn(async () => {
+          throw new Error("db unavailable");
+        }),
+      },
+    } as unknown as PrismaService;
+  }
+
+  function nextFn(): NextFunction & { calls: number } {
+    let calls = 0;
+    const fn = ((..._args: unknown[]) => {
+      calls += 1;
+    }) as NextFunction & { calls: number };
+    Object.defineProperty(fn, "calls", { get: () => calls });
+    return fn;
+  }
+
+  const res = {} as Response;
+
+  it("uses the x-tenant-id header when req.user.tenantId is null AND the user has an ACTIVE membership", async () => {
+    const ability = buildAbility([{ action: "read", subject: "Example" }]);
+    const service = makeService(ability);
+    const prisma = makePrismaWithRow({ id: "m1", status: "ACTIVE" });
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: null },
+      headers: { [TENANT_HEADER]: VALID_TENANT },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBe(ability);
+    expect(service.abilityFor).toHaveBeenCalledWith("u1", VALID_TENANT);
+    expect(next.calls).toBe(1);
+  });
+
+  it("keeps the empty-ability fallback when the header is set but membership is INVITED (not ACTIVE)", async () => {
+    const service = makeService(buildAbility([{ action: "read", subject: "Example" }]));
+    const prisma = makePrismaWithRow({ id: "m1", status: "INVITED" });
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: null },
+      headers: { [TENANT_HEADER]: VALID_TENANT },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBeDefined();
+    // Empty-ability fallback denies everything.
+    expect(req.ability!.can("read", "Example")).toBe(false);
+    expect(service.abilityFor).not.toHaveBeenCalled();
+    expect(next.calls).toBe(1);
+  });
+
+  it("keeps the empty-ability fallback when the header points at a tenant the user is NOT a member of", async () => {
+    const service = makeService(buildAbility([{ action: "read", subject: "Example" }]));
+    const prisma = makePrismaWithRow(null);
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: null },
+      headers: { [TENANT_HEADER]: OTHER_TENANT },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBeDefined();
+    expect(req.ability!.can("read", "Example")).toBe(false);
+    expect(service.abilityFor).not.toHaveBeenCalled();
+    expect(next.calls).toBe(1);
+  });
+
+  it("rejects a non-UUID x-tenant-id header without consulting the membership table (fail-closed)", async () => {
+    const service = makeService(buildAbility([{ action: "read", subject: "Example" }]));
+    const findFirst = vi.fn(async () => null);
+    const prisma = {
+      tenantMember: { findFirst },
+    } as unknown as PrismaService;
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: null },
+      headers: { [TENANT_HEADER]: "not-a-uuid" },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBeDefined();
+    expect(req.ability!.can("read", "Example")).toBe(false);
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(service.abilityFor).not.toHaveBeenCalled();
+    expect(next.calls).toBe(1);
+  });
+
+  it("does NOT consult the header when req.user.tenantId is already set (header is fallback-only)", async () => {
+    const ability = buildAbility([{ action: "read", subject: "Example" }]);
+    const service = makeService(ability);
+    const findFirst = vi.fn();
+    const prisma = {
+      tenantMember: { findFirst },
+    } as unknown as PrismaService;
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: "session-tenant" },
+      headers: { [TENANT_HEADER]: OTHER_TENANT },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBe(ability);
+    expect(service.abilityFor).toHaveBeenCalledWith("u1", "session-tenant");
+    expect(findFirst).not.toHaveBeenCalled();
+    expect(next.calls).toBe(1);
+  });
+
+  it("falls back to empty ability when storage lookup throws (fail-closed, no 500)", async () => {
+    const service = makeService(buildAbility([{ action: "read", subject: "Example" }]));
+    const prisma = makePrismaThrowing();
+    const mw = new AbilityMiddleware(service, prisma);
+    const req: Req = {
+      user: { id: "u1", tenantId: null },
+      headers: { [TENANT_HEADER]: VALID_TENANT },
+    };
+    const next = nextFn();
+    await mw.use(req as never, res, next);
+
+    expect(req.ability).toBeDefined();
+    expect(req.ability!.can("read", "Example")).toBe(false);
+    expect(next.calls).toBe(1);
+  });
+});

--- a/tests/stories/ability-middleware.story.test.ts
+++ b/tests/stories/ability-middleware.story.test.ts
@@ -4,6 +4,19 @@ import { describe, expect, it, vi } from "vitest";
 import { AbilityMiddleware } from "../../src/core/permissions/ability.middleware.js";
 import { type Ability, buildAbility } from "../../src/core/permissions/casl-ability.js";
 import { PermissionService } from "../../src/core/permissions/permission.service.js";
+import type { PrismaService } from "../../src/core/prisma/prisma.service.js";
+
+/**
+ * Prisma stand-in for cases where the middleware does NOT need to
+ * consult the membership table — `findFirst` is always-null fallback.
+ * The middleware-tenant-header-fallback story covers the path where
+ * the lookup actually matters.
+ */
+function prismaStub(): PrismaService {
+  return {
+    tenantMember: { findFirst: vi.fn(async () => null) },
+  } as unknown as PrismaService;
+}
 
 /**
  * Story · `AbilityMiddleware` (closes blocker — replaces interceptor
@@ -38,7 +51,7 @@ describe("Story · AbilityMiddleware", () => {
   it("attaches the resolved ability for authenticated requests", async () => {
     const ability = buildAbility([{ action: "read", subject: "Example" }]);
     const service = makeService(ability);
-    const mw = new AbilityMiddleware(service);
+    const mw = new AbilityMiddleware(service, prismaStub());
     const req: { user?: { id: string; tenantId: string | null }; ability?: Ability } = {
       user: { id: "u1", tenantId: "t1" },
     };
@@ -52,7 +65,7 @@ describe("Story · AbilityMiddleware", () => {
   it("does not overwrite a pre-seeded ability (TestAbilityMiddleware contract)", async () => {
     const seeded = buildAbility([{ action: "manage", subject: "all" }]);
     const service = makeService(buildAbility([]));
-    const mw = new AbilityMiddleware(service);
+    const mw = new AbilityMiddleware(service, prismaStub());
     const req: { user?: { id: string; tenantId: string | null }; ability?: Ability } = {
       user: { id: "u1", tenantId: "t1" },
       ability: seeded,
@@ -66,7 +79,7 @@ describe("Story · AbilityMiddleware", () => {
 
   it("attaches an empty ability when there is no user", async () => {
     const service = makeService(buildAbility([]));
-    const mw = new AbilityMiddleware(service);
+    const mw = new AbilityMiddleware(service, prismaStub());
     const req: { user?: { id: string; tenantId: string | null }; ability?: Ability } = {};
     const next = nextFn();
     await mw.use(req as never, res, next);
@@ -78,7 +91,7 @@ describe("Story · AbilityMiddleware", () => {
 
   it("attaches an empty ability when the user has no tenantId", async () => {
     const service = makeService(buildAbility([]));
-    const mw = new AbilityMiddleware(service);
+    const mw = new AbilityMiddleware(service, prismaStub());
     const req: { user?: { id: string; tenantId: string | null }; ability?: Ability } = {
       user: { id: "u1", tenantId: null },
     };
@@ -95,7 +108,7 @@ describe("Story · AbilityMiddleware", () => {
         throw new Error("db unavailable");
       }),
     } as unknown as PermissionService;
-    const mw = new AbilityMiddleware(service);
+    const mw = new AbilityMiddleware(service, prismaStub());
     const req: { user?: { id: string; tenantId: string | null }; ability?: Ability } = {
       user: { id: "u1", tenantId: "t1" },
     };

--- a/tests/stories/tenant-self-service-sets-user-tenant.story.test.ts
+++ b/tests/stories/tenant-self-service-sets-user-tenant.story.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+import { PrismaTenantSelfServiceStorage } from "../../src/core/multi-tenancy/prisma-tenant-self-service-storage.js";
+import { uuidV7 } from "../../src/core/uuid/uuid-v7.js";
+
+/**
+ * Story · `createTenantWithMember` patches `User.tenantId`.
+ *
+ * Friction-log blocker (LLM-test 2026-05-03 #4): a freshly signed-up
+ * user runs `POST /tenants` to bootstrap their first tenant — the row
+ * lands, the membership lands, but `User.tenantId` stays `null`. Every
+ * `@Can()` route then 403s because `AbilityMiddleware` short-circuits
+ * to an empty ability when the session's `tenantId` is null.
+ *
+ * Defense-in-depth fix part 1: the storage adapter MUST patch
+ * `User.tenantId = tenant.id` in the same transaction as the tenant +
+ * membership inserts. The `where: { id, tenantId: null }` guard is
+ * non-negotiable — only "claim" the user's primary tenant when they
+ * don't already have one. Subsequent `POST /tenants` calls (second
+ * tenant, third tenant, ...) MUST NOT silently re-flag the primary,
+ * otherwise users with several memberships would lose their primary
+ * context every time they create a new tenant.
+ */
+describe("Story · TenantSelfService → User.tenantId patch", () => {
+  let prisma: PrismaClient;
+  const stamp = Date.now();
+  const tenantNames: string[] = [];
+  const userIds: string[] = [];
+
+  beforeAll(async () => {
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL missing — global-setup did not run");
+    prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString: url }) });
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    for (const name of tenantNames) {
+      const t = await prisma.tenant.findUnique({ where: { name } });
+      if (!t) continue;
+      await prisma.tenantMember.deleteMany({ where: { tenantId: t.id } });
+      // Detach any users still pointing at this tenant before delete.
+      await prisma.user.updateMany({ where: { tenantId: t.id }, data: { tenantId: null } });
+      await prisma.tenant.delete({ where: { id: t.id } });
+    }
+    for (const id of userIds) {
+      try {
+        await prisma.user.delete({ where: { id } });
+      } catch {
+        // ignore
+      }
+    }
+    await prisma.$disconnect();
+  });
+
+  async function makeUser(tenantId: string | null = null): Promise<string> {
+    const id = uuidV7();
+    await prisma.user.create({
+      data: {
+        id,
+        email: `tss-tenant-patch-${id}@example.test`,
+        name: "Self-Service",
+        ...(tenantId ? { tenantId } : {}),
+      },
+    });
+    userIds.push(id);
+    return id;
+  }
+
+  it("patches User.tenantId when the user has no primary tenant yet", async () => {
+    const storage = new PrismaTenantSelfServiceStorage(prisma);
+    const owner = await makeUser();
+    const name = `tss-userpatch-fresh-${stamp}`;
+    tenantNames.push(name);
+
+    const tenantId = uuidV7();
+    const memberId = uuidV7();
+    const now = new Date();
+    await storage.createTenantWithMember({
+      tenant: { id: tenantId, name, createdAt: now },
+      member: {
+        id: memberId,
+        userId: owner,
+        tenantId,
+        role: "owner",
+        status: "ACTIVE",
+        joinedAt: now,
+      },
+    });
+
+    const userRow = await prisma.user.findUnique({ where: { id: owner } });
+    expect(userRow).not.toBeNull();
+    expect(userRow!.tenantId).toBe(tenantId);
+  });
+
+  it("does NOT overwrite User.tenantId when the user already has a primary tenant", async () => {
+    const storage = new PrismaTenantSelfServiceStorage(prisma);
+
+    // Step 1: create the user's first tenant — establishes the primary.
+    const owner = await makeUser();
+    const firstName = `tss-userpatch-first-${stamp}`;
+    tenantNames.push(firstName);
+    const firstTenantId = uuidV7();
+    const firstMemberId = uuidV7();
+    const now = new Date();
+    await storage.createTenantWithMember({
+      tenant: { id: firstTenantId, name: firstName, createdAt: now },
+      member: {
+        id: firstMemberId,
+        userId: owner,
+        tenantId: firstTenantId,
+        role: "owner",
+        status: "ACTIVE",
+        joinedAt: now,
+      },
+    });
+    const afterFirst = await prisma.user.findUnique({ where: { id: owner } });
+    expect(afterFirst!.tenantId).toBe(firstTenantId);
+
+    // Step 2: same user creates a second tenant. The User.tenantId
+    // pointer must stay on the FIRST tenant — silently re-primaring
+    // would break "current tenant" semantics for users with multiple
+    // memberships.
+    const secondName = `tss-userpatch-second-${stamp}`;
+    tenantNames.push(secondName);
+    const secondTenantId = uuidV7();
+    const secondMemberId = uuidV7();
+    await storage.createTenantWithMember({
+      tenant: { id: secondTenantId, name: secondName, createdAt: now },
+      member: {
+        id: secondMemberId,
+        userId: owner,
+        tenantId: secondTenantId,
+        role: "owner",
+        status: "ACTIVE",
+        joinedAt: now,
+      },
+    });
+    const afterSecond = await prisma.user.findUnique({ where: { id: owner } });
+    expect(afterSecond!.tenantId).toBe(firstTenantId);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the LLM-test 2026-05-03 friction-log **blocker #4**: a fresh
self-service user who creates their first tenant via `POST /tenants`
stays locked out of every `@Can()`-gated route they nominally own,
because the bootstrap path leaves `User.tenantId = null` and
`AbilityMiddleware` short-circuits to an empty ability whenever the
session tenant is null.

The fix is **defense-in-depth — two layers**:

### 1. Storage adapter patches `User.tenantId`
`PrismaTenantSelfServiceStorage.createTenantWithMember` now updates
the user inside the same `$transaction`:

```ts
await tx.user.updateMany({
  where: { id: member.userId, tenantId: null },
  data: { tenantId: tenant.id },
});
```

The `tenantId: null` guard is non-negotiable: it only "claims" the
user's primary when they don't already have one. Users creating
their second / third tenant keep their existing primary — silently
re-primaring on every `POST /tenants` would break "current tenant"
semantics for multi-tenant accounts.

### 2. `AbilityMiddleware` falls back to validated `x-tenant-id` header
When `req.user.tenantId` is null, the middleware reads the
`x-tenant-id` request header and ONLY trusts it after a
`tenantMember.findFirst({ status: "ACTIVE", userId, tenantId })`
membership lookup confirms the user can act in that tenant.
Privilege-escalation guard is non-negotiable.

This catches two cases Fix 1 alone misses:
- Users created **before** Fix 1 ships still have `tenantId = null`
  even after gaining memberships.
- Users with multiple memberships switching tenant context per-request.

## Tests (TDD red-first)
- `tests/stories/tenant-self-service-sets-user-tenant.story.test.ts`
  — RED before fix, GREEN after. Pins the `User.tenantId` patch and
  the no-overwrite guard against real Postgres.
- `tests/stories/ability-middleware-tenant-header-fallback.story.test.ts`
  — RED for the positive case before fix, GREEN after. Covers ACTIVE
  allow, INVITED deny, missing-membership deny, malformed UUID deny,
  session-tenant takes precedence, and storage-throws fail-closed.
- `tests/me-tenants-self-service.e2e-spec.ts` extended with the exact
  friction-log path: sign-up → `POST /tenants` → `POST /examples`
  with `x-tenant-id` header → expects **201**, was **403** before.

All five existing tests in `ability-middleware.story.test.ts` continue
to pass against the new constructor signature (added a `prismaStub()`
helper).

## E2E baseline
- **Before fix on this branch's HEAD**: `bun run test:e2e` ran
  290 files / 2733 tests, **1 failure** in this exact slice
  (the new `fresh sign-up → POST /tenants → POST /examples` case
  returned 403 instead of 201). All other 2732 tests passed.
- **After fix**: 290 files / 2733 tests, **0 failures**.

(Note: the LLM-test agent's "54 e2e baseline failures" were against
a different head; the current `main` is green. The friction-log
**path** the agent traced is real and is what the new e2e
demonstrates RED→GREEN.)

## Six quality gates
- `bun run lint` — 0 warnings, 0 errors (651 files)
- `bun run test:unit` — 168/168
- `bun run test:e2e` — 2733/2733
- `bun run test:types` — clean
- `bun run test:coverage` — 90.45 % statements, thresholds met
- `bun run build` — dev-portal (57 artefacts) + server bundle

## Test plan

- [x] Unit / story / e2e suites green locally (TDD red-first, then green)
- [x] All six quality gates pass
- [x] No coverage threshold lowered, no `it.skip`, no `--no-verify`
- [x] `User.tenantId` overwrite is guarded (`where: { tenantId: null }`)
- [x] `x-tenant-id` header is membership-checked before being trusted
- [x] Header fallback fails closed on DB error / malformed UUID / no
      membership / non-ACTIVE status

🤖 Generated with [Claude Code](https://claude.com/claude-code)