### PR TITLE
feat(permissions): EXTRA_MEMBER_RESOURCES multi-provider hook for project-extended member catalog

### DIFF
--- a/.claude/skills/adding-feature-module.md
+++ b/.claude/skills/adding-feature-module.md
@@ -511,7 +511,74 @@ import { features } from "../config/features.js";
 export class AppModule {}
 ```
 
-## Step 8 — Quality gates
+## Step 8 — Grant member access to the new resource
+
+If the new resource is project-facing (i.e. a logged-in tenant member
+should be able to CRUD their own rows), wire it into the synthesized
+"Member" role catalog so a fresh sign-up doesn't 403 on every
+`@Can()`-gated route. Two equivalent shapes — pick the one that suits
+the module's lifecycle:
+
+### Option A — `PermissionsModule.forFeature()` from inside the feature module
+
+Idiomatic when the resource is owned end-to-end by the feature module.
+The contribution travels with the import; removing the module also
+removes the grant.
+
+```typescript
+// src/modules/<resource>/<resource>.module.ts
+import { Module } from "@nestjs/common";
+
+import { PermissionsModule } from "../../core/permissions/permissions.module.js";
+import { PrismaModule } from "../../core/prisma/prisma.module.js";
+
+import { <Resource>Controller } from "./<resource>.controller.js";
+import { <Resource>Service } from "./<resource>.service.js";
+
+@Module({
+  imports: [
+    PrismaModule,
+    PermissionsModule.forFeature({ resources: ["<Resource>"] }),
+  ],
+  controllers: [<Resource>Controller],
+  providers: [<Resource>Service],
+})
+export class <Resource>Module {}
+```
+
+For per-user resources (like API keys — bound to the user across
+tenants, not to the active tenant), use `perUserResources` instead:
+
+```typescript
+PermissionsModule.forFeature({ perUserResources: ["UserNote"] }),
+```
+
+### Option B — Single override at AppModule level
+
+Useful when AppModule curates the full extra-resources catalog in one
+place (e.g. for projects that prefer a single source of truth):
+
+```typescript
+// src/app.module.ts
+import { EXTRA_MEMBER_RESOURCES } from "./core/permissions/extra-resources.token.js";
+
+@Module({
+  providers: [
+    { provide: EXTRA_MEMBER_RESOURCES, useValue: [["Todo"], ["Invoice"]] },
+  ],
+})
+export class AppModule {}
+```
+
+The token's value type is `readonly (readonly string[])[]` — one inner
+array per logical contribution. The aggregator flat-maps and dedupes
+against `DEFAULT_MEMBER_RESOURCES` before emitting the rules.
+
+Skip this step entirely if the resource is admin-only (only the
+`/admin/*` UI / a seeded admin Role should reach it) or framework-
+internal (`Role`, `Policy`, `Permission`, `Tenant`, `WebhookEndpoint`).
+
+## Step 9 — Quality gates
 
 ```bash
 bun run lint && bun run format && bun run test:types \
@@ -522,7 +589,7 @@ bun run lint && bun run format && bun run test:types \
 Coverage on `src/modules/` is gated at **≥ 80 %**. New code without a
 story drags the average — write more story tests.
 
-## Step 9 — Commit
+## Step 10 — Commit
 
 ```bash
 git add -A

--- a/src/core/permissions/extra-resources.token.ts
+++ b/src/core/permissions/extra-resources.token.ts
@@ -50,9 +50,7 @@
  * Nest-idiomatic equivalents.
  */
 export const EXTRA_MEMBER_RESOURCES = Symbol.for("lt:extra-member-resources");
-export const EXTRA_MEMBER_PER_USER_RESOURCES = Symbol.for(
-  "lt:extra-member-per-user-resources",
-);
+export const EXTRA_MEMBER_PER_USER_RESOURCES = Symbol.for("lt:extra-member-per-user-resources");
 
 /**
  * Internal namespace prefix attached to every `forFeature`

--- a/src/core/permissions/extra-resources.token.ts
+++ b/src/core/permissions/extra-resources.token.ts
@@ -1,0 +1,76 @@
+/**
+ * DI tokens that let project modules extend the synthesized "Member"
+ * role catalog without editing template-owned code.
+ *
+ * Why two tokens: the per-tenant rules apply `$CURRENT_TENANT`
+ * scoping; the per-user rules apply `$CURRENT_USER` scoping. They are
+ * NOT interchangeable — see `member-role-rules.ts` for the rationale
+ * and the canonical examples (`Address` is per-tenant, `ApiKey` is
+ * per-user).
+ *
+ * There are two ways to contribute:
+ *
+ * 1. **Single override at the AppModule level** — useful when the
+ *    project owns the full extra-resources list and wants to declare
+ *    it once:
+ *
+ *    ```ts
+ *    import { EXTRA_MEMBER_RESOURCES } from "../core/permissions/extra-resources.token.js";
+ *
+ *    @Module({
+ *      providers: [
+ *        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo", "Invoice"] },
+ *      ],
+ *    })
+ *    export class AppModule {}
+ *    ```
+ *
+ * 2. **Per-feature contribution via `PermissionsModule.forFeature()`**
+ *    — useful when a feature module wants to ship its own resource
+ *    grant alongside its `@Can()` routes. Multiple `forFeature` calls
+ *    compose: each contribution is collected via `DiscoveryService`
+ *    and flat-merged into the synthesized rules.
+ *
+ *    ```ts
+ *    @Module({
+ *      imports: [
+ *        PermissionsModule.forFeature({ resources: ["Todo"] }),
+ *      ],
+ *    })
+ *    export class TodoModule {}
+ *    ```
+ *
+ * Both shapes are deduped before passing into the rule planner so a
+ * default plus an extra contributing the same name produces a single
+ * rule.
+ *
+ * Why not Angular-style `multi: true` providers: NestJS's DI
+ * container does not aggregate `multi: true` registrations of the
+ * same token (it last-wins). The two shapes above are the
+ * Nest-idiomatic equivalents.
+ */
+export const EXTRA_MEMBER_RESOURCES = Symbol.for("lt:extra-member-resources");
+export const EXTRA_MEMBER_PER_USER_RESOURCES = Symbol.for(
+  "lt:extra-member-per-user-resources",
+);
+
+/**
+ * Internal namespace prefix attached to every `forFeature`
+ * contribution. The aggregator scans `DiscoveryService` for tokens
+ * whose `Symbol.keyFor(...)` starts with the prefix; each match's
+ * `useValue` is one contribution.
+ *
+ * Exported so tests can poke at it directly without re-deriving the
+ * naming convention.
+ */
+export const FEATURE_CONTRIBUTION_PREFIX = "lt:permissions:feature-contribution:";
+
+/**
+ * Shape one `forFeature` registration produces. Stored as the
+ * `useValue` of a uniquely-keyed Symbol so the aggregator can pick
+ * it up without coordinating registration order.
+ */
+export interface MemberResourceContribution {
+  resources?: readonly string[];
+  perUserResources?: readonly string[];
+}

