### PR TITLE
fix(tests): isolate test env from .env autoload + setup-wizard volume safety

### DIFF
--- a/.claude/QUICKSTART.md
+++ b/.claude/QUICKSTART.md
@@ -85,6 +85,14 @@ All six must pass before commit. If `lint`/`format` fails, run their
 `*:fix` siblings. If `coverage` fails, write more story tests — don't
 add files to the exclude list without strong justification.
 
+> **Test env caveat**: tests run against an isolated Postgres
+> testcontainer; `DATABASE_URL` and `NODE_ENV` from `.env` are
+> intentionally ignored, so Bun's `.env` autoload can never silently
+> route the suite at your dev DB. Two explicit overrides exist:
+> `TEST_DATABASE_URL=<url>` (CI service container, no opt-in needed),
+> or `TEST_REUSE_DEV_DB=1` (DESTRUCTIVE — tests will write to and
+> drop rows from the dev DB). See `tests/CLAUDE.md` for details.
+
 ## Common gotchas (one-liners — full skill in `avoiding-common-pitfalls`)
 
 - **Forgot `.js` suffix on import?** TypeScript will compile, runtime

--- a/scripts/setup-wizard.ts
+++ b/scripts/setup-wizard.ts
@@ -8,8 +8,13 @@
  * is just the thin CLI surface (cwd + stdout logging + exit code).
  */
 
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { findFreePort } from '../src/core/setup/find-free-port.js';
 import { runSetupWizard } from '../src/core/setup/setup-wizard-runner.js';
+import { planVolumeCollisionCheck } from '../src/core/setup/volume-collision-check.js';
 
 // Pick a free Postgres host-port at setup time so two `--next`
 // workspaces on the same machine never collide on `5432:5432`. The
@@ -36,14 +41,49 @@ if (!result.created) {
   process.exit(1);
 }
 
+// Probe for a stale docker volume from a same-named older workspace.
+// The friction is that `${COMPOSE_PROJECT_NAME}_postgres_data` keeps
+// the *old* POSTGRES_PASSWORD; the freshly written `.env` carries a
+// new one, so `bun run prisma:migrate` fails with P1000 and the
+// operator chases an opaque auth error. Fail-fast here with the
+// recovery commands instead of letting them rediscover the trap.
+const composeProjectName = readComposeProjectName(process.cwd()) ?? 'nest-base';
+const volumeName = `${composeProjectName}_postgres_data`;
+const volumeProbe = spawnSync('docker', ['volume', 'inspect', volumeName], {
+  stdio: 'pipe',
+  encoding: 'utf8',
+});
+// `docker volume inspect` exits 0 when the volume exists, non-zero
+// otherwise. We treat any non-zero (including "docker not installed"
+// → ENOENT) as "no collision", because a host without Docker can't
+// have the legacy volume. The runner stays planner-driven so the
+// operator-visible message is built from a single source of truth.
+const collisionPlan = planVolumeCollisionCheck({
+  composeProjectName,
+  volumeExists: volumeProbe.status === 0,
+});
+
+if (!collisionPlan.ok) {
+  console.error('');
+  console.error(collisionPlan.message);
+  console.error('');
+  console.error('Aborting before `prisma:migrate` would fail with P1000.');
+  process.exit(2);
+}
+
 console.log('');
 console.log('Next steps:');
 console.log('  1. Review and adjust values in .env');
 console.log('  2. Start dependencies: docker compose up -d');
 console.log('  3. Run migrations:     bun run prisma:migrate');
 console.log('  4. Boot the server:    bun run dev');
-console.log('');
-console.log('Re-running setup after a previous boot? Postgres remembers the old');
-console.log("password in its volume — if `bun run prisma:migrate` later fails with");
-console.log('P1000 auth error, run `docker compose down -v` first to wipe the');
-console.log('volume, then `docker compose up -d` again.');
+
+function readComposeProjectName(cwd: string): string | undefined {
+  // The wizard just wrote `.env`; read the value back rather than
+  // re-parsing `.env.example` so any operator override is honoured.
+  const envPath = join(cwd, '.env');
+  if (!existsSync(envPath)) return undefined;
+  const text = readFileSync(envPath, 'utf8');
+  const match = /^COMPOSE_PROJECT_NAME=(.*)$/m.exec(text);
+  return match?.[1]?.trim() || undefined;
+}

