### PR TITLE
feat(prisma): CI gate fails when a tenant-scoped Prisma model has no RLS-enabling migration

### DIFF
--- a/.claude/skills/adding-feature-module.md
+++ b/.claude/skills/adding-feature-module.md
@@ -265,6 +265,16 @@ CREATE POLICY "tenant_isolation" ON "<plural_snake_case>"
 `PrismaService.runWithRlsTenant(fn, tenantId)` (used by every service
 method below) does the `SET LOCAL` so the policy fires.
 
+`bunx prisma migrate dev` does NOT generate the `ENABLE ROW LEVEL
+SECURITY` clause for you — the CI gate `bun run check:rls` walks
+every tenant-scoped model and fails when no RLS-enabling migration
+exists. Run it locally after `prisma migrate dev` to catch a missed
+sibling migration before pushing:
+
+```bash
+bun run check:rls   # exits 1 + lists offenders if any
+```
+
 ## Step 3 — DTOs
 
 Zod schemas as the single source of truth — runtime validation, type

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Lint
         run: bun run lint
+      # Tenant-scoped models (those with a `tenantId` column) MUST be paired
+      # with an `ENABLE ROW LEVEL SECURITY` migration — otherwise the whole
+      # multi-tenant isolation contract is silently bypassed. The audit is
+      # cheap (no DB / no Nest bootstrap), so it lives in the lint job
+      # rather than as its own ~30s checkout-and-install pipeline.
+      - name: RLS coverage audit
+        run: bun run check:rls
 
   format:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prisma:migrate": "prisma migrate deploy",
     "postinstall": "bun run scripts/postinstall-prisma-symlink.ts",
     "prepare:schema": "bun run scripts/prepare-schema.ts",
+    "check:rls": "bun run scripts/check-rls.ts",
     "doctor": "bun run scripts/doctor.ts",
     "onboard": "bun run scripts/onboard.ts",
     "rename": "bun run scripts/rename-project.ts",

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -124,6 +124,23 @@ Commit the schema diff + the generated SQL migration together.
 It's a build artifact. Treat it as read-only output of
 `prepare:schema`.
 
+## RLS coverage is enforced in CI
+
+Tenant-scoped models (any model with a `tenantId` field) MUST be paired
+with a migration that enables Postgres RLS on the resolved table —
+`ALTER TABLE "<table>" ENABLE ROW LEVEL SECURITY;` plus a
+`CREATE POLICY` matching `tenant_id = current_setting('app.tenant_id')`.
+See `prisma/migrations/20260428000150_rls_tenant_isolation_extended/`
+for the canonical shape.
+
+The CI gate `bun run check:rls` (planner:
+`src/core/permissions/rls-audit-planner.ts`, runner:
+`scripts/check-rls.ts`) walks every model + every migration and fails
+when a tenant-scoped model has no RLS-enabling migration anywhere in
+the tree. Run it locally before commit; the lint job runs it on every
+PR. There's no auto-fix — RLS is a load-bearing security layer, opt-in
+per table is the safer default.
+
 ## Migrations are forward-only
 
 Per `docs/api-stability-promise.md`, we don't rewrite history of an