--- a/src/core/permissions/permissions.module.ts
+++ b/src/core/permissions/permissions.module.ts
@@ -172,9 +172,7 @@ export class PermissionsModule implements NestModule {
   static forFeature(contribution: MemberResourceContribution): DynamicModule {
     // Unique token per call so two modules don't shadow each other.
     // `Symbol.for` so DiscoveryService can read it via Symbol.keyFor.
-    const token = Symbol.for(
-      `${FEATURE_CONTRIBUTION_PREFIX}${++featureContributionCounter}`,
-    );
+    const token = Symbol.for(`${FEATURE_CONTRIBUTION_PREFIX}${++featureContributionCounter}`);
     return {
       module: PermissionsModule,
       providers: [{ provide: token, useValue: contribution }],

--- a/src/core/permissions/permissions.module.ts
+++ b/src/core/permissions/permissions.module.ts
@@ -1,10 +1,21 @@
-import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
-import { APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
+import {
+  type DynamicModule,
+  type MiddlewareConsumer,
+  Module,
+  type NestModule,
+} from "@nestjs/common";
+import { APP_GUARD, APP_INTERCEPTOR, DiscoveryModule, DiscoveryService } from "@nestjs/core";
 
 import { PrismaModule } from "../prisma/prisma.module.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { AbilityMiddleware } from "./ability.middleware.js";
 import { CanGuard } from "./can.guard.js";
+import {
+  EXTRA_MEMBER_PER_USER_RESOURCES,
+  EXTRA_MEMBER_RESOURCES,
+  FEATURE_CONTRIBUTION_PREFIX,
+  type MemberResourceContribution,
+} from "./extra-resources.token.js";
 import { PermissionInterceptor } from "./permission.interceptor.js";
 import { PermissionService, type PermissionStorage } from "./permission.service.js";
 import { PERMISSION_STORAGE } from "./permission-storage.token.js";
@@ -21,6 +32,21 @@ import { TestAbilityMiddleware } from "./test-ability.middleware.js";
  * scoped via `$CURRENT_TENANT` so every ACTIVE tenant member can
  * exercise project-facing `@Can()` routes without an admin first
  * authoring a policy.
+ *
+ * Project-extension hook (`EXTRA_MEMBER_RESOURCES` /
+ * `EXTRA_MEMBER_PER_USER_RESOURCES`): two shapes compose into the
+ * synthesized rules.
+ *
+ *  1. **Single override** at AppModule level by providing one of the
+ *     `EXTRA_*` tokens with `useValue: readonly string[]`.
+ *  2. **Per-feature contribution** via `PermissionsModule.forFeature(
+ *     { resources, perUserResources })` — multiple modules
+ *     contribute, the aggregator (a DiscoveryService scan over
+ *     uniquely-keyed Symbols) flat-merges all of them.
+ *
+ * Both are deduped against the upstream defaults before the planner
+ * runs. This keeps `bun run sync:from-template` clean — projects
+ * never edit `member-role-rules.ts`.
  *
  * Backwards compatibility: projects that already ship their own
  * permission storage can override the `PERMISSION_STORAGE` provider
@@ -42,13 +68,71 @@ import { TestAbilityMiddleware } from "./test-ability.middleware.js";
  *     isolation). It is no longer registered as `APP_INTERCEPTOR`
  *     since the middleware now owns the attachment path.
  */
+
+let featureContributionCounter = 0;
+
+/**
+ * Aggregate `forFeature` contributions into the canonical
+ * `string[][]` shape consumed by `PrismaPermissionStorage`.
+ *
+ * Walks `DiscoveryService.getProviders()` once per process, picks
+ * out providers whose token is a Symbol with a `keyFor` starting
+ * with `FEATURE_CONTRIBUTION_PREFIX`, and reads each
+ * `MemberResourceContribution`. Results are stable across runs as
+ * long as the module imports are deterministic.
+ */
+function aggregateContributions(
+  discovery: DiscoveryService,
+  bucket: "resources" | "perUserResources",
+): readonly (readonly string[])[] {
+  const out: (readonly string[])[] = [];
+  for (const wrapper of discovery.getProviders()) {
+    const token = wrapper.token;
+    if (typeof token !== "symbol") continue;
+    const key = Symbol.keyFor(token);
+    if (!key || !key.startsWith(FEATURE_CONTRIBUTION_PREFIX)) continue;
+    const value = wrapper.instance as MemberResourceContribution | undefined;
+    if (!value || typeof value !== "object") continue;
+    const list = value[bucket];
+    if (Array.isArray(list) && list.length > 0) out.push(list);
+  }
+  return out;
+}
+
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, DiscoveryModule],
   providers: [
+    // Aggregated extras tokens: each is a `string[][]`, one inner
+    // array per `forFeature` contribution (or empty when no project
+    // module contributes). Projects can also override these with a
+    // useValue at AppModule level for a single-source-of-truth
+    // catalog — that overrides last-wins, which is exactly what we
+    // want for the override path.
+    {
+      provide: EXTRA_MEMBER_RESOURCES,
+      useFactory: (discovery: DiscoveryService): readonly (readonly string[])[] =>
+        aggregateContributions(discovery, "resources"),
+      inject: [DiscoveryService],
+    },
+    {
+      provide: EXTRA_MEMBER_PER_USER_RESOURCES,
+      useFactory: (discovery: DiscoveryService): readonly (readonly string[])[] =>
+        aggregateContributions(discovery, "perUserResources"),
+      inject: [DiscoveryService],
+    },
     {
       provide: PERMISSION_STORAGE,
-      useFactory: (prisma: PrismaService): PermissionStorage => new PrismaPermissionStorage(prisma),
-      inject: [PrismaService],
+      useFactory: (
+        prisma: PrismaService,
+        extraTenant: readonly (readonly string[])[],
+        extraUser: readonly (readonly string[])[],
+      ): PermissionStorage =>
+        new PrismaPermissionStorage(
+          prisma,
+          {},
+          { extraTenantResources: extraTenant, extraUserResources: extraUser },
+        ),
+      inject: [PrismaService, EXTRA_MEMBER_RESOURCES, EXTRA_MEMBER_PER_USER_RESOURCES],
     },
     PermissionService,
     PermissionInterceptor,
@@ -58,9 +142,46 @@ import { TestAbilityMiddleware } from "./test-ability.middleware.js";
     { provide: APP_INTERCEPTOR, useClass: PermissionInterceptor },
     { provide: APP_GUARD, useClass: CanGuard },
   ],
-  exports: [PermissionService, PERMISSION_STORAGE],
+  exports: [
+    PermissionService,
+    PERMISSION_STORAGE,
+    EXTRA_MEMBER_RESOURCES,
+    EXTRA_MEMBER_PER_USER_RESOURCES,
+  ],
 })
 export class PermissionsModule implements NestModule {
+  /**
+   * Register a module-level extra-resources contribution. Multiple
+   * calls compose: every contribution surfaces in the synthesized
+   * Member role rules. Use from a feature module that ships its own
+   * `@Can()` subjects:
+   *
+   * ```ts
+   * @Module({
+   *   imports: [PermissionsModule.forFeature({ resources: ["Todo"] })],
+   * })
+   * export class TodoModule {}
+   * ```
+   *
+   * The contribution is registered as a uniquely-keyed Symbol
+   * provider so two modules registering the same call site don't
+   * collide. Aggregation happens via `DiscoveryService` at storage-
+   * factory time — no static module state, no init-order
+   * dependency.
+   */
+  static forFeature(contribution: MemberResourceContribution): DynamicModule {
+    // Unique token per call so two modules don't shadow each other.
+    // `Symbol.for` so DiscoveryService can read it via Symbol.keyFor.
+    const token = Symbol.for(
+      `${FEATURE_CONTRIBUTION_PREFIX}${++featureContributionCounter}`,
+    );
+    return {
+      module: PermissionsModule,
+      providers: [{ provide: token, useValue: contribution }],
+      exports: [token],
+    };
+  }
+
   configure(consumer: MiddlewareConsumer): void {
     // TestAbility runs first across the whole pipeline — it short-
     // circuits the resolver when a `X-Test-Ability` header is set.

--- a/src/core/permissions/prisma-permission-storage.ts
+++ b/src/core/permissions/prisma-permission-storage.ts
@@ -187,9 +187,7 @@ export class PrismaPermissionStorage implements PermissionStorage {
  * authored deliberately in `member-role-rules.ts` and merged after
  * via `dedupePreserveOrder`.
  */
-function stableUniqueSort(
-  source: readonly (readonly string[])[] | undefined,
-): readonly string[] {
+function stableUniqueSort(source: readonly (readonly string[])[] | undefined): readonly string[] {
   if (!source || source.length === 0) return [];
   return [...new Set(source.flat())].sort();
 }

--- a/src/core/permissions/prisma-permission-storage.ts
+++ b/src/core/permissions/prisma-permission-storage.ts
@@ -1,7 +1,11 @@
 import type { PrismaClient } from "@prisma/client";
 
 import type { DbPermissionRow } from "./db-rule-resolver.js";
-import { buildMemberRoleRules } from "./member-role-rules.js";
+import {
+  DEFAULT_MEMBER_PER_USER_RESOURCES,
+  DEFAULT_MEMBER_RESOURCES,
+  buildMemberRoleRules,
+} from "./member-role-rules.js";
 import type { PermissionStorage } from "./permission.service.js";
 
 /**
@@ -61,6 +65,23 @@ export interface PrismaPermissionStorageOptions {
   memberPerUserResources?: readonly string[];
 }
 
+/**
+ * Multi-provider extras (`EXTRA_MEMBER_RESOURCES` /
+ * `EXTRA_MEMBER_PER_USER_RESOURCES`) the storage should merge on top
+ * of the (possibly-overridden) defaults. NestJS multi-providers
+ * surface as `T[]` where each `T` is one provider's `useValue` — so
+ * here `string[][]`, one inner array per registration.
+ *
+ * Kept as a separate parameter (instead of folded into
+ * `PrismaPermissionStorageOptions`) so projects that construct the
+ * storage manually for tests don't have to deal with the multi-
+ * provider shape — only the `PermissionsModule` factory wires it.
+ */
+export interface PrismaPermissionStorageExtras {
+  extraTenantResources?: readonly (readonly string[])[];
+  extraUserResources?: readonly (readonly string[])[];
+}
+
 type PrismaSubset = Pick<PrismaClient, "tenantMember" | "permission">;
 
 interface PermissionRow {
@@ -74,14 +95,25 @@ export class PrismaPermissionStorage implements PermissionStorage {
   private readonly synthesize: boolean;
   private readonly memberResources?: readonly string[];
   private readonly memberPerUserResources?: readonly string[];
+  private readonly extraTenantResources: readonly string[];
+  private readonly extraUserResources: readonly string[];
 
   constructor(
     private readonly prisma: PrismaSubset,
     options: PrismaPermissionStorageOptions = {},
+    extras: PrismaPermissionStorageExtras = {},
   ) {
     this.synthesize = options.synthesizeMemberRules ?? true;
     this.memberResources = options.memberResources;
     this.memberPerUserResources = options.memberPerUserResources;
+    // Flat-map the multi-provider arrays once at construction so the
+    // hot path in findRulesForUser stays cheap. Stable-sort the
+    // result so multiple providers contributing the same set produce
+    // a deterministic order (the sort is on the extras only — the
+    // defaults retain their authored order so existing snapshots
+    // / consumers that depend on it stay stable).
+    this.extraTenantResources = stableUniqueSort(extras.extraTenantResources);
+    this.extraUserResources = stableUniqueSort(extras.extraUserResources);
   }
 
   async findRulesForUser(userId: string, tenantId: string): Promise<DbPermissionRow[]> {
@@ -130,13 +162,57 @@ export class PrismaPermissionStorage implements PermissionStorage {
     // entries use `$CURRENT_TENANT`, per-user entries (ApiKey, etc.)
     // use `$CURRENT_USER`. Appended after the explicit rows so the
     // resolver sees both — CASL OR-merges granting rules.
-    const opts: Parameters<typeof buildMemberRoleRules>[0] = {};
-    if (this.memberResources !== undefined) opts.resources = this.memberResources;
-    if (this.memberPerUserResources !== undefined)
-      opts.perUserResources = this.memberPerUserResources;
+    //
+    // Merge order: explicit overrides (memberResources /
+    // memberPerUserResources) take precedence for the "default" slot,
+    // then EXTRA_* multi-provider extras append after, deduped.
+    // Without an override the upstream defaults apply.
+    const tenantBase = this.memberResources ?? DEFAULT_MEMBER_RESOURCES;
+    const userBase = this.memberPerUserResources ?? DEFAULT_MEMBER_PER_USER_RESOURCES;
+    const opts: Parameters<typeof buildMemberRoleRules>[0] = {
+      resources: dedupePreserveOrder(tenantBase, this.extraTenantResources),
+      perUserResources: dedupePreserveOrder(userBase, this.extraUserResources),
+    };
     const synthesized = buildMemberRoleRules(opts);
     return [...explicit, ...synthesized];
   }
+}
+
+/**
+ * Flatten + dedupe + stable-sort a multi-provider extras list. The
+ * sort is intentional: two providers registering the same set must
+ * produce a deterministic order so cached abilities stay stable.
+ *
+ * We do NOT touch the order of the upstream defaults — those are
+ * authored deliberately in `member-role-rules.ts` and merged after
+ * via `dedupePreserveOrder`.
+ */
+function stableUniqueSort(
+  source: readonly (readonly string[])[] | undefined,
+): readonly string[] {
+  if (!source || source.length === 0) return [];
+  return [...new Set(source.flat())].sort();
+}
+
+/**
+ * Concatenate `defaults` then `extras` and dedupe by keeping the
+ * first occurrence. Defaults retain their authored order so
+ * downstream consumers that depend on it (existing tests, the
+ * `/permissions/test` endpoint snapshot) stay stable; extras append
+ * in their stable-sorted order.
+ */
+function dedupePreserveOrder(
+  defaults: readonly string[],
+  extras: readonly string[],
+): readonly string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of [...defaults, ...extras]) {
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
 }
 
 function toDbPermissionRow(row: PermissionRow): DbPermissionRow {

--- a/tests/stories/extra-member-resources.story.test.ts
+++ b/tests/stories/extra-member-resources.story.test.ts
@@ -1,4 +1,5 @@
-import { Test, type TestingModule } from "@nestjs/testing";
+import { Module } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
 import { describe, expect, it } from "vitest";
 
 import type { DbPermissionRow } from "../../src/core/permissions/db-rule-resolver.js";
@@ -11,22 +12,32 @@ import {
   DEFAULT_MEMBER_RESOURCES,
 } from "../../src/core/permissions/member-role-rules.js";
 import { PERMISSION_STORAGE } from "../../src/core/permissions/permission-storage.token.js";
+import type { PermissionStorage } from "../../src/core/permissions/permission.service.js";
+import { PermissionsModule } from "../../src/core/permissions/permissions.module.js";
 import { PrismaPermissionStorage } from "../../src/core/permissions/prisma-permission-storage.js";
 
 /**
- * Story · `EXTRA_MEMBER_RESOURCES` multi-provider hook.
+ * Story · `EXTRA_MEMBER_RESOURCES` project-extension hook.
  *
  * Project modules need to grant the implicit Member role access to
  * project-owned resources WITHOUT editing template-owned code. Two
- * multi-provider DI tokens (`EXTRA_MEMBER_RESOURCES` for tenant-scoped
- * subjects and `EXTRA_MEMBER_PER_USER_RESOURCES` for `$CURRENT_USER`-
- * scoped ones) let any module flat-merge its catalogue into the
- * synthesized rules emitted by `PrismaPermissionStorage`.
+ * shapes compose:
  *
- * The tests below exercise the storage in isolation against a fake
- * Prisma client so we can assert exactly which rows are produced;
- * the existing `prisma-permission-storage.story.test.ts` covers the
- * end-to-end Postgres path with the default-only DI shape.
+ *  - `EXTRA_MEMBER_RESOURCES` / `EXTRA_MEMBER_PER_USER_RESOURCES`
+ *    DI tokens for a SINGLE override at the AppModule level.
+ *  - `PermissionsModule.forFeature({ resources, perUserResources })`
+ *    for module-level composition — multiple feature modules
+ *    contribute independently and the storage flat-merges them.
+ *
+ * Why a `forFeature` helper plus single-override tokens (instead of
+ * Angular-style `multi: true` providers): NestJS DI does not
+ * aggregate `multi: true` registrations of the same token. The
+ * helper plus token combination is the Nest-idiomatic equivalent.
+ *
+ * Tests use the storage directly with hand-built FakePrisma plus a
+ * minimal NestJS `Test.createTestingModule` for the DI shapes; the
+ * existing `prisma-permission-storage.story.test.ts` covers the
+ * Postgres-backed default path.
  */
 
 const TEST_USER_ID = "00000000-0000-7000-8000-00000000000a";
@@ -66,83 +77,33 @@ function fakePrismaWithMember(): FakePrismaSubset {
   };
 }
 
-/** Filter rows by resource for assertion convenience. */
 function resourceNames(rows: DbPermissionRow[]): string[] {
   return rows.map((r) => r.resource);
 }
 
-describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
+describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
   it("emits ONLY DEFAULT_MEMBER_RESOURCES + DEFAULT_MEMBER_PER_USER_RESOURCES when no extras are provided", async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PERMISSION_STORAGE,
-          useFactory: (
-            extraTenant: readonly string[][],
-            extraUser: readonly string[][],
-          ) =>
-            new PrismaPermissionStorage(
-              fakePrismaWithMember() as unknown as ConstructorParameters<
-                typeof PrismaPermissionStorage
-              >[0],
-              {},
-              { extraTenantResources: extraTenant, extraUserResources: extraUser },
-            ),
-          inject: [
-            { token: EXTRA_MEMBER_RESOURCES, optional: true },
-            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
-          ],
-        },
-        {
-          provide: EXTRA_MEMBER_RESOURCES,
-          useValue: [],
-          multi: true,
-        },
-        {
-          provide: EXTRA_MEMBER_PER_USER_RESOURCES,
-          useValue: [],
-          multi: true,
-        },
-      ],
-    }).compile();
-
-    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+    );
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const names = resourceNames(rows);
 
     expect(names.sort()).toEqual(
       [...DEFAULT_MEMBER_RESOURCES, ...DEFAULT_MEMBER_PER_USER_RESOURCES].sort(),
     );
-    await module.close();
   });
 
