### PR TITLE
fix(http): allow http://localhost:3001 in dev CORS defaults so the template frontend talks to its own API

### DIFF
--- a/src/core/http/cookie-cors-config.ts
+++ b/src/core/http/cookie-cors-config.ts
@@ -62,6 +62,10 @@ export function corsDefaults(env: AppEnv): CorsConfig {
     return {
       allowedOrigins: [
         "http://localhost:3000",
+        // Default Nuxt dev port for the lt fullstack template's
+        // `projects/app/` frontend — keeps a freshly-scaffolded SPA able
+        // to call its own API without a proxy workaround.
+        "http://localhost:3001",
         "http://localhost:5173",
         "http://app.nst.localhost",
       ],

--- a/tests/cookies-cors-config.spec.ts
+++ b/tests/cookies-cors-config.spec.ts
@@ -100,6 +100,15 @@ describe("Cookie & CORS Config", () => {
       expect(cfg.allowedOrigins.some((origin) => origin.includes("localhost"))).toBe(true);
     });
 
+    it('corsDefaults("development") includes http://localhost:3001 (template frontend port)', () => {
+      // The lt fullstack template's Nuxt frontend runs on :3001 by default
+      // (see projects/app/nuxt.config.ts devServer.port). Without this entry
+      // the freshly-scaffolded SPA cannot call its own API in the browser
+      // due to CORS preflight failure.
+      const cfg = corsDefaults("development");
+      expect(cfg.allowedOrigins).toContain("http://localhost:3001");
+    });
+
     it('corsDefaults("production") returns no origins (must be configured explicitly)', () => {
       const cfg = corsDefaults("production");
       expect(cfg.allowedOrigins).toEqual([]);


### PR DESCRIPTION
## Summary

- The lt fullstack template's Nuxt frontend (`projects/app/`) runs on **port 3001** by default — `projects/app/nuxt.config.ts` `devServer.port`, mirrored in `.claude/QUICKSTART.md`. But `corsDefaults('development')` in `src/core/http/cookie-cors-config.ts` only listed `:3000`, `:5173`, and `app.nst.localhost`.
- A freshly-scaffolded fullstack workspace therefore tripped a CORS preflight failure on every browser-side call from the SPA to the API. Workaround was to edit the defaults or proxy through `:3000`.
- Added `http://localhost:3001` to the development allowlist. Production/staging behaviour is unchanged.

## Friction log

LLM-test 2026-05-03 #2 (high) — friction #2: "API CORS dev defaults missing template frontend port `:3001`".

## Test plan

- [x] RED-first: extended `tests/cookies-cors-config.spec.ts` with `it('corsDefaults("development") includes http://localhost:3001 ...')`. Verified failing on the unchanged file.
- [x] GREEN: added `'http://localhost:3001'` to the dev `allowedOrigins` array. Re-ran the spec.
- [x] All six gates locally:
  - [x] `bun run lint` — 0 errors / 0 warnings
  - [x] `bun run test:unit` — 174/174
  - [x] `bun run test:e2e` — 2788/2788 (after `bun run prepare:schema && bun run prisma:generate` per repo convention)
  - [x] `bun run test:types` — clean
  - [x] `bun run test:coverage` — thresholds held (`src/core/` ≥ 90%)
  - [x] `bun run build` — dev-portal + server bundle
- [ ] CI green (will watch on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)