--- a/scripts/check-rls.ts
+++ b/scripts/check-rls.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * `bun run check:rls` — fails when a tenant-scoped Prisma model has
+ * no `ENABLE ROW LEVEL SECURITY` migration anywhere in the tree.
+ *
+ * Tenant isolation in this template rests on Postgres RLS — every
+ * `runWithRlsTenant` wrapper, every `tenant_isolation_<table>`
+ * policy, every `@Can(...)` permission rule assumes RLS is on for
+ * tenant-scoped tables. But `bunx prisma migrate dev` does NOT emit
+ * `ALTER TABLE … ENABLE ROW LEVEL SECURITY` for a new model with a
+ * `tenantId` column — so a forgotten manual migration ships a
+ * tenant-leaky table without warning.
+ *
+ * This runner is deliberately a separate CI gate (not a Prisma plugin
+ * / migrate hook): the audit lives next to `bun run test:e2e`, runs
+ * in CI exactly once per push, and surfaces with an actionable error
+ * message. Wrapping `prisma migrate dev` would need a custom Prisma
+ * plugin trampoline + a `postinstall` shim to make the hook
+ * discoverable for everyone — too much surface area for a single
+ * lint rule.
+ *
+ * The runner is the thin I/O layer. The pure planner
+ * (`auditRlsCoverage`) is exhaustively unit-tested in
+ * `tests/stories/rls-audit-planner.story.test.ts`.
+ *
+ * Exit code:
+ *   - 0 — no findings (clean).
+ *   - 1 — one or more tenant-scoped models lack an RLS migration.
+ *   - 2 — runner failure (missing schema / migrations dir / read err).
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  type RlsAuditFinding,
+  auditRlsCoverage,
+} from "../src/core/permissions/rls-audit-planner.js";
+
+const ROOT = process.cwd();
+const PRISMA_DIR = resolve(ROOT, "prisma");
+const SCHEMA_PATH = resolve(PRISMA_DIR, "schema.prisma");
+const GENERATED_SCHEMA_PATH = resolve(PRISMA_DIR, "schema.generated.prisma");
+const MIGRATIONS_DIR = resolve(PRISMA_DIR, "migrations");
+
+function fail(message: string, code = 2): never {
+  console.error(`[check:rls] ${message}`);
+  process.exit(code);
+}
+
+if (!existsSync(SCHEMA_PATH)) {
+  fail(`missing schema at ${SCHEMA_PATH}`);
+}
+if (!existsSync(MIGRATIONS_DIR)) {
+  fail(`missing migrations directory at ${MIGRATIONS_DIR}`);
+}
+
+// Prefer the merged feature schema if it has been written by
+// `prepare:schema` — that's what `prisma migrate` actually consumes.
+// Fall back to the core schema if not.
+const schemaSource = existsSync(GENERATED_SCHEMA_PATH)
+  ? readFileSync(GENERATED_SCHEMA_PATH, "utf8")
+  : readFileSync(SCHEMA_PATH, "utf8");
+
+const migrations: { name: string; sql: string }[] = [];
+for (const entry of readdirSync(MIGRATIONS_DIR)) {
+  const dir = resolve(MIGRATIONS_DIR, entry);
+  if (!statSync(dir).isDirectory()) continue;
+  const sqlPath = resolve(dir, "migration.sql");
+  if (!existsSync(sqlPath)) continue;
+  migrations.push({ name: entry, sql: readFileSync(sqlPath, "utf8") });
+}
+
+const findings: RlsAuditFinding[] = auditRlsCoverage({ schemaSource, migrations });
+
+// Count tenant-scoped models for an informative success line. Every
+// model that the planner reports against an empty-migrations input is
+// tenant-scoped (each one is "uncovered"); subtract nothing — that's
+// the canonical count regardless of how many were covered this run.
+const tenantScopedCount = auditRlsCoverage({ schemaSource, migrations: [] }).length;
+
+if (findings.length === 0) {
+  console.log(
+    `[check:rls] clean (${tenantScopedCount} tenant-scoped model(s), ${migrations.length} migration(s) scanned)`,
+  );
+  process.exit(0);
+}
+
+console.error(
+  `[check:rls] ${findings.length} tenant-scoped model(s) lack an ENABLE ROW LEVEL SECURITY migration:`,
+);
+for (const f of findings) {
+  console.error(
+    `  - RLS missing: ${f.model} (table: ${f.table}) — add ENABLE ROW LEVEL SECURITY migration`,
+  );
+}
+console.error("");
+console.error(
+  "Fix: create a migration that runs `ALTER TABLE \"<table>\" ENABLE ROW LEVEL SECURITY;`",
+);
+console.error("plus a `CREATE POLICY` matching tenant_id = current_setting('app.tenant_id').");
+console.error("See prisma/migrations/20260428000150_rls_tenant_isolation_extended/ for the shape.");
+process.exit(1);