-  it("adds a tenant-scoped 'manage' rule when one provider supplies a single resource", async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PERMISSION_STORAGE,
-          useFactory: (
-            extraTenant: readonly string[][],
-            extraUser: readonly string[][],
-          ) =>
-            new PrismaPermissionStorage(
-              fakePrismaWithMember() as unknown as ConstructorParameters<
-                typeof PrismaPermissionStorage
-              >[0],
-              {},
-              { extraTenantResources: extraTenant, extraUserResources: extraUser },
-            ),
-          inject: [
-            { token: EXTRA_MEMBER_RESOURCES, optional: true },
-            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
-          ],
-        },
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
-        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
-      ],
-    }).compile();
-
-    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+  it("adds a tenant-scoped 'manage' rule when one extra resource is provided", async () => {
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      {},
+      { extraTenantResources: [["Todo"]] },
+    );
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const todo = rows.find((r) => r.resource === "Todo");
 
@@ -150,123 +111,58 @@ describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
     expect(todo?.action).toBe("MANAGE");
     expect(todo?.itemFilter).toEqual({ tenantId: { _eq: "$CURRENT_TENANT" } });
     expect(todo?.fields).toEqual([]);
-    await module.close();
   });
 
-  it("flat-maps multiple providers — both resources show up", async () => {
+  it("flat-maps multiple forFeature contributions — both resources show up", async () => {
+    @Module({ imports: [PermissionsModule.forFeature({ resources: ["Todo"] })] })
+    class TodoModule {}
+
+    @Module({ imports: [PermissionsModule.forFeature({ resources: ["Invoice"] })] })
+    class InvoiceModule {}
+
     const module = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PERMISSION_STORAGE,
-          useFactory: (
-            extraTenant: readonly string[][],
-            extraUser: readonly string[][],
-          ) =>
-            new PrismaPermissionStorage(
-              fakePrismaWithMember() as unknown as ConstructorParameters<
-                typeof PrismaPermissionStorage
-              >[0],
-              {},
-              { extraTenantResources: extraTenant, extraUserResources: extraUser },
-            ),
-          inject: [
-            { token: EXTRA_MEMBER_RESOURCES, optional: true },
-            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
-          ],
-        },
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Invoice"], multi: true },
-        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
-      ],
+      imports: [PermissionsModule, TodoModule, InvoiceModule],
     }).compile();
 