--- a/src/core/setup/volume-collision-check.ts
+++ b/src/core/setup/volume-collision-check.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure planner for the setup-wizard's volume-collision safety gate.
+ *
+ * Friction: a same-named older workspace leaves behind the docker
+ * volume `${COMPOSE_PROJECT_NAME}_postgres_data`. The new workspace
+ * generates a fresh `POSTGRES_PASSWORD` in `.env`, but the volume
+ * still carries the *old* one — every `prisma:migrate` then fails
+ * with `P1000` and the operator has to figure out the cause from a
+ * confusing auth error.
+ *
+ * The planner is intentionally pure: the runner shells `docker volume
+ * inspect <name>` (or any equivalent probe) and feeds the boolean
+ * outcome here. The planner builds the operator-visible message and
+ * names the exact recovery commands. Auto-destruction is explicitly
+ * NOT in scope — a `docker compose down -v` is destructive and must
+ * remain a deliberate keystroke.
+ */
+
+export interface VolumeCollisionInput {
+  /** The compose-project name (the value of `COMPOSE_PROJECT_NAME`). */
+  composeProjectName: string;
+  /** True if the runner's `docker volume inspect` probe succeeded. */
+  volumeExists: boolean;
+}
+
+export interface VolumeCollisionPlan {
+  /** True when it's safe to proceed with `prisma:migrate`. */
+  ok: boolean;
+  /** The conventional volume name derived from the project. */
+  volumeName: string;
+  /**
+   * Operator-visible message. Defined when `ok === false`; otherwise
+   * undefined (no message means "all clear, keep going").
+   */
+  message?: string;
+}
+
+export function planVolumeCollisionCheck(input: VolumeCollisionInput): VolumeCollisionPlan {
+  const name = input.composeProjectName;
+  if (!name || name.trim().length === 0) {
+    // Programmer error rather than a user-visible state — surface
+    // loudly so the runner's call site is fixed, not patched around.
+    throw new Error("planVolumeCollisionCheck: composeProjectName is required");
+  }
+
+  const volumeName = `${name}_postgres_data`;
+
+  if (!input.volumeExists) {
+    return { ok: true, volumeName };
+  }
+
+  const message = [
+    `Detected existing docker volume \`${volumeName}\` from a previous workspace.`,
+    "",
+    "The volume was initialised with that workspace's POSTGRES_PASSWORD,",
+    "but the freshly generated `.env` carries a new password — `prisma:migrate`",
+    "will fail with `P1000: Authentication failed` until the volume is reset.",
+    "",
+    "Recovery (pick one):",
+    "  - In this workspace: `docker compose down -v` to wipe the volume,",
+    "    then `docker compose up -d` (DESTRUCTIVE — drops the prior data).",
+    "  - Re-init with a unique `--name` so the new compose project gets",
+    "    its own namespace and its own volume.",
+  ].join("\n");
+
+  return { ok: false, volumeName, message };
+}