--- a/src/core/permissions/rls-audit-planner.ts
+++ b/src/core/permissions/rls-audit-planner.ts
@@ -1,0 +1,222 @@
+/**
+ * Pure planner for the RLS-coverage audit (LLM-test 2026-05-03 #3).
+ *
+ * Tenant isolation is the load-bearing guarantee of this template's
+ * multi-tenant stack — every layer above (CASL abilities, the
+ * `runWithRlsTenant` wrapper, the `tenant_isolation_<table>` policies)
+ * assumes Postgres RLS is on for every tenant-scoped table.
+ *
+ * The friction: `bunx prisma migrate dev` will happily emit a
+ * `CREATE TABLE` for a tenant-scoped model WITHOUT a sibling
+ * `ALTER TABLE … ENABLE ROW LEVEL SECURITY`. Nothing fails, no
+ * warning, the new table is wide open.
+ *
+ * This planner closes that gap. Given the merged Prisma schema source
+ * and the migrations on disk, it returns one finding per tenant-
+ * scoped model that has no RLS-enabling migration anywhere in the
+ * tree. The runner half (`scripts/check-rls.ts`) wires the file I/O
+ * and exits non-zero on findings — so the gate fails CI before a
+ * tenant-leaky migration ships.
+ *
+ * The planner stays a pure function on purpose:
+ *   - Re-runnable in tests with synthetic schemas + migrations,
+ *   - No coupling to Prisma's runtime / migration engine,
+ *   - Easy to extend (e.g. detect missing CREATE POLICY rows).
+ *
+ * Heuristics are intentionally narrow:
+ *   - "Tenant-scoped" = the model block declares a `tenantId` field
+ *     (any case for the leading `t`, must be a real field declaration
+ *     — `tenantId String …`. SQL-style `tenant_id` references in
+ *     `// comments` do NOT count).
+ *   - "Has RLS migration" = at least one migration's SQL contains a
+ *     case-insensitive, whitespace-tolerant
+ *     `ALTER TABLE [<schema>.]<table-name> ENABLE ROW LEVEL SECURITY`
+ *     for the model's resolved Postgres table (camel-to-snake or
+ *     `@@map("…")` override).
+ */
+
+export interface RlsAuditPlannerInput {
+  /** Full text of the Prisma schema (or merged feature schema). */
+  schemaSource: string;
+  /** Each migration as `{ name, sql }`. Order is irrelevant. */
+  migrations: ReadonlyArray<{ name: string; sql: string }>;
+}
+
+export interface RlsAuditFinding {
+  /** PascalCase Prisma model name. */
+  model: string;
+  /** Resolved Postgres table name (`@@map` if present, else snake_case(model)). */
+  table: string;
+  /** Number of migrations the planner scanned for this finding. */
+  migrationsScanned: number;
+}
+
+/**
+ * Inspect every model in `schemaSource`. For each model that declares
+ * a `tenantId` field (i.e. is tenant-scoped), check whether any
+ * migration's SQL enables RLS on the resolved table. Return one
+ * finding per uncovered model.
+ */
+export function auditRlsCoverage(input: RlsAuditPlannerInput): RlsAuditFinding[] {
+  const models = parseModels(input.schemaSource);
+  const tenantScoped = models.filter((m) => m.hasTenantIdField);
+  const findings: RlsAuditFinding[] = [];
+  for (const model of tenantScoped) {
+    const covered = input.migrations.some((mig) => migrationEnablesRls(mig.sql, model.table));
+    if (!covered) {
+      findings.push({
+        model: model.name,
+        table: model.table,
+        migrationsScanned: input.migrations.length,
+      });
+    }
+  }
+  return findings;
+}
+
+// ─── Schema parsing ─────────────────────────────────────────────────
+
+interface ParsedModel {
+  name: string;
+  /** Resolved Postgres table name (after applying `@@map`). */
+  table: string;
+  /** Does the model block declare a `tenantId` field? */
+  hasTenantIdField: boolean;
+}
+
+/**
+ * Walk every `model <Name> { … }` block in the schema source and
+ * collect: the PascalCase model name, the resolved table name (via
+ * `@@map("…")` if present, else `snake_case(name)`), and whether the
+ * block contains a `tenantId` field declaration.
+ *
+ * The parser is regex-driven on purpose — Prisma's schema grammar is
+ * simple enough for a hand-written walker, and dragging `@prisma/sdk`
+ * (or shelling out to `prisma format`) into a CI gate would be
+ * disproportionate. The planner only cares about three things per
+ * model: the name, the `@@map`, and whether `tenantId` shows up.
+ */
+function parseModels(source: string): ParsedModel[] {
+  const stripped = stripCommentsForFieldScan(source);
+  const models: ParsedModel[] = [];
+  const modelRegex = /\bmodel\s+(\w+)\s*\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = modelRegex.exec(stripped)) !== null) {
+    const name = match[1];
+    if (!name) continue;
+    const braceOpen = match.index + match[0].length - 1;
+    const braceClose = matchClosingBrace(stripped, braceOpen);
+    if (braceClose < 0) continue;
+    const body = stripped.slice(braceOpen + 1, braceClose);
+
+    models.push({
+      name,
+      table: resolveTableName(name, body),
+      hasTenantIdField: hasTenantIdFieldDeclaration(body),
+    });
+
+    // Skip past the model body so nested `{}` (rare but legal in
+    // attribute arguments) cannot confuse the next iteration.
+    modelRegex.lastIndex = braceClose + 1;
+  }
+  return models;
+}
+
+/**
+ * Remove `//` line comments and `/* … *\/` block comments from the
+ * source so that field-scan heuristics (e.g. `tenantId`) can't be
+ * tricked by commented-out text. Preserves newlines so line numbers
+ * (if ever added to findings) stay aligned.
+ */
+function stripCommentsForFieldScan(source: string): string {
+  // Block comments first — replace with whitespace of equal length so
+  // offsets stay roughly in sync with the original.
+  let out = source.replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "));
+  // Line comments next.
+  out = out.replace(/\/\/[^\n]*/g, (m) => " ".repeat(m.length));
+  return out;
+}
+
+function resolveTableName(modelName: string, body: string): string {
+  const mapMatch = /@@map\s*\(\s*["']([^"']+)["']\s*\)/.exec(body);
+  if (mapMatch?.[1]) return mapMatch[1];
+  return pascalToSnake(modelName);
+}
+
+/**
+ * `tenantId` is a Prisma field declaration of the form
+ * `tenantId   String   @map("tenant_id") @db.Uuid`. Match that, and
+ * only that — never an `@@index([tenantId])` or a SQL-style
+ * `tenant_id` reference inside an attribute argument.
+ */
+function hasTenantIdFieldDeclaration(body: string): boolean {
+  // Walk line-by-line. A field declaration starts with the field name
+  // at the beginning of a line (modulo leading whitespace) and the
+  // next token is the type. We only care that `tenantId` appears as
+  // such an identifier.
+  const lines = body.split("\n");
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith("@@")) continue; // model-level attribute.
+    // Pull the first identifier token.
+    const tokenMatch = /^([A-Za-z_][A-Za-z0-9_]*)/.exec(line);
+    if (!tokenMatch) continue;
+    if (tokenMatch[1] === "tenantId") return true;
+  }
+  return false;
+}
+
+function pascalToSnake(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase();
+}
+
+function matchClosingBrace(source: string, openIndex: number): number {
+  let depth = 0;
+  for (let i = openIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+// ─── Migration scanning ─────────────────────────────────────────────
+
+/**
+ * Does `sql` enable RLS on `table`?
+ *
+ * The check is whitespace + quoting + case tolerant: `ALTER TABLE`
+ * with any internal whitespace, the table name with or without
+ * double-quotes (and optionally schema-qualified `public.<table>`),
+ * any whitespace, then `ENABLE ROW LEVEL SECURITY`. Comments don't
+ * count — we strip `--` line comments before searching.
+ */
+function migrationEnablesRls(sql: string, table: string): boolean {
+  const stripped = stripSqlComments(sql);
+  // Build a tolerant regex: optional schema, optional quoting, the
+  // table name, then the keyword sequence with arbitrary whitespace.
+  const tableEsc = escapeRegex(table);
+  const re = new RegExp(
+    String.raw`alter\s+table\s+(?:"?[A-Za-z_][A-Za-z0-9_]*"?\s*\.\s*)?"?` +
+      tableEsc +
+      String.raw`"?\s+enable\s+row\s+level\s+security\b`,
+    "i",
+  );
+  return re.test(stripped);
+}
+
+function stripSqlComments(sql: string): string {
+  // `--` to end-of-line.
+  let out = sql.replace(/--[^\n]*/g, "");
+  // `/* … */` block.
+  out = out.replace(/\/\*[\s\S]*?\*\//g, "");
+  return out;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/stories/rls-audit-planner.story.test.ts
+++ b/tests/stories/rls-audit-planner.story.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import { auditRlsCoverage } from "../../src/core/permissions/rls-audit-planner.js";
+
+/**
+ * Story · RLS-coverage audit planner.
+ *
+ * Pure planner that, given the merged Prisma schema source and the
+ * collected migrations (`{ name, sql }[]`), reports every tenant-
+ * scoped model (i.e. every model whose block declares a `tenantId`
+ * field) that lacks a `ALTER TABLE … ENABLE ROW LEVEL SECURITY`
+ * migration anywhere in the migration tree.
+ *
+ * Tenant isolation is the load-bearing guarantee of the multi-tenant
+ * stack — the CASL ability layer treats RLS as the last line of
+ * defense, and `bunx prisma migrate dev` will happily emit a
+ * `CREATE TABLE` for a tenant-scoped model without the matching
+ * `ENABLE ROW LEVEL SECURITY`. The planner closes that gap so a CI
+ * gate can fail fast before such a migration ships.
+ *
+ * The planner is a pure function (string + structured input → list
+ * of findings). The runner half lives in `scripts/check-rls.ts` and
+ * does the I/O.
+ */
+describe("Story · RLS-audit planner — auditRlsCoverage", () => {
+  it("flags a single tenant-scoped model with no RLS migration", () => {
+    const schemaSource = `
+      model Todo {
+        id        String @id
+        tenantId  String @map("tenant_id")
+        title     String
+        @@map("todos")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101000000_init",
+          sql: 'CREATE TABLE "todos" ("id" UUID NOT NULL, "tenant_id" UUID NOT NULL);',
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      model: "Todo",
+      table: "todos",
+      migrationsScanned: 1,
+    });
+  });
+
+  it("returns no findings when the tenant-scoped model has an RLS-enabling migration", () => {
+    const schemaSource = `
+      model Todo {
+        id        String @id
+        tenantId  String @map("tenant_id")
+        @@map("todos")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101000000_init",
+          sql: 'CREATE TABLE "todos" ("id" UUID NOT NULL);',
+        },
+        {
+          name: "20260101000010_rls",
+          sql: 'ALTER TABLE "todos" ENABLE ROW LEVEL SECURITY;',
+        },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("ignores non-tenant-scoped models in a mixed schema", () => {
+    const schemaSource = `
+      model HealthPing {
+        id        String @id
+        createdAt DateTime
+        @@map("_health_ping")
+      }
+      model Tenant {
+        id   String @id
+        name String
+        @@map("tenants")
+      }
+      model Todo {
+        id       String @id
+        tenantId String @map("tenant_id")
+        @@map("todos")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_init",
+          sql: 'ALTER TABLE "todos" ENABLE ROW LEVEL SECURITY;',
+        },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("flags the only tenant-scoped model in a mixed schema when RLS is missing", () => {
+    const schemaSource = `
+      model HealthPing { id String @id }
+      model Tenant     { id String @id name String }
+      model Todo {
+        id       String @id
+        tenantId String @map("tenant_id")
+        @@map("todos")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_init",
+          sql: 'CREATE TABLE "todos" ("id" UUID NOT NULL);',
+        },
+      ],
+    });
+    expect(findings.map((f) => f.model)).toEqual(["Todo"]);
+  });
+
+  it("uses @@map to resolve the table name when scanning migrations", () => {
+    const schemaSource = `
+      model Invoice {
+        id       String @id
+        tenantId String @map("tenant_id")
+        @@map("custom_invoices")
+      }
+    `;
+    const withRls = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_rls",
+          sql: 'ALTER TABLE "custom_invoices" ENABLE ROW LEVEL SECURITY;',
+        },
+      ],
+    });
+    expect(withRls).toHaveLength(0);
+
+    // Same model, but the migration only mentions the camel-derived
+    // snake_case `invoices` (the planner must NOT silently accept that —
+    // the @@map override is the canonical table name).
+    const withWrongTable = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_rls",
+          sql: 'ALTER TABLE "invoices" ENABLE ROW LEVEL SECURITY;',
+        },
+      ],
+    });
+    expect(withWrongTable).toHaveLength(1);
+    expect(withWrongTable[0]).toMatchObject({
+      model: "Invoice",
+      table: "custom_invoices",
+    });
+  });
+
+  it("ignores `tenant_id` mentions in SQL comments — only ALTER TABLE … ENABLE RLS counts", () => {
+    const schemaSource = `
+      model Todo {
+        id       String @id
+        tenantId String @map("tenant_id")
+        @@map("todos")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_init",
+          sql: [
+            "-- todo: enable RLS on todos.tenant_id later",
+            '-- ALTER TABLE "todos" ENABLE ROW LEVEL SECURITY; (commented out)',
+            'CREATE TABLE "todos" ("id" UUID NOT NULL, "tenant_id" UUID NOT NULL);',
+          ].join("\n"),
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.model).toBe("Todo");
+  });
+
+  it("returns an empty list when the schema has no models", () => {
+    const findings = auditRlsCoverage({
+      schemaSource: "// just a banner comment\n",
+      migrations: [],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("returns an empty list when the schema has no tenant-scoped models", () => {
+    const schemaSource = `
+      model HealthPing {
+        id        String @id
+        createdAt DateTime
+        @@map("_health_ping")
+      }
+      model Tenant {
+        id   String @id
+        name String
+        @@map("tenants")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [{ name: "20260101_init", sql: "-- nothing" }],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("matches the ALTER TABLE …ENABLE RLS regardless of whitespace and quoting", () => {
+    const schemaSource = `
+      model Todo {
+        id       String @id
+        tenantId String @map("tenant_id")
+        @@map("todos")
+      }
+    `;
+    // Unquoted table name + multiple spaces + lower-case keywords — the
+    // planner should still recognise this as the canonical RLS opt-in.
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [
+        {
+          name: "20260101_rls",
+          sql: "alter   table  todos   enable   row   level   security ;",
+        },
+      ],
+    });
+    expect(findings).toHaveLength(0);
+  });
+
+  it("does not register `tenant_id` in a comment line inside a model block as a tenant-scope signal", () => {
+    // A model that *talks about* tenant_id in a `//` comment but does not
+    // actually declare a `tenantId` field is NOT tenant-scoped and must
+    // not trigger a finding even when no RLS migration exists.
+    const schemaSource = `
+      model AuditLog {
+        id String @id
+        // tenant_id intentionally omitted — audit logs are global.
+        message String
+        @@map("audit_logs")
+      }
+    `;
+    const findings = auditRlsCoverage({
+      schemaSource,
+      migrations: [],
+    });
+    expect(findings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the third high-severity friction from the **LLM-test 2026-05-03** run:
`bunx prisma migrate dev` emits a `CREATE TABLE` for a tenant-scoped Prisma
model (one with a `tenantId` column) **without** an `ALTER TABLE … ENABLE
ROW LEVEL SECURITY` clause, and nothing in the toolchain warns. The whole
multi-tenant promise — `runWithRlsTenant`, the `tenant_isolation_<table>`
policies, the `@Can(...)` ability rules — collapses the moment a single
forgotten migration ships a tenant-leaky table.

This PR adds a CI gate that fails fast when that happens:

- **Pure planner** `src/core/permissions/rls-audit-planner.ts`:
  `auditRlsCoverage({ schemaSource, migrations })` walks every Prisma
  model block, classifies the ones with a `tenantId` field as tenant-
  scoped, resolves the Postgres table name (`@@map(...)` override or
  `snake_case(modelName)`), and reports each model whose table is
  missing a whitespace/quote/case-tolerant `ALTER TABLE … ENABLE ROW
  LEVEL SECURITY` in any migration. SQL `--` and `/* */` comments
  are stripped before matching so commented-out RLS clauses can't
  silence the gate.
- **10 RED-first story tests** in
  `tests/stories/rls-audit-planner.story.test.ts` covering: missing
  RLS, present RLS, `@@map` overrides (incl. wrong-table fallback),
  comment-only `tenant_id` mentions, whitespace tolerance, empty
  schemas, no-tenant-scope schemas.
- **Thin runner** `scripts/check-rls.ts` — reads `prisma/schema.prisma`
  (or the merged `schema.generated.prisma` after `prepare:schema`),
  iterates `prisma/migrations/*/migration.sql`, calls the planner,
  exits 1 with an actionable per-finding line on issues / 0 on clean.
- **`package.json`** exposes `bun run check:rls`.
- **`.github/workflows/ci.yml`** runs `check:rls` inside the existing
  `lint` job (no new pipeline job — the audit needs no DB / build /
  Prisma generate, so it would just bloat CI to give it its own).
- **Docs**: `prisma/CLAUDE.md` gets a "RLS coverage is enforced in CI"
  section; the `adding-feature-module` skill picks up a one-liner
  pointing module authors at `bun run check:rls` after `prisma
  migrate dev`.

### Why a CI gate over a Prisma migrate hook

Hooking into `prisma migrate dev` would need a custom Prisma plugin
trampoline + a `postinstall` shim to make the hook discoverable for
every consumer of the template. A standalone audit:

- Lives next to the existing `bun run test:e2e` story tests.
- Is one CI job step (no new pipeline) — runs in ~50ms.
- Surfaces the failure in the place CI reviewers already look.
- Has no runtime coupling to Prisma's migration engine, so it keeps
  working across Prisma 7 → 8 upgrades.

The pure-planner / thin-runner split also means the entire contract
is exercised by 10 in-memory unit tests with synthetic schemas — no
DB, no migrations dir, no I/O.

### Reproduction (the gate trips on the offence)

```bash
$ bun run check:rls                                       # main, clean
[check:rls] clean (9 tenant-scoped model(s), 8 migration(s) scanned)

$ mv prisma/migrations/20260428000150_rls_tenant_isolation_extended /tmp/_b
$ bun run check:rls                                       # exit 1
[check:rls] 7 tenant-scoped model(s) lack an ENABLE ROW LEVEL SECURITY migration:
  - RLS missing: TenantMember (table: tenant_members) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: FileBlob (table: file_blobs) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: Folder (table: folders) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: File (table: files) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: WebhookEndpoint (table: webhook_endpoints) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: Example (table: examples) — add ENABLE ROW LEVEL SECURITY migration
  - RLS missing: UserProfile (table: user_profiles) — add ENABLE ROW LEVEL SECURITY migration
```

`main` was already RLS-clean (9 tenant-scoped models, all covered by
`20260428000100_rls_tenant_isolation` and the extended sibling) — no
real RLS gap to escalate. The gate is purely forward-looking.

### No auto-fix

`check:rls` deliberately does NOT generate a fix migration. RLS is a
load-bearing security layer; opt-in per table is the safer default,
and an irreversible DB change ought to be the human's deliberate
decision. The runner prints the canonical migration shape and points
at `20260428000150_rls_tenant_isolation_extended/` as the worked
example.

## Test plan

- [x] RED → GREEN: `bun run test:e2e tests/stories/rls-audit-planner.story.test.ts` — 10/10 pass after planner ships
- [x] `bun run check:rls` exits 0 on `main`
- [x] Removing an RLS migration locally → `check:rls` exits 1 + lists 7 offenders → restoring → exits 0 again
- [x] `bun run lint` clean
- [x] `bun run format` clean
- [x] `bun run test:types` clean
- [x] `bun run test:unit` — 174/174 pass
- [x] `bun run test:e2e` — 2797/2797 pass
- [x] `bun run test:coverage` — 90.5% statements / 92.7% lines / 93.96% functions; new planner is at 98.11% line coverage
- [x] `bun run build` clean
- [ ] CI: all required jobs green (the lint job picks up `check:rls` automatically; coverage threshold guards the new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)