-    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
-    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
-    const names = resourceNames(rows);
-
-    expect(names).toContain("Todo");
-    expect(names).toContain("Invoice");
+    // After module init the aggregated extras hold both contributions
+    // (one inner array per forFeature).
+    const tenantExtras = module.get<readonly (readonly string[])[]>(EXTRA_MEMBER_RESOURCES);
+    const flat = tenantExtras.flat();
+    expect(flat).toContain("Todo");
+    expect(flat).toContain("Invoice");
     await module.close();
   });
 
   it("scopes per-user extras with $CURRENT_USER, not $CURRENT_TENANT", async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PERMISSION_STORAGE,
-          useFactory: (
-            extraTenant: readonly string[][],
-            extraUser: readonly string[][],
-          ) =>
-            new PrismaPermissionStorage(
-              fakePrismaWithMember() as unknown as ConstructorParameters<
-                typeof PrismaPermissionStorage
-              >[0],
-              {},
-              { extraTenantResources: extraTenant, extraUserResources: extraUser },
-            ),
-          inject: [
-            { token: EXTRA_MEMBER_RESOURCES, optional: true },
-            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
-          ],
-        },
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: [], multi: true },
-        {
-          provide: EXTRA_MEMBER_PER_USER_RESOURCES,
-          useValue: ["UserNote"],
-          multi: true,
-        },
-      ],
-    }).compile();
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      {},
+      { extraUserResources: [["UserNote"]] },
+    );
 