--- a/src/core/testing/pin-test-node-env.ts
+++ b/src/core/testing/pin-test-node-env.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure pinning helper for the test-runner's NODE_ENV.
+ *
+ * Bun auto-loads `.env` at process start, so a workspace whose `.env`
+ * declares `NODE_ENV=development` will boot Vitest with that value
+ * baked in. The legacy contract — "globalSetup writes
+ * `process.env.NODE_ENV = 'test'`" — proved leaky: when Vitest forks
+ * workers under `pool: 'forks'`, the env-pinning race against module
+ * load order in each worker manifests as the
+ * `tests/unit/test-infrastructure.spec.ts > "exposes NODE_ENV=test"`
+ * assertion failing on a fresh consumer.
+ *
+ * `pinTestNodeEnv()` is the pure helper invoked by both the
+ * `globalSetup` hook and the per-worker `setupFiles` entry. The hook
+ * approach matches the existing `with-node-env.ts` discipline (the
+ * pinner mutates the supplied object; the caller decides whether
+ * that's `process.env` or a sandbox in tests).
+ */
+
+export function pinTestNodeEnv(env: Record<string, string | undefined>): void {
+  // Single line of behaviour: regardless of what came in (including
+  // 'production' from a misconfigured CI), the test process speaks for
+  // the test runner. Comparing identity ('test' === 'test') is a free
+  // micro-opt that also keeps re-pin idempotent.
+  if (env.NODE_ENV !== "test") {
+    env.NODE_ENV = "test";
+  }
+}

--- a/src/core/testing/test-database-strategy.ts
+++ b/src/core/testing/test-database-strategy.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure planner for the Vitest globalSetup database strategy.
+ *
+ * Bun auto-loads `.env` at process start, so a fresh consumer
+ * workspace exposes its dev `DATABASE_URL` to the test runner whether
+ * the operator wanted it or not. Branching on `if (!DATABASE_URL)`
+ * (the legacy behaviour) silently turned `bun run test:e2e` into
+ * "drop my dev DB" the first time it ran. The planner makes the
+ * decision explicit and writes the reasoning into the log so a fresh
+ * consumer can see what happened.
+ *
+ * Decision matrix:
+ *
+ *   - `TEST_DATABASE_URL` set    → reuse-existing (CI service container).
+ *   - `TEST_REUSE_DEV_DB=1`      → reuse-existing (destructive opt-in).
+ *   - any other state            → spawn-container (default).
+ *
+ * Spawning still respects `DATABASE_URL` IF the operator explicitly
+ * opted in via `TEST_REUSE_DEV_DB=1`. Without that flag, the runner
+ * MUST clear the inherited URL (`clearDatabaseUrl: true`) so the
+ * fresh testcontainer's connection string actually wins.
+ */
+
+export interface TestDatabaseStrategyInput {
+  env: Record<string, string | undefined>;
+}
+
+export interface TestDatabaseStrategyPlan {
+  /** Which storage backs the test run. */
+  strategy: "spawn-container" | "reuse-existing";
+  /**
+   * When `strategy === "reuse-existing"`, the URL the runner should
+   * advertise via `process.env.DATABASE_URL`. Always defined for
+   * "reuse-existing", undefined for "spawn-container".
+   */
+  useUrl?: string;
+  /**
+   * When `strategy === "spawn-container"`, signals the runner to
+   * delete `process.env.DATABASE_URL` before starting the container,
+   * otherwise the inherited dev URL would survive the testcontainer
+   * boot and downstream Prisma calls would race between the two.
+   */
+  clearDatabaseUrl: boolean;
+  /** One-line operator-visible reason. Always present. */
+  reason: string;
+  /**
+   * Surface a destructive-opt-in warning when reusing an inherited
+   * DATABASE_URL. Undefined on the safe default path.
+   */
+  warning?: string;
+}
+
+const TEST_REUSE_DEV_DB_ENABLE_VALUES = new Set(["1"]);
+
+export function planTestDatabaseStrategy(
+  input: TestDatabaseStrategyInput,
+): TestDatabaseStrategyPlan {
+  const { env } = input;
+
+  const ciUrl = env.TEST_DATABASE_URL;
+  if (ciUrl && ciUrl.length > 0) {
+    return {
+      strategy: "reuse-existing",
+      useUrl: ciUrl,
+      clearDatabaseUrl: false,
+      reason: "TEST_DATABASE_URL is set — reusing the CI service container.",
+    };
+  }
+
+  const optIn = env.TEST_REUSE_DEV_DB ?? "";
+  const reuseDevDb = TEST_REUSE_DEV_DB_ENABLE_VALUES.has(optIn);
+
+  if (reuseDevDb) {
+    const url = env.DATABASE_URL;
+    if (!url) {
+      // Defensive: TEST_REUSE_DEV_DB=1 without an inherited URL is
+      // operator confusion. Fall back to the safe default rather than
+      // throw, so a typo in CI doesn't take down the whole suite.
+      return {
+        strategy: "spawn-container",
+        clearDatabaseUrl: false,
+        reason:
+          "TEST_REUSE_DEV_DB=1 but DATABASE_URL is empty — spawning a fresh testcontainer instead.",
+      };
+    }
+    return {
+      strategy: "reuse-existing",
+      useUrl: url,
+      clearDatabaseUrl: false,
+      reason: "TEST_REUSE_DEV_DB=1 — reusing the inherited DATABASE_URL.",
+      warning:
+        "TEST_REUSE_DEV_DB=1 is destructive; tests will write to and drop rows from the dev DB.",
+    };
+  }
+
+  // Default: always spawn an isolated testcontainer. If a stale
+  // DATABASE_URL was inherited from `.env`, signal the runner to
+  // clear it so the just-booted container's URL wins.
+  const inheritedUrl = env.DATABASE_URL;
+  return {
+    strategy: "spawn-container",
+    clearDatabaseUrl: Boolean(inheritedUrl),
+    reason: inheritedUrl
+      ? "Inherited DATABASE_URL detected — spawning isolated testcontainer (set TEST_REUSE_DEV_DB=1 to override; destructive)."
+      : "No DATABASE_URL inherited — spawning isolated testcontainer.",
+  };
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -164,11 +164,28 @@ expectTypeOf(foo({ x: 1 })).toMatchTypeOf<{ y: string }>();
 
 `tests/global-setup.ts` is a Vitest globalSetup hook. It:
 
-1. Sets `NODE_ENV=test`.
-2. Starts a Postgres testcontainer (`postgres:18-alpine`) if
-   `DATABASE_URL` isn't already set (CI passes one in).
-3. Exposes `DATABASE_URL` to every test.
+1. Pins `NODE_ENV=test` via `pinTestNodeEnv()` (the per-worker
+   `setupFiles` entry pins it earlier still, before any user
+   import — the duo is defence-in-depth against Bun's `.env`
+   autoload).
+2. Decides via the pure `planTestDatabaseStrategy()` planner whether
+   to spawn an isolated Postgres testcontainer (`postgres:18-alpine`)
+   or reuse an inherited URL.
+3. Exposes the chosen `DATABASE_URL` to every test.
 4. Tears the container down after the run.
+
+### Test-DB strategy (env hygiene)
+
+The default is **always testcontainer**. Bun auto-loads `.env`, so
+without this rule a fresh consumer's dev `DATABASE_URL` would silently
+route the suite at the dev DB and `bun run test:e2e` would drop rows
+from `localhost:5434/<workspace>`. Two explicit overrides:
+
+| Env var                   | Effect                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------- |
+| `TEST_DATABASE_URL=<url>` | Reuse the URL (CI service container, no opt-in needed).                               |
+| `TEST_REUSE_DEV_DB=1`     | Reuse the inherited `DATABASE_URL` (DESTRUCTIVE — writes to / drops from the dev DB). |
+| _none_                    | Spawn a fresh testcontainer; clear any inherited URL first.                           |
 
 If your test needs RustFS (file storage), use the
 `buildRustFsContainerConfig` helper from `tests/lib/rustfs-container.ts`

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -5,13 +5,26 @@ import { resolve } from "node:path";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { Client } from "pg";
 
+import { pinTestNodeEnv } from "../src/core/testing/pin-test-node-env.js";
+import { planTestDatabaseStrategy } from "../src/core/testing/test-database-strategy.js";
+
 /**
  * Vitest globalSetup hook.
  *
- * Bootstraps a Postgres test container for the entire test run and exposes its
- * connection URL via `DATABASE_URL`. If a `DATABASE_URL` is already provided
- * (CI service container, dev override), the existing URL is reused and no
- * container is started.
+ * Bootstraps a Postgres test container for the entire test run and exposes
+ * its connection URL via `DATABASE_URL`.
+ *
+ * Database strategy is decided by `planTestDatabaseStrategy()` (pure
+ * planner), not by branching on the inherited env directly. The default
+ * is **always testcontainer** — even when `DATABASE_URL` is already in
+ * `process.env`. Bun auto-loads `.env`, so a fresh consumer's dev URL
+ * would otherwise leak into the test runner and silently turn
+ * `bun run test:e2e` into "drop my dev DB". Two explicit overrides
+ * exist:
+ *   - `TEST_DATABASE_URL=<url>`  → CI service container (no opt-in needed).
+ *   - `TEST_REUSE_DEV_DB=1`      → reuse the inherited DATABASE_URL
+ *                                   (DESTRUCTIVE — tests will write to
+ *                                   and drop rows from the dev DB).
  *
  * Why testcontainers and not docker-compose: testcontainers gives us
  * parallel-safe, run-isolated databases with deterministic cleanup. The
@@ -28,9 +41,30 @@ import { Client } from "pg";
 let container: StartedPostgreSqlContainer | undefined;
 
 export default async function globalSetup(): Promise<() => Promise<void>> {
-  process.env.NODE_ENV = "test";
+  // Belt-and-braces NODE_ENV pin. The per-worker `setupFiles` hook
+  // (pin-node-env.ts) is the load-bearing version; pinning here too
+  // covers the main Vitest process where globalSetup itself runs.
+  pinTestNodeEnv(process.env);
 
-  if (!process.env.DATABASE_URL) {
+  const plan = planTestDatabaseStrategy({ env: process.env });
+  // eslint-disable-next-line no-console
+  console.log(`[global-setup] database strategy: ${plan.reason}`);
+  if (plan.warning) {
+    // eslint-disable-next-line no-console
+    console.warn(`[global-setup] WARNING: ${plan.warning}`);
+  }
+
+  if (plan.strategy === "reuse-existing" && plan.useUrl) {
+    process.env.DATABASE_URL = plan.useUrl;
+  } else {
+    // Spawn-container path. Clear any inherited URL so the runner's
+    // testcontainer URL is the only one that lands in process.env —
+    // otherwise a stale dev URL could survive the assignment if the
+    // testcontainer assignment races with a parallel module read.
+    if (plan.clearDatabaseUrl) {
+      delete process.env.DATABASE_URL;
+    }
+
     container = await new PostgreSqlContainer("postgres:18-alpine")
       .withDatabase("nst_test")
       .withUsername("nst_test")

--- a/tests/setup-files/pin-node-env.ts
+++ b/tests/setup-files/pin-node-env.ts
@@ -1,0 +1,28 @@
+/**
+ * Vitest `setupFiles` entry: pins NODE_ENV='test' BEFORE any user
+ * test code (or imported source) loads in a worker.
+ *
+ * Why a per-worker setupFile + globalSetup duo:
+ *
+ *   - globalSetup runs once in the main Vitest process. It can mutate
+ *     `process.env` for itself, but worker forks under `pool: 'forks'`
+ *     don't always observe those mutations in time — workers fork
+ *     from the main process, but module evaluation order can still
+ *     read `process.env.NODE_ENV` before the inherited mutation
+ *     lands. setupFiles run synchronously at the very top of every
+ *     worker, which is the earliest hook before any user import.
+ *
+ *   - Bun auto-loads `.env` at process start. A fresh consumer
+ *     workspace ships `.env` with `NODE_ENV=development`. Without
+ *     this pin, the unit test `tests/unit/test-infrastructure.spec.ts`
+ *     fails its `expect(process.env.NODE_ENV).toBe("test")` assertion
+ *     the very first time someone runs `bun run test:unit`.
+ *
+ * The pin is intentionally also performed in `tests/global-setup.ts`
+ * for belt-and-braces — a defence-in-depth pattern aligned with the
+ * existing `with-node-env.ts` and `test-ability.ts` discipline.
+ */
+
+import { pinTestNodeEnv } from "../../src/core/testing/pin-test-node-env.js";
+
+pinTestNodeEnv(process.env);

--- a/tests/stories/setup-wizard-volume-safety.story.test.ts
+++ b/tests/stories/setup-wizard-volume-safety.story.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { planVolumeCollisionCheck } from "../../src/core/setup/volume-collision-check.js";
+
+/**
+ * Story · Setup-Wizard · Volume-Collision-Safety.
+ *
+ * Friction-log run 2026-05-03-06-15-57: a fresh `lt fullstack init
+ * --next --name my-next-fs` failed with `prisma:migrate` P1000 because
+ * a same-named older workspace had already created the docker volume
+ * `my-next-fs_postgres_data`. The new `.env` had a freshly random
+ * `POSTGRES_PASSWORD`, but the volume still carried the *old* one.
+ *
+ * `planVolumeCollisionCheck()` is the pure planner that the wizard's
+ * runner calls before `prisma:migrate`. It takes the compose-project
+ * name + the result of a "does this volume already exist?" probe
+ * (the runner shells `docker volume inspect <name>`) and returns a
+ * fail-fast plan with a message that names the exact recovery
+ * commands. The runner never auto-destroys the volume — silent data
+ * loss is not on the table.
+ */
+describe("Story · Setup-Wizard volume-collision-check planner", () => {
+  it("returns ok=true when no volume exists for the compose project", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: false,
+    });
+    expect(plan.ok).toBe(true);
+    expect(plan.message).toBeUndefined();
+  });
+
+  it("returns ok=false when the compose-project's postgres volume already exists", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: true,
+    });
+    expect(plan.ok).toBe(false);
+  });
+
+  it("derives the conventional volume name `<project>_postgres_data` and surfaces it", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: true,
+    });
+    expect(plan.volumeName).toBe("my-next-fs_postgres_data");
+    expect(plan.message).toContain("my-next-fs_postgres_data");
+  });
+
+  it("fail-fast message includes the actionable `docker compose down -v` recovery line", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: true,
+    });
+    expect(plan.message).toMatch(/docker compose down -v/);
+  });
+
+  it("fail-fast message also offers the alternative of re-init with a unique --name", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: true,
+    });
+    expect(plan.message).toMatch(/--name|unique/i);
+  });
+
+  it("explains the root cause (old volume + new password) so a human can self-diagnose", () => {
+    const plan = planVolumeCollisionCheck({
+      composeProjectName: "my-next-fs",
+      volumeExists: true,
+    });
+    expect(plan.message).toMatch(/(password|previous|prior|existing)/i);
+  });
+
+  it("never sets `ok=true` when the volume exists, regardless of project name", () => {
+    for (const name of ["foo", "bar-baz", "MY_APP", "x"]) {
+      const plan = planVolumeCollisionCheck({
+        composeProjectName: name,
+        volumeExists: true,
+      });
+      expect(plan.ok).toBe(false);
+      expect(plan.volumeName).toBe(`${name}_postgres_data`);
+    }
+  });
+
+  it("treats an empty/whitespace project name as a programmer error (throws)", () => {
+    expect(() => planVolumeCollisionCheck({ composeProjectName: "", volumeExists: false })).toThrow(
+      /composeProjectName/,
+    );
+    expect(() =>
+      planVolumeCollisionCheck({ composeProjectName: "   ", volumeExists: false }),
+    ).toThrow(/composeProjectName/);
+  });
+});