-    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const userNote = rows.find((r) => r.resource === "UserNote");
 
     expect(userNote).toBeDefined();
     expect(userNote?.itemFilter).toEqual({ userId: { _eq: "$CURRENT_USER" } });
-    await module.close();
   });
 
-  it("dedupes when two providers list the same extra (Todo appears once)", async () => {
-    const module = await Test.createTestingModule({
-      providers: [
-        {
-          provide: PERMISSION_STORAGE,
-          useFactory: (
-            extraTenant: readonly string[][],
-            extraUser: readonly string[][],
-          ) =>
-            new PrismaPermissionStorage(
-              fakePrismaWithMember() as unknown as ConstructorParameters<
-                typeof PrismaPermissionStorage
-              >[0],
-              {},
-              { extraTenantResources: extraTenant, extraUserResources: extraUser },
-            ),
-          inject: [
-            { token: EXTRA_MEMBER_RESOURCES, optional: true },
-            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
-          ],
-        },
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
-        {
-          provide: EXTRA_MEMBER_RESOURCES,
-          useValue: ["Todo", "Invoice"],
-          multi: true,
-        },
-        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
-      ],
-    }).compile();
-
-    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+  it("dedupes when two contributions list the same extra (Todo appears once)", async () => {
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      {},
+      { extraTenantResources: [["Todo"], ["Todo", "Invoice"]] },
+    );
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const todoRows = rows.filter((r) => r.resource === "Todo");
     const invoiceRows = rows.filter((r) => r.resource === "Invoice");
 
     expect(todoRows).toHaveLength(1);
     expect(invoiceRows).toHaveLength(1);
-    await module.close();
   });
 
   it("empty defaults override + empty extras → only per-user rules remain", async () => {
@@ -306,28 +202,19 @@ describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
     expect(userNote?.itemFilter).toEqual({ userId: { _eq: "$CURRENT_USER" } });
   });
 
-  it("PermissionsModule provides the EXTRA_* tokens with empty defaults (consumers don't have to provide them)", async () => {
+  it("PermissionsModule provides empty defaults for both EXTRA_* tokens — consumers don't have to provide them", async () => {
     // Smoke check: a consumer that imports PermissionsModule and never
-    // multi-provides anything still gets a working PermissionService.
-    // The defaults below (empty arrays) are what the module must emit.
-    const module = await Test.createTestingModule({
-      providers: [
-        { provide: EXTRA_MEMBER_RESOURCES, useValue: [], multi: true },
-        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
-      ],
-    }).compile();
-
-    const tenantExtras = module.get<readonly string[][]>(EXTRA_MEMBER_RESOURCES);
-    const userExtras = module.get<readonly string[][]>(EXTRA_MEMBER_PER_USER_RESOURCES);
+    // contributes via forFeature still gets working defaults. The
+    // values below are what the module emits when no project module
+    // contributes.
+    const module = await Test.createTestingModule({ imports: [PermissionsModule] }).compile();
+    const tenantExtras = module.get<readonly (readonly string[])[]>(EXTRA_MEMBER_RESOURCES);
+    const userExtras = module.get<readonly (readonly string[])[]>(EXTRA_MEMBER_PER_USER_RESOURCES);
     expect(Array.isArray(tenantExtras)).toBe(true);
     expect(Array.isArray(userExtras)).toBe(true);
-    // Each multi-provider entry is itself an array.
-    for (const entry of tenantExtras) {
-      expect(Array.isArray(entry)).toBe(true);
-    }
-    for (const entry of userExtras) {
-      expect(Array.isArray(entry)).toBe(true);
-    }
+    // No forFeature contributions yet → empty aggregated lists.
+    expect(tenantExtras.flat()).toEqual([]);
+    expect(userExtras.flat()).toEqual([]);
     await module.close();
   });
 
@@ -341,7 +228,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
         typeof PrismaPermissionStorage
       >[0],
       {},
-      { extraTenantResources: [["ZZZTodo", "AAAInvoice"]], extraUserResources: [] },
+      { extraTenantResources: [["ZZZTodo", "AAAInvoice"]] },
     );
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const tenantNames = rows
@@ -355,5 +242,58 @@ describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
     // Extras follow, stable-sorted (so two equal-input runs match).
     const extras = tenantNames.slice(DEFAULT_MEMBER_RESOURCES.length);
     expect([...extras].sort()).toEqual(extras);
+  });
+
+  it("a forFeature contribution surfaces in the synthesized rules at runtime", async () => {
+    // End-to-end: register Todo via forFeature, then call into the
+    // wired PERMISSION_STORAGE — Todo must be one of the synthesized
+    // tenant-scoped subjects.
+    @Module({
+      imports: [
+        PermissionsModule.forFeature({
+          resources: ["Todo"],
+          perUserResources: ["UserNote"],
+        }),
+      ],
+    })
+    class TodoModule {}
+
+    const module = await Test.createTestingModule({
+      imports: [PermissionsModule, TodoModule],
+    })
+      // overrideProvider so the prod PrismaService dependency is
+      // skipped — the fake storage is what we want to assert against.
+      .overrideProvider(PERMISSION_STORAGE)
+      .useFactory({
+        factory: (
+          extraTenant: readonly (readonly string[])[],
+          extraUser: readonly (readonly string[])[],
+        ): PermissionStorage =>
+          new PrismaPermissionStorage(
+            fakePrismaWithMember() as unknown as ConstructorParameters<
+              typeof PrismaPermissionStorage
+            >[0],
+            {},
+            { extraTenantResources: extraTenant, extraUserResources: extraUser },
+          ),
+        inject: [EXTRA_MEMBER_RESOURCES, EXTRA_MEMBER_PER_USER_RESOURCES],
+      })
+      .compile();
+
+    const storage = module.get<PermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const tenantSubjects = new Set(
+      rows
+        .filter((r) => r.itemFilter && "tenantId" in (r.itemFilter as Record<string, unknown>))
+        .map((r) => r.resource),
+    );
+    const userSubjects = new Set(
+      rows
+        .filter((r) => r.itemFilter && "userId" in (r.itemFilter as Record<string, unknown>))
+        .map((r) => r.resource),
+    );
+    expect(tenantSubjects.has("Todo")).toBe(true);
+    expect(userSubjects.has("UserNote")).toBe(true);
+    await module.close();
   });
 });

--- a/tests/stories/extra-member-resources.story.test.ts
+++ b/tests/stories/extra-member-resources.story.test.ts
@@ -1,0 +1,359 @@
+import { Test, type TestingModule } from "@nestjs/testing";
+import { describe, expect, it } from "vitest";
+
+import type { DbPermissionRow } from "../../src/core/permissions/db-rule-resolver.js";
+import {
+  EXTRA_MEMBER_PER_USER_RESOURCES,
+  EXTRA_MEMBER_RESOURCES,
+} from "../../src/core/permissions/extra-resources.token.js";
+import {
+  DEFAULT_MEMBER_PER_USER_RESOURCES,
+  DEFAULT_MEMBER_RESOURCES,
+} from "../../src/core/permissions/member-role-rules.js";
+import { PERMISSION_STORAGE } from "../../src/core/permissions/permission-storage.token.js";
+import { PrismaPermissionStorage } from "../../src/core/permissions/prisma-permission-storage.js";
+
+/**
+ * Story · `EXTRA_MEMBER_RESOURCES` multi-provider hook.
+ *
+ * Project modules need to grant the implicit Member role access to
+ * project-owned resources WITHOUT editing template-owned code. Two
+ * multi-provider DI tokens (`EXTRA_MEMBER_RESOURCES` for tenant-scoped
+ * subjects and `EXTRA_MEMBER_PER_USER_RESOURCES` for `$CURRENT_USER`-
+ * scoped ones) let any module flat-merge its catalogue into the
+ * synthesized rules emitted by `PrismaPermissionStorage`.
+ *
+ * The tests below exercise the storage in isolation against a fake
+ * Prisma client so we can assert exactly which rows are produced;
+ * the existing `prisma-permission-storage.story.test.ts` covers the
+ * end-to-end Postgres path with the default-only DI shape.
+ */
+
+const TEST_USER_ID = "00000000-0000-7000-8000-00000000000a";
+const TEST_TENANT_ID = "00000000-0000-7000-8000-00000000000b";
+
+interface MemberStub {
+  id: string;
+  role: string;
+}
+
+interface FakePrismaSubset {
+  tenantMember: {
+    findFirst: (args: {
+      where: { userId: string; tenantId: string; status: string };
+      select: { id: true; role: true };
+    }) => Promise<MemberStub | null>;
+  };
+  permission: {
+    findMany: (args: unknown) => Promise<unknown[]>;
+  };
+}
+
+function fakePrismaWithMember(): FakePrismaSubset {
+  return {
+    tenantMember: {
+      async findFirst() {
+        return { id: "m1", role: "member" };
+      },
+    },
+    permission: {
+      async findMany() {
+        // No explicit Role/Policy/Permission rows — only synthesized
+        // rules surface, which is exactly what we want to assert on.
+        return [];
+      },
+    },
+  };
+}
+
+/** Filter rows by resource for assertion convenience. */
+function resourceNames(rows: DbPermissionRow[]): string[] {
+  return rows.map((r) => r.resource);
+}
+
+describe("Story · EXTRA_MEMBER_RESOURCES multi-provider hook", () => {
+  it("emits ONLY DEFAULT_MEMBER_RESOURCES + DEFAULT_MEMBER_PER_USER_RESOURCES when no extras are provided", async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PERMISSION_STORAGE,
+          useFactory: (
+            extraTenant: readonly string[][],
+            extraUser: readonly string[][],
+          ) =>
+            new PrismaPermissionStorage(
+              fakePrismaWithMember() as unknown as ConstructorParameters<
+                typeof PrismaPermissionStorage
+              >[0],
+              {},
+              { extraTenantResources: extraTenant, extraUserResources: extraUser },
+            ),
+          inject: [
+            { token: EXTRA_MEMBER_RESOURCES, optional: true },
+            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
+          ],
+        },
+        {
+          provide: EXTRA_MEMBER_RESOURCES,
+          useValue: [],
+          multi: true,
+        },
+        {
+          provide: EXTRA_MEMBER_PER_USER_RESOURCES,
+          useValue: [],
+          multi: true,
+        },
+      ],
+    }).compile();
+
+    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const names = resourceNames(rows);
+
+    expect(names.sort()).toEqual(
+      [...DEFAULT_MEMBER_RESOURCES, ...DEFAULT_MEMBER_PER_USER_RESOURCES].sort(),
+    );
+    await module.close();
+  });
+
+  it("adds a tenant-scoped 'manage' rule when one provider supplies a single resource", async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PERMISSION_STORAGE,
+          useFactory: (
+            extraTenant: readonly string[][],
+            extraUser: readonly string[][],
+          ) =>
+            new PrismaPermissionStorage(
+              fakePrismaWithMember() as unknown as ConstructorParameters<
+                typeof PrismaPermissionStorage
+              >[0],
+              {},
+              { extraTenantResources: extraTenant, extraUserResources: extraUser },
+            ),
+          inject: [
+            { token: EXTRA_MEMBER_RESOURCES, optional: true },
+            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
+          ],
+        },
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
+        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
+      ],
+    }).compile();
+
+    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const todo = rows.find((r) => r.resource === "Todo");
+
+    expect(todo).toBeDefined();
+    expect(todo?.action).toBe("MANAGE");
+    expect(todo?.itemFilter).toEqual({ tenantId: { _eq: "$CURRENT_TENANT" } });
+    expect(todo?.fields).toEqual([]);
+    await module.close();
+  });
+
+  it("flat-maps multiple providers — both resources show up", async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PERMISSION_STORAGE,
+          useFactory: (
+            extraTenant: readonly string[][],
+            extraUser: readonly string[][],
+          ) =>
+            new PrismaPermissionStorage(
+              fakePrismaWithMember() as unknown as ConstructorParameters<
+                typeof PrismaPermissionStorage
+              >[0],
+              {},
+              { extraTenantResources: extraTenant, extraUserResources: extraUser },
+            ),
+          inject: [
+            { token: EXTRA_MEMBER_RESOURCES, optional: true },
+            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
+          ],
+        },
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Invoice"], multi: true },
+        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
+      ],
+    }).compile();
+
+    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const names = resourceNames(rows);
+
+    expect(names).toContain("Todo");
+    expect(names).toContain("Invoice");
+    await module.close();
+  });
+
+  it("scopes per-user extras with $CURRENT_USER, not $CURRENT_TENANT", async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PERMISSION_STORAGE,
+          useFactory: (
+            extraTenant: readonly string[][],
+            extraUser: readonly string[][],
+          ) =>
+            new PrismaPermissionStorage(
+              fakePrismaWithMember() as unknown as ConstructorParameters<
+                typeof PrismaPermissionStorage
+              >[0],
+              {},
+              { extraTenantResources: extraTenant, extraUserResources: extraUser },
+            ),
+          inject: [
+            { token: EXTRA_MEMBER_RESOURCES, optional: true },
+            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
+          ],
+        },
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: [], multi: true },
+        {
+          provide: EXTRA_MEMBER_PER_USER_RESOURCES,
+          useValue: ["UserNote"],
+          multi: true,
+        },
+      ],
+    }).compile();
+
+    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const userNote = rows.find((r) => r.resource === "UserNote");
+
+    expect(userNote).toBeDefined();
+    expect(userNote?.itemFilter).toEqual({ userId: { _eq: "$CURRENT_USER" } });
+    await module.close();
+  });
+
+  it("dedupes when two providers list the same extra (Todo appears once)", async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PERMISSION_STORAGE,
+          useFactory: (
+            extraTenant: readonly string[][],
+            extraUser: readonly string[][],
+          ) =>
+            new PrismaPermissionStorage(
+              fakePrismaWithMember() as unknown as ConstructorParameters<
+                typeof PrismaPermissionStorage
+              >[0],
+              {},
+              { extraTenantResources: extraTenant, extraUserResources: extraUser },
+            ),
+          inject: [
+            { token: EXTRA_MEMBER_RESOURCES, optional: true },
+            { token: EXTRA_MEMBER_PER_USER_RESOURCES, optional: true },
+          ],
+        },
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: ["Todo"], multi: true },
+        {
+          provide: EXTRA_MEMBER_RESOURCES,
+          useValue: ["Todo", "Invoice"],
+          multi: true,
+        },
+        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
+      ],
+    }).compile();
+
+    const storage = module.get<PrismaPermissionStorage>(PERMISSION_STORAGE);
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const todoRows = rows.filter((r) => r.resource === "Todo");
+    const invoiceRows = rows.filter((r) => r.resource === "Invoice");
+
+    expect(todoRows).toHaveLength(1);
+    expect(invoiceRows).toHaveLength(1);
+    await module.close();
+  });
+
+  it("empty defaults override + empty extras → only per-user rules remain", async () => {
+    // Defense in depth: a project that overrides resources to []
+    // should still see its perUser defaults (here also overridden to
+    // []) — and emerge with zero rules. Proves the flat-map / merge
+    // does not "rescue" extras into the wrong bucket.
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      { memberResources: [], memberPerUserResources: [] },
+      { extraTenantResources: [], extraUserResources: [] },
+    );
+
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    expect(rows).toEqual([]);
+  });
+
+  it("when the resources override is set to [], extras still merge in (no defaults)", async () => {
+    // Project test fixture pattern: override defaults to a minimal
+    // catalogue but still keep the EXTRA_* hook composable.
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      { memberResources: [], memberPerUserResources: [] },
+      { extraTenantResources: [["Todo"]], extraUserResources: [["UserNote"]] },
+    );
+
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const names = resourceNames(rows).sort();
+    expect(names).toEqual(["Todo", "UserNote"]);
+    const todo = rows.find((r) => r.resource === "Todo");
+    const userNote = rows.find((r) => r.resource === "UserNote");
+    expect(todo?.itemFilter).toEqual({ tenantId: { _eq: "$CURRENT_TENANT" } });
+    expect(userNote?.itemFilter).toEqual({ userId: { _eq: "$CURRENT_USER" } });
+  });
+
+  it("PermissionsModule provides the EXTRA_* tokens with empty defaults (consumers don't have to provide them)", async () => {
+    // Smoke check: a consumer that imports PermissionsModule and never
+    // multi-provides anything still gets a working PermissionService.
+    // The defaults below (empty arrays) are what the module must emit.
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: EXTRA_MEMBER_RESOURCES, useValue: [], multi: true },
+        { provide: EXTRA_MEMBER_PER_USER_RESOURCES, useValue: [], multi: true },
+      ],
+    }).compile();
+
+    const tenantExtras = module.get<readonly string[][]>(EXTRA_MEMBER_RESOURCES);
+    const userExtras = module.get<readonly string[][]>(EXTRA_MEMBER_PER_USER_RESOURCES);
+    expect(Array.isArray(tenantExtras)).toBe(true);
+    expect(Array.isArray(userExtras)).toBe(true);
+    // Each multi-provider entry is itself an array.
+    for (const entry of tenantExtras) {
+      expect(Array.isArray(entry)).toBe(true);
+    }
+    for (const entry of userExtras) {
+      expect(Array.isArray(entry)).toBe(true);
+    }
+    await module.close();
+  });
+
+  it("preserves insertion order: defaults first, then extras (no global alphabetical sort)", async () => {
+    // The existing `member-role-rules.story.test.ts` does NOT depend on
+    // an alphabetical order, but other CASL-rule consumers might. We
+    // pin a determinism contract here so future refactors don't shuffle
+    // the list silently.
+    const storage = new PrismaPermissionStorage(
+      fakePrismaWithMember() as unknown as ConstructorParameters<
+        typeof PrismaPermissionStorage
+      >[0],
+      {},
+      { extraTenantResources: [["ZZZTodo", "AAAInvoice"]], extraUserResources: [] },
+    );
+    const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
+    const tenantNames = rows
+      .filter((r) => r.itemFilter && "tenantId" in (r.itemFilter as Record<string, unknown>))
+      .map((r) => r.resource);
+
+    // First N entries are the verbatim DEFAULT_MEMBER_RESOURCES order.
+    expect(tenantNames.slice(0, DEFAULT_MEMBER_RESOURCES.length)).toEqual([
+      ...DEFAULT_MEMBER_RESOURCES,
+    ]);
+    // Extras follow, stable-sorted (so two equal-input runs match).
+    const extras = tenantNames.slice(DEFAULT_MEMBER_RESOURCES.length);
+    expect([...extras].sort()).toEqual(extras);
+  });
+});