--- a/tests/stories/test-containers-setup.story.test.ts
+++ b/tests/stories/test-containers-setup.story.test.ts
@@ -49,9 +49,15 @@ describe("Story · Test-Containers-Setup", () => {
       expect(read()).toMatch(/DATABASE_URL/);
     });
 
-    it("reuses an existing DATABASE_URL when provided (CI service-container path)", () => {
+    it("delegates the database-strategy decision to the pure planTestDatabaseStrategy() planner", () => {
       const src = read();
-      expect(src).toMatch(/if\s*\(!process\.env\.DATABASE_URL\)/);
+      // Replaces the legacy `if (!process.env.DATABASE_URL)` branch.
+      // The planner is the single source of truth for "spawn vs
+      // reuse"; globalSetup just executes its plan. CI service
+      // containers route through `TEST_DATABASE_URL`; destructive
+      // dev-DB reuse routes through `TEST_REUSE_DEV_DB=1`.
+      expect(src).toMatch(/planTestDatabaseStrategy/);
+      expect(src).toMatch(/strategy === "reuse-existing"/);
     });
 
     it("stops the container in the teardown callback", () => {

--- a/tests/stories/test-env-isolation.story.test.ts
+++ b/tests/stories/test-env-isolation.story.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { planTestDatabaseStrategy } from "../../src/core/testing/test-database-strategy.js";
+
+/**
+ * Story · Test-Env-Isolation.
+ *
+ * Bun auto-loads `.env` at process start. A typical workspace ships
+ * `DATABASE_URL=postgresql://…@localhost:5434/<workspace>` (the dev
+ * Postgres). The legacy `tests/global-setup.ts` branched on
+ * `if (!process.env.DATABASE_URL)` and skipped the testcontainer when
+ * a URL was already present — which silently turned `bun run test:e2e`
+ * into "rm your dev DB roulette".
+ *
+ * `planTestDatabaseStrategy()` is the pure planner that decides whether
+ * the runner spawns a fresh testcontainer or reuses an inherited URL.
+ * Default behaviour is **always testcontainer** unless the operator
+ * explicitly sets `TEST_REUSE_DEV_DB=1` (destructive opt-in) or the
+ * environment provides a dedicated CI service container via
+ * `TEST_DATABASE_URL`. The planner never decides "reuse" silently.
+ */
+describe("Story · Test-Env-Isolation · planTestDatabaseStrategy", () => {
+  it("defaults to spawning a fresh testcontainer when no env hints are present", () => {
+    const plan = planTestDatabaseStrategy({ env: {} });
+    expect(plan.strategy).toBe("spawn-container");
+    // The runner uses this to decide whether to clear the inherited URL
+    // before the container starts. With no hints, nothing to clear.
+    expect(plan.clearDatabaseUrl).toBe(false);
+  });
+
+  it("spawns a testcontainer and CLEARS DATABASE_URL when only DATABASE_URL is set (Bun .env autoload)", () => {
+    const plan = planTestDatabaseStrategy({
+      env: { DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app" },
+    });
+    expect(plan.strategy).toBe("spawn-container");
+    expect(plan.clearDatabaseUrl).toBe(true);
+    // The reason string surfaces in the global-setup log so a fresh
+    // consumer sees why their dev DB wasn't touched.
+    expect(plan.reason).toMatch(/spawn|isolated|testcontainer/i);
+  });
+
+  it("reuses an inherited DATABASE_URL only when TEST_REUSE_DEV_DB=1 is explicit", () => {
+    const plan = planTestDatabaseStrategy({
+      env: {
+        DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app",
+        TEST_REUSE_DEV_DB: "1",
+      },
+    });
+    expect(plan.strategy).toBe("reuse-existing");
+    expect(plan.clearDatabaseUrl).toBe(false);
+    expect(plan.reason).toMatch(/TEST_REUSE_DEV_DB/);
+  });
+
+  it("reuses CI service container when TEST_DATABASE_URL is set (no opt-in needed)", () => {
+    const plan = planTestDatabaseStrategy({
+      env: {
+        DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app",
+        TEST_DATABASE_URL: "postgresql://ci:ci@postgres:5432/ci",
+      },
+    });
+    expect(plan.strategy).toBe("reuse-existing");
+    expect(plan.useUrl).toBe("postgresql://ci:ci@postgres:5432/ci");
+    expect(plan.reason).toMatch(/TEST_DATABASE_URL|CI/i);
+  });
+
+  it("treats TEST_REUSE_DEV_DB=0 / unset values as opt-out (only `1` enables reuse)", () => {
+    for (const flag of ["0", "false", "no", ""]) {
+      const plan = planTestDatabaseStrategy({
+        env: {
+          DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app",
+          TEST_REUSE_DEV_DB: flag,
+        },
+      });
+      expect(plan.strategy).toBe("spawn-container");
+      expect(plan.clearDatabaseUrl).toBe(true);
+    }
+  });
+
+  it("emits a warning string when reusing an inherited URL (operator visibility)", () => {
+    const plan = planTestDatabaseStrategy({
+      env: {
+        DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app",
+        TEST_REUSE_DEV_DB: "1",
+      },
+    });
+    expect(plan.warning).toBeDefined();
+    // The warning must explicitly call out the destructive path so a
+    // CI accident with `TEST_REUSE_DEV_DB=1` set globally still
+    // surfaces in the test log.
+    expect(plan.warning).toMatch(/destructive|dev DB|will write/i);
+  });
+
+  it("does not warn on the default spawn-container path (clean run, clean log)", () => {
+    const plan = planTestDatabaseStrategy({
+      env: { DATABASE_URL: "postgresql://my-app:secret@localhost:5434/my-app" },
+    });
+    expect(plan.warning).toBeUndefined();
+  });
+});

--- a/tests/unit/node-env-pinning.spec.ts
+++ b/tests/unit/node-env-pinning.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { pinTestNodeEnv } from "../../src/core/testing/pin-test-node-env.js";
+
+/**
+ * Smoke + planner test for the NODE_ENV pinning helper.
+ *
+ * Friction-log run 2026-05-03-06-15-57: Bun auto-loads `.env`, which
+ * normally ships `NODE_ENV=development` in a fresh consumer workspace.
+ * `tests/unit/test-infrastructure.spec.ts` then fails its
+ * `expect(process.env.NODE_ENV).toBe("test")` assertion because the
+ * legacy globalSetup either runs too late (after worker fork) or
+ * doesn't run for the unit-only path. The fix layers
+ * `setupFiles: ['tests/setup-files/pin-node-env.ts']` on top so every
+ * worker pins NODE_ENV before any user test code touches it.
+ *
+ * The pinner itself is a pure planner (`pinTestNodeEnv`) so we can
+ * unit-test the override behaviour without poisoning the worker.
+ */
+describe("Test-Env · pinTestNodeEnv()", () => {
+  it("forces NODE_ENV to 'test' when the input env says 'development' (Bun .env autoload case)", () => {
+    const env: Record<string, string | undefined> = { NODE_ENV: "development" };
+    pinTestNodeEnv(env);
+    expect(env.NODE_ENV).toBe("test");
+  });
+
+  it("forces NODE_ENV to 'test' when the input env is empty (no autoload)", () => {
+    const env: Record<string, string | undefined> = {};
+    pinTestNodeEnv(env);
+    expect(env.NODE_ENV).toBe("test");
+  });
+
+  it("leaves NODE_ENV='test' alone (idempotent)", () => {
+    const env: Record<string, string | undefined> = { NODE_ENV: "test" };
+    pinTestNodeEnv(env);
+    expect(env.NODE_ENV).toBe("test");
+  });
+
+  it("overrides every non-test value, including 'production' (a misconfigured CI must not pass quietly)", () => {
+    for (const value of ["production", "staging", "development", "DEV", " test"]) {
+      const env: Record<string, string | undefined> = { NODE_ENV: value };
+      pinTestNodeEnv(env);
+      expect(env.NODE_ENV).toBe("test");
+    }
+  });
+
+  it("never throws on a frozen-like Record (defensive: caller-supplied env)", () => {
+    const env: Record<string, string | undefined> = { NODE_ENV: "development" };
+    expect(() => pinTestNodeEnv(env)).not.toThrow();
+  });
+
+  it("the live process.env was pinned to 'test' before this test ran (setupFile contract)", () => {
+    // This is the integration assertion the friction log called for:
+    // running `bun run test:unit` on a fresh workspace whose `.env`
+    // says `NODE_ENV=development` must STILL show NODE_ENV=test here.
+    expect(process.env.NODE_ENV).toBe("test");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     globalSetup: ['./tests/global-setup.ts'],
+    // Per-worker setup: pins NODE_ENV='test' before any user test
+    // code (or imported source module) loads. Counters Bun's `.env`
+    // autoload — a fresh consumer's `.env` ships with
+    // `NODE_ENV=development` and the assertion in
+    // `tests/unit/test-infrastructure.spec.ts` would otherwise fail.
+    setupFiles: ['./tests/setup-files/pin-node-env.ts'],
     include: ['tests/**/*.{spec,test,e2e-spec,story.test}.ts'],
     exclude: ['node_modules', 'dist', 'tests/k6/**', 'tests/types/**'],
     testTimeout: 30_000,


### PR DESCRIPTION
## Summary

Fixes four friction findings from `friction.md` run `2026-05-03-06-15-57` — all rooted in Bun auto-loading `.env`, which polluted test runs and trapped fresh consumers.

| # | Severity | Friction | Before | After |
|---|---|---|---|---|
| **#1** | high | `prisma:migrate` P1000 on fresh init due to docker volume collision (`2026-05-03T08:25`) | A same-named older workspace's volume `<name>_postgres_data` kept the OLD `POSTGRES_PASSWORD`, so the freshly written `.env` failed `P1000: Authentication failed` and the operator chased an opaque auth error | Setup-wizard probes `docker volume inspect` BEFORE printing "Next steps" and fails fast with the exact `docker compose down -v` recovery line + the `--name unique` alternative. Auto-destruction explicitly NOT in scope. |
| **#2** | high | `bun run test:e2e` silently uses dev DB instead of testcontainer (`2026-05-03T08:24`) | `tests/global-setup.ts` branched on `if (!process.env.DATABASE_URL)`. Bun auto-loads `.env`, so the dev `DATABASE_URL=postgresql://…@localhost:5434/<workspace>` leaked in, the testcontainer was skipped, and `prisma migrate deploy` ran against the dev DB | New pure planner `planTestDatabaseStrategy()` decides spawn-container vs. reuse-existing. **Default is always testcontainer.** Two explicit overrides: `TEST_DATABASE_URL=<url>` (CI service container) and `TEST_REUSE_DEV_DB=1` (DESTRUCTIVE — destructive opt-in for the rare "yes, I really mean it" case). |
| **#7** | medium | `bun run test:unit` fails because Bun auto-loads `NODE_ENV=development` (`2026-05-03T08:33`) | `tests/unit/test-infrastructure.spec.ts > "exposes NODE_ENV=test for downstream guards"` failed because Bun's `.env` autoload set `NODE_ENV=development` and the existing globalSetup didn't propagate to forked workers in time | New pure helper `pinTestNodeEnv()` forces `NODE_ENV=test`. Wired in **both** the per-worker `setupFiles` entry (load-bearing) and `globalSetup` (defence-in-depth) — same belt-and-braces shape as the existing `with-node-env.ts` discipline. |
| **#11** | medium | QUICKSTART doc-gap on the env caveat (`2026-05-03T08:24`) | Six-gate block was bare commands with no env-mode caveats; `Common gotchas` didn't cover this case | `.claude/QUICKSTART.md` now warns about the testcontainer/`.env` separation under "The six quality gates", and `tests/CLAUDE.md` adds a "Test-DB strategy" table with the new env vars. |

## Implementation notes

- **TDD red-first**: 21 new tests across 3 files covered the four fixes before any source landed (`tests/stories/test-env-isolation.story.test.ts` 7 tests, `tests/stories/setup-wizard-volume-safety.story.test.ts` 8 tests, `tests/unit/node-env-pinning.spec.ts` 6 tests).
- **Planner / runner split**: All three subsystem changes follow the project convention — pure planners (`planTestDatabaseStrategy`, `pinTestNodeEnv`, `planVolumeCollisionCheck`) live under `src/core/`, the runners just shell I/O. The wizard's runner does the actual `docker volume inspect` shell-out; the test only exercises the planner.
- **No volume auto-destroy**: `docker compose down -v` must remain a deliberate human keystroke. The wizard surfaces the command in the fail message; it never executes it.
- **Always-testcontainer default is non-negotiable**: silently using the dev DB would equal data loss. The opt-in `TEST_REUSE_DEV_DB=1` is the only path that bypasses the testcontainer.
- The legacy `tests/stories/test-containers-setup.story.test.ts > "reuses an existing DATABASE_URL when provided"` test was rewritten to assert the planner is now the source of truth (it grep'd for `if (!process.env.DATABASE_URL)` which no longer exists).

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run format` — all files pass
- [x] `bun run test:types` — clean
- [x] `bun run test:unit` — 174 tests across 18 files pass (including new `node-env-pinning.spec.ts`)
- [x] `bun run test:e2e` — 2754 tests across 293 files pass
- [x] `bun run test:coverage` — `core/setup` 96.15% lines, `core/testing` 97.56% lines (above the 70% / 60% gate)
- [x] `bun run build` — clean
- [x] Replicated friction case: `NODE_ENV=development DATABASE_URL=postgresql://my-next-fs:secret@localhost:5434/my-next-fs bun run test:unit` now passes
- [x] Replicated friction case: `NODE_ENV=development bun run test:unit` now passes (issue #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)