--- a/tests/stories/extra-member-resources.story.test.ts
+++ b/tests/stories/extra-member-resources.story.test.ts
@@ -84,9 +84,7 @@ function resourceNames(rows: DbPermissionRow[]): string[] {
 describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
   it("emits ONLY DEFAULT_MEMBER_RESOURCES + DEFAULT_MEMBER_PER_USER_RESOURCES when no extras are provided", async () => {
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
     );
     const rows = await storage.findRulesForUser(TEST_USER_ID, TEST_TENANT_ID);
     const names = resourceNames(rows);
@@ -98,9 +96,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
 
   it("adds a tenant-scoped 'manage' rule when one extra resource is provided", async () => {
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       {},
       { extraTenantResources: [["Todo"]] },
     );
@@ -135,9 +131,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
 
   it("scopes per-user extras with $CURRENT_USER, not $CURRENT_TENANT", async () => {
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       {},
       { extraUserResources: [["UserNote"]] },
     );
@@ -151,9 +145,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
 
   it("dedupes when two contributions list the same extra (Todo appears once)", async () => {
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       {},
       { extraTenantResources: [["Todo"], ["Todo", "Invoice"]] },
     );
@@ -171,9 +163,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
     // []) — and emerge with zero rules. Proves the flat-map / merge
     // does not "rescue" extras into the wrong bucket.
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       { memberResources: [], memberPerUserResources: [] },
       { extraTenantResources: [], extraUserResources: [] },
     );
@@ -186,9 +176,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
     // Project test fixture pattern: override defaults to a minimal
     // catalogue but still keep the EXTRA_* hook composable.
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       { memberResources: [], memberPerUserResources: [] },
       { extraTenantResources: [["Todo"]], extraUserResources: [["UserNote"]] },
     );
@@ -224,9 +212,7 @@ describe("Story · EXTRA_MEMBER_RESOURCES project-extension hook", () => {
     // pin a determinism contract here so future refactors don't shuffle
     // the list silently.
     const storage = new PrismaPermissionStorage(
-      fakePrismaWithMember() as unknown as ConstructorParameters<
-        typeof PrismaPermissionStorage
-      >[0],
+      fakePrismaWithMember() as unknown as ConstructorParameters<typeof PrismaPermissionStorage>[0],
       {},
       { extraTenantResources: [["ZZZTodo", "AAAInvoice"]] },
     );


### PR DESCRIPTION
## Motivation

LLM-test 2026-05-03 surfaced friction #8 (high severity):
`DEFAULT_MEMBER_RESOURCES` lives in template-owned code with no
project-extension hook. Every new project resource that a Member
should be able to CRUD forces an `src/core/` edit, which collides on
`bun run sync:from-template`.

This PR adds a project-extension hook so projects can extend the
synthesized "Member" role catalog WITHOUT editing template-owned
code (sync-from-template stays clean).

## What changed

- **New file** `src/core/permissions/extra-resources.token.ts`
  exports two DI tokens (`EXTRA_MEMBER_RESOURCES`,
  `EXTRA_MEMBER_PER_USER_RESOURCES`) and the
  `MemberResourceContribution` shape consumed by `forFeature`.
- **`PermissionsModule`** now exposes a `forFeature({ resources,
  perUserResources })` static method. Each call registers a
  uniquely-keyed Symbol provider so multiple modules can contribute
  independently. A `DiscoveryService`-backed aggregator collects
  them at storage-factory time and flat-maps + dedupes before
  passing them into the rule planner.
- **`PrismaPermissionStorage`** accepts the aggregated extras as a
  new (third) constructor argument
  (`PrismaPermissionStorageExtras`). Defaults retain their authored
  order; extras append, stable-sorted so caching stays
  deterministic across runs.
- **`buildMemberRoleRules`** is unchanged — its existing
  `resources` / `perUserResources` overrides are still
  backwards-compatible.
- **Skill update** — `.claude/skills/adding-feature-module.md`
  gains a new "Step 8 — Grant member access to the new resource"
  describing both shapes (the `forFeature` per-module path and the
  AppModule-level single override).

### Sample provider snippet from the skill

```ts
import { PermissionsModule } from "../../core/permissions/permissions.module.js";

@Module({
  imports: [
    PermissionsModule.forFeature({ resources: ["Todo"] }),
    // ...
  ],
})
export class TodoModule {}
```

For per-user resources (like API keys — bound to the user across
tenants):

```ts
PermissionsModule.forFeature({ perUserResources: ["UserNote"] }),
```

### Why a `forFeature` helper instead of `multi: true`

NestJS's DI container does not aggregate `multi: true`
registrations of the same token (last-wins, unlike Angular). The
`forFeature` helper plus `DiscoveryService` aggregator is the
Nest-idiomatic equivalent of Angular's multi-provider pattern.

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run test:types` — passes
- [x] `bun run test:unit` — 174/174 passes
- [x] `bun run test:e2e` — 2772 passes (one unrelated email-builder
  ECONNRESET flake on first run, green on re-run)
- [x] `bun run test:coverage` — passes thresholds; src/core 92.65%
  lines, core/permissions 93.39% lines
- [x] `bun run build` — passes
- [x] New story `tests/stories/extra-member-resources.story.test.ts`
  covers: zero-provider default, single + multi `forFeature`
  contributions, `$CURRENT_USER` scope for per-user extras, dedupe
  across providers, empty-defaults override, insertion-order
  determinism, end-to-end synthesized rules surfacing the
  contribution
- [x] Existing `member-role-rules.story.test.ts` and
  `prisma-permission-storage.story.test.ts` pass unchanged (no
  behaviour regression on the override path)