### PR TITLE
fix(testing): APP_FILTER auto-registration + fake-prisma null/undefined normalization + RED-first scaffold

### DIFF
--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -1,6 +1,8 @@
 import { type MiddlewareConsumer, Module, type NestModule } from "@nestjs/common";
-import { APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
+
+import { ProblemDetailsExceptionFilter } from "../errors/problem-details.filter.js";
 
 import { AuditLogModule } from "../audit/audit-log.module.js";
 import { ApiKeyModule } from "../auth/api-keys/api-key.module.js";
@@ -120,6 +122,16 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
   providers: [
     RequestContextMiddleware,
     BetterAuthSessionMiddleware,
+    // RFC 7807 Problem-Details exception filter — registered via
+    // APP_FILTER so it activates for BOTH the production
+    // `bootstrap()` chain AND tests booted through
+    // `Test.createTestingModule({ imports: [AppModule] })
+    //   .createNestApplication()`. Previously the filter was only
+    // attached imperatively in `bootstrap.ts` via
+    // `app.useGlobalFilters(...)`, which the testing module skips —
+    // so a `ZodError` raised inside a handler returned 500 instead
+    // of 400 + CORE_VALIDATION (friction-log 2026-05-03).
+    { provide: APP_FILTER, useClass: ProblemDetailsExceptionFilter },
     { provide: APP_GUARD, useClass: ThrottlerGuard },
     { provide: APP_INTERCEPTOR, useClass: OutputPipelineInterceptor },
     ...(features.multiTenancy.enabled

--- a/src/core/app/bootstrap.ts
+++ b/src/core/app/bootstrap.ts
@@ -21,7 +21,6 @@ import { buildDevPortalShellInput, renderDevPortalShell } from "../dx/dev-portal
 import { planPrismaStudio } from "../dx/prisma-studio.js";
 import { buildScalarConfig } from "../dx/scalar-config.js";
 import { planStartupBanner } from "../dx/startup-banner.js";
-import { ProblemDetailsExceptionFilter } from "../errors/problem-details.filter.js";
 import { buildSecurityHeadersConfig } from "../http/security-headers.js";
 import { createLogger } from "../observability/logger.js";
 import { PinoLoggerService } from "../observability/pino-logger.service.js";
@@ -87,7 +86,14 @@ export async function bootstrap(options: BootstrapOptions = {}): Promise<INestAp
     }),
   );
 
-  app.useGlobalFilters(new ProblemDetailsExceptionFilter());
+  // RFC 7807 Problem-Details exception filter is registered via
+  // `APP_FILTER` inside `AppModule` so DI hands it to both the
+  // production boot AND `Test.createTestingModule({ imports:
+  // [AppModule] }).createNestApplication()`. No imperative
+  // `useGlobalFilters(...)` here — the previous explicit attach left
+  // testing-module specs without the filter, returning 500 on
+  // `ZodError` instead of 400 + CORE_VALIDATION (friction-log
+  // 2026-05-03).
 
   // OpenAPI spec generator. The document builder
   // walks every controller registered in DI and produces an OpenAPI

--- a/src/core/dx/scaffold-module-planner.ts
+++ b/src/core/dx/scaffold-module-planner.ts
@@ -574,6 +574,27 @@ function renderStoryTest(ctx: NameContext): string {
  * Scaffolded by \`bun run add:module ${ctx.kebab}\`. Adjust assertions
  * to the actual fields and behaviours of your resource — the seeded
  * shape mirrors the \`example\` reference.
+ *
+ * ── RED-first by design ───────────────────────────────────────────────
+ *
+ * This file ships intentionally RED. The first \`create\` assertion is
+ * pinned to a placeholder shape (\`{ TODO: "rename me" }\`) so the
+ * scaffolded slice fails the suite immediately — that's the project's
+ * RED-first TDD discipline (see CLAUDE.md "How development happens").
+ *
+ * Workflow for a fresh \`bun run add:module ${ctx.kebab}\`:
+ *   1. Run \`bun run test:e2e tests/stories/${ctx.kebab}-module.story.test.ts\` →
+ *      see the placeholder assertion fail. That's the RED step.
+ *   2. Edit each assertion below to match YOUR domain shape (the
+ *      Example-cloned scaffold is just a starting template, not the
+ *      target). Drop the \`TODO: "rename me"\` placeholder once your
+ *      real expectations are in.
+ *   3. Implement the service / DTO until the rewritten assertions
+ *      pass. That's the GREEN step.
+ *
+ * If you're genuinely happy with the Example carbon-copy shape, replace
+ * the \`{ TODO: "rename me" }\` line with \`{ name: "${ctx.pascal} one", ... }\`
+ * — that flips this slice green.
  */
 
 import { NotFoundException } from "@nestjs/common";
@@ -611,6 +632,12 @@ describe("Story · ${ctx.pascal} module", () => {
         description: "A first ${ctx.kebab}",
         status: "draft",
       });
+      // RED-first placeholder — replace with the real shape your
+      // controller / SDK consumers expect. The scaffold ships this
+      // line failing on purpose so the slice can't go green without
+      // a deliberate edit (project RED-first TDD discipline). See the
+      // file-header doc-comment for the workflow.
+      expect(out).toEqual({ TODO: "rename me" });
       expect(out).toMatchObject({
         name: "${ctx.pascal} one",
         description: "A first ${ctx.kebab}",
@@ -763,7 +790,17 @@ function renderNextSteps(ctx: NameContext): string {
   5. (Optional) If non-admin tenant members manage ${ctx.pascal}, add it
      to EXTRA_MEMBER_RESOURCES (PR #66's multi-provider hook).
 
-  6. Run the six quality gates:
+  6. Story test ships RED on purpose. Edit assertions for your
+     domain, then run
+
+     bun run test:e2e tests/stories/${ctx.kebab}-module.story.test.ts
+
+     until it goes green. The scaffolded story file hard-codes a
+     \`{ TODO: "rename me" }\` placeholder so the slice can't sneak
+     past the gate without a deliberate edit — that's the project's
+     RED-first TDD discipline.
+
+  7. Run the six quality gates:
 
      bun run lint && bun run test:unit && bun run test:e2e \\
        && bun run test:types && bun run test:coverage && bun run build

--- a/tests/app-filter-test-module-inheritance.e2e-spec.ts
+++ b/tests/app-filter-test-module-inheritance.e2e-spec.ts
@@ -1,0 +1,96 @@
+import { Controller, Get, type INestApplication } from "@nestjs/common";
+import { Test } from "@nestjs/testing";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { Public } from "../src/core/permissions/public.decorator.js";
+
+/**
+ * E2E · `Test.createTestingModule({ imports: [AppModule] })` inherits
+ * the global `ProblemDetailsExceptionFilter`.
+ *
+ * Friction log 2026-05-03 entry "Test.createTestingModule()
+ * createNestApplication does not register ProblemDetailsExceptionFilter":
+ * the filter used to be attached only by `bootstrap()` via
+ * `app.useGlobalFilters(...)`. Tests that boot through
+ * `Test.createTestingModule({ imports: [AppModule] }).createNestApplication()`
+ * skip `bootstrap()` and therefore lacked the filter — a `ZodError`
+ * raised inside a handler returned 500 instead of 400 + CORE_VALIDATION,
+ * silently inverting the ZodValidationPipe's documented contract.
+ *
+ * Fix: register the filter as `{ provide: APP_FILTER, useClass:
+ * ProblemDetailsExceptionFilter }` inside `AppModule`. Production AND
+ * test boots both inherit it through DI for free; no per-spec
+ * `useGlobalFilters(...)` boilerplate.
+ *
+ * This e2e pins the contract: import `AppModule` AS-IS via the testing
+ * module, throw a `ZodError` from a sibling probe controller, and
+ * assert the response is 400 + `application/problem+json` + body
+ * `code: "CORE_VALIDATION"`. Was RED before the AppModule edit, GREEN
+ * after.
+ */
+
+const Body = z.object({ name: z.string().min(2) });
+
+// `/dev/*` is on the path-allowlist (jwt-middleware `PUBLIC_PREFIXES`
+// + tenant-guard `EXEMPT_*`) so neither the session middleware nor
+// the tenant guard can short-circuit our request to 401/403 before
+// the handler runs. That keeps this test's assertion narrowly focused
+// on the global exception filter (ZodError → 400 + CORE_VALIDATION),
+// not on the auth chain.
+@Controller("dev/filter-inheritance-probe")
+class ZodBoomController {
+  @Get("zod")
+  @Public("test-only ZodError probe — exercises global ProblemDetailsExceptionFilter")
+  zod(): void {
+    // The validation literally fails — the filter must catch the
+    // ZodError. If the filter is missing, NestJS' default exception
+    // handler emits a 500.
+    Body.parse({ name: "a" });
+  }
+}
+
+describe("E2E · APP_FILTER inheritance via Test.createTestingModule({ imports: [AppModule] })", () => {
+  let app: INestApplication;
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+
+  beforeAll(async () => {
+    // Better-Auth boots eagerly when AppModule loads — give it the
+    // bare-minimum env so its config validation passes.
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    const { AppModule } = await import("../src/core/app/app.module.js");
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+      controllers: [ZodBoomController],
+    }).compile();
+    app = moduleRef.createNestApplication({ logger: false });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+  });
+
+  it("returns 400 + CORE_VALIDATION + problem+json content-type for an in-handler ZodError", async () => {
+    const res = await request(app.getHttpServer()).get("/dev/filter-inheritance-probe/zod");
+    // Was 500 + plain JSON before the AppModule APP_FILTER edit.
+    expect(res.status).toBe(400);
+    expect(res.headers["content-type"]).toMatch(/application\/problem\+json/);
+    expect(res.body).toMatchObject({
+      code: "CORE_VALIDATION",
+      status: 400,
+    });
+    // The filter also synthesises the per-field `errors` array from
+    // `ZodError.issues` — pin a thin invariant so future filter
+    // refactors that drop this attribute fail this spec loudly.
+    expect(Array.isArray(res.body.errors)).toBe(true);
+    expect(res.body.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/lib/fake-prisma.ts
+++ b/tests/lib/fake-prisma.ts
@@ -76,7 +76,18 @@ function makeTable<T extends Row>(): TableMock<T> {
 
   const matchesWhere = (row: T, where: Partial<T>): boolean => {
     for (const [key, value] of Object.entries(where)) {
-      if (row[key as keyof T] !== value) return false;
+      const rowValue = row[key as keyof T];
+      // Real Prisma + Postgres treat `where: { col: null }` and
+      // "column was never assigned on insert" identically, because the
+      // column defaults to NULL. The naive `!==` check excluded rows
+      // whose column was undefined — silently breaking
+      // `findMany({ where: { deletedAt: null } })` for soft-delete
+      // services. Normalise `undefined → null` for filter comparison
+      // only — the row's stored shape is left untouched. (friction-log
+      // 2026-05-03)
+      const a = rowValue === undefined ? null : rowValue;
+      const b = value === undefined ? null : value;
+      if (a !== b) return false;
     }
     return true;
   };

--- a/tests/stories/fake-prisma-pagination.story.test.ts
+++ b/tests/stories/fake-prisma-pagination.story.test.ts
@@ -101,4 +101,109 @@ describe("Story · FakePrisma pagination (skip / take / count)", () => {
     expect(await dynamic.invoice.count()).toBe(2);
     expect(await dynamic.invoice.count({})).toBe(2);
   });
+
+  /**
+   * Story · `where: { col: null }` matches a row whose column was
+   * never assigned (friction-log 2026-05-03 entry "fake-prisma's
+   * `where: { col: null }` doesn't match an undefined column").
+   *
+   * Real Prisma + Postgres treat "column was never assigned on insert"
+   * and `IS NULL` identically because the column defaults to NULL.
+   * The fake's original `row[key] !== value` check returned `false`
+   * for `undefined !== null`, excluding rows with omitted columns —
+   * which silently broke every soft-delete `findMany({ where: {
+   * deletedAt: null } })` call. Fix: normalise so `undefined` and
+   * `null` compare equal for filter equality only.
+   */
+  describe("null/undefined equality (matches real Prisma)", () => {
+    it("matches a row created without `deletedAt` when filtering by `deletedAt: null`", async () => {
+      const dynamic = fake as unknown as Record<
+        string,
+        ReturnType<typeof createFakePrisma>["example"]
+      >;
+      // Create a row WITHOUT a `deletedAt` field — equivalent to a
+      // soft-delete-aware schema where the column defaults to NULL.
+      await dynamic.todo.create({
+        data: { id: "todo-active", title: "Active todo", tenantId: "t-1" } as never,
+      });
+      const rows = await dynamic.todo.findMany({
+        where: { tenantId: "t-1", deletedAt: null } as never,
+      });
+      expect(rows.map((r) => r.id)).toEqual(["todo-active"]);
+    });
+
+    it("excludes rows whose column is explicitly set to a non-null value", async () => {
+      const dynamic = fake as unknown as Record<
+        string,
+        ReturnType<typeof createFakePrisma>["example"]
+      >;
+      // One soft-deleted row, one active row.
+      await dynamic.todo.create({
+        data: { id: "todo-active", title: "Active", tenantId: "t-1" } as never,
+      });
+      await dynamic.todo.create({
+        data: {
+          id: "todo-soft-deleted",
+          title: "Removed",
+          tenantId: "t-1",
+          deletedAt: new Date("2026-01-01"),
+        } as never,
+      });
+      const rows = await dynamic.todo.findMany({
+        where: { tenantId: "t-1", deletedAt: null } as never,
+      });
+      expect(rows.map((r) => r.id)).toEqual(["todo-active"]);
+    });
+
+    it("`count({ where: { deletedAt: null } })` includes rows with the column omitted", async () => {
+      const dynamic = fake as unknown as Record<
+        string,
+        ReturnType<typeof createFakePrisma>["example"] & {
+          count(input?: { where?: Record<string, unknown> }): Promise<number>;
+        }
+      >;
+      await dynamic.todo.create({
+        data: { id: "a", title: "A", tenantId: "t-1" } as never,
+      });
+      await dynamic.todo.create({
+        data: { id: "b", title: "B", tenantId: "t-1" } as never,
+      });
+      await dynamic.todo.create({
+        data: {
+          id: "c",
+          title: "C",
+          tenantId: "t-1",
+          deletedAt: new Date(),
+        } as never,
+      });
+      const total = await dynamic.todo.count({
+        where: { tenantId: "t-1", deletedAt: null } as never,
+      });
+      expect(total).toBe(2);
+    });
+
+    it("symmetric: `findUnique` + `update` honour the same null/undefined equivalence", async () => {
+      const dynamic = fake as unknown as Record<
+        string,
+        ReturnType<typeof createFakePrisma>["example"]
+      >;
+      const created = await dynamic.todo.create({
+        data: { id: "t-1", title: "Foo" } as never,
+      });
+      // findUnique on a where with `deletedAt: null` finds it even though
+      // the row never had `deletedAt` assigned — matches Prisma's
+      // semantics where the column is NULL by default.
+      const found = await dynamic.todo.findUnique({
+        where: { id: created.id, deletedAt: null } as never,
+      });
+      expect(found).not.toBeNull();
+      // Same for update — used by services that gate updates on
+      // "still alive" rows.
+      const updated = await dynamic.todo.update({
+        where: { id: created.id, deletedAt: null } as never,
+        data: { title: "Bar" } as never,
+      });
+      expect(updated.title).toBe("Bar");
+    });
+  });
 });

--- a/tests/stories/scaffold-module-planner.story.test.ts
+++ b/tests/stories/scaffold-module-planner.story.test.ts
@@ -102,6 +102,76 @@ describe("Story · scaffold-module-planner", () => {
     });
   });
 
+  /**
+   * Friction-log 2026-05-03 entry "add:module scaffold ignores domain
+   * shape": the generated story test passed against the Example
+   * carbon-copy shape, which violates the project's RED-first TDD
+   * discipline (the generated test was already green for the wrong
+   * domain). Pin the structural property: the scaffolded story test
+   * MUST contain a clearly intentional failure marker (`expect.fail`
+   * or a `TODO|RED|placeholder`-marked assertion). The exact bytes are
+   * deliberately not pinned — that would make any non-cosmetic edit
+   * to the placeholder text brittle.
+   */
+  describe("scaffolded story test ships RED-first", () => {
+    it("contains an intentional failure marker (expect.fail OR a clearly wrong placeholder assertion)", () => {
+      const plan = planScaffoldModule({ name: "todo", existingResources: [] });
+      if (plan.action !== "write") throw new Error("expected write plan");
+      const story = plan.files.find((f) =>
+        f.path.includes("stories/todo-module.story.test.ts"),
+      )!.content;
+      const hasExpectFail = /expect\.fail\s*\(/.test(story);
+      // Match uppercase markers only (TODO / RED / FIXME) — the
+      // resource name "todo" itself contains the lowercase substring
+      // and would falsely match a case-insensitive check. Likewise
+      // require the placeholder to be a literal "rename me" string,
+      // not an arbitrary verb.
+      const hasRedMarker =
+        /\bTODO\b|\bRED\b|\bFIXME\b/.test(story) || /["'`]rename me["'`]/i.test(story);
+      expect(hasExpectFail || hasRedMarker).toBe(true);
+    });
+
+    it("explains in a doc-comment that the test is intentionally RED", () => {
+      const plan = planScaffoldModule({ name: "todo", existingResources: [] });
+      if (plan.action !== "write") throw new Error("expected write plan");
+      const story = plan.files.find((f) =>
+        f.path.includes("stories/todo-module.story.test.ts"),
+      )!.content;
+      // The doc-block at the top of the file makes the RED-first
+      // intent obvious to a fresh agent so they don't misread the
+      // failure as a regression.
+      expect(story).toMatch(/intentional(ly)? RED|RED-first|TDD discipline/i);
+    });
+
+    it("scaffolded story test still parses as TypeScript (no syntax errors)", () => {
+      const plan = planScaffoldModule({ name: "todo", existingResources: [] });
+      if (plan.action !== "write") throw new Error("expected write plan");
+      const story = plan.files.find((f) =>
+        f.path.includes("stories/todo-module.story.test.ts"),
+      )!.content;
+      // Light structural sanity — paired braces / parens / backticks
+      // don't drift after the RED-first edit. A real TS parse would be
+      // ideal but adding a runtime ts-parse just for one assertion is
+      // disproportionate; balance check is enough to catch the common
+      // template-edit foot-guns.
+      const balanced = (s: string, open: string, close: string) =>
+        [...s].reduce((acc, ch) => acc + (ch === open ? 1 : ch === close ? -1 : 0), 0) === 0;
+      expect(balanced(story, "{", "}")).toBe(true);
+      expect(balanced(story, "(", ")")).toBe(true);
+      expect(balanced(story, "[", "]")).toBe(true);
+    });
+
+    it("nextSteps mentions the scaffolded story test ships RED on purpose", () => {
+      const plan = planScaffoldModule({ name: "todo", existingResources: [] });
+      if (plan.action !== "write") throw new Error("expected write plan");
+      // Operator-visible printout points new contributors at the
+      // RED-first contract so they don't waste a cycle assuming the
+      // scaffold output is broken.
+      expect(plan.nextSteps).toMatch(/RED|story test.*on purpose|edit assertions/i);
+      expect(plan.nextSteps).toMatch(/tests\/stories\/todo-module\.story\.test\.ts/);
+    });
+  });
+
   describe("idempotency", () => {
     it("aborts with a clear reason when the module folder already exists", () => {
       const plan = planScaffoldModule({


### PR DESCRIPTION
## Summary

Three medium-severity frictions from the LLM-test #3 friction-log
(2026-05-03), bundled into one cohesive PR. Each fix is a separate
commit on this branch for review-friendly history.

### 1. `Test.createTestingModule({ imports: [AppModule] })` did not register `ProblemDetailsExceptionFilter`

`src/core/app/bootstrap.ts:90` attached the filter imperatively via
`app.useGlobalFilters(...)`. Tests booting through the testing module
skip `bootstrap()` — so a `ZodError` raised inside a handler returned
500 instead of 400 + `CORE_VALIDATION`, silently inverting the
ZodValidationPipe contract.

**Fix:** moved the filter to `{ provide: APP_FILTER, useClass:
ProblemDetailsExceptionFilter }` inside `AppModule`. DI now hands it
to the production boot AND `Test.createTestingModule(...)` calls.
Pinned by `tests/app-filter-test-module-inheritance.e2e-spec.ts`.

### 2. fake-prisma's `where: { col: null }` did not match a row whose column was `undefined`

`tests/lib/fake-prisma.ts` `matchesWhere` used `row[key] !== value`.
A row created without `deletedAt` has the column `undefined`; the
typical soft-delete read filter is `null`. `undefined !== null`, so
the row was excluded — silently breaking every `findMany({ where: {
deletedAt: null } })` call.

**Fix:** normalise `undefined → null` in the equality check (filter
comparison only; the row's stored shape is left untouched). Pinned by
four new assertions in `tests/stories/fake-prisma-pagination.story.test.ts`
covering `findMany`, `count`, `findUnique`, and `update`.

### 3. `bun run add:module` scaffold shipped passing tests for the wrong domain

The generated `tests/stories/<name>-module.story.test.ts` PASSED against
the Example carbon-copy shape. The project's RED-first TDD discipline
(see `CLAUDE.md`) says new tests must FAIL first — but a fresh agent
running `bun run test:e2e ...` immediately saw green tests for the
wrong domain.

**Fix:** the scaffolded file now ships a placeholder
`expect(out).toEqual({ TODO: "rename me" })` assertion + a doc-block
explaining the RED-first contract + an extra step in the runner's
next-steps printout. Pinned in
`tests/stories/scaffold-module-planner.story.test.ts` as a
**structural** assertion (failure marker present, doc-block mentions
"RED-first", braces / parens stay balanced) — not byte-exact text, so
non-cosmetic edits to the placeholder don't break the gate.

## Reproduction commands (RED → GREEN)

Each fix has a paired test that was RED at HEAD~3 and GREEN now:

```bash
# Fix #1 — APP_FILTER inheritance
bun run test:e2e tests/app-filter-test-module-inheritance.e2e-spec.ts

# Fix #2 — fake-prisma null/undefined equality
bun run test:e2e tests/stories/fake-prisma-pagination.story.test.ts

# Fix #3 — scaffold ships RED-first
bun run test:e2e tests/stories/scaffold-module-planner.story.test.ts
```

## Six gates (local)

- `bun run lint` — green
- `bun run test:unit` — green (174/174)
- `bun run test:e2e` — green (2873/2873)
- `bun run test:types` — green
- `bun run test:coverage` — green (statements 90.62%, lines 92.79%)
- `bun run build` — green

## Test plan

- [ ] CI green on all six gates
- [ ] Verify the new e2e (`tests/app-filter-test-module-inheritance.e2e-spec.ts`) returns 400 + `CORE_VALIDATION` (not 500)
- [ ] Verify `tests/stories/fake-prisma-pagination.story.test.ts` covers the four null/undefined cases
- [ ] Verify `bun run add:module foo` (sandbox repo) emits a `foo-module.story.test.ts` that fails on the placeholder assertion
- [ ] Confirm the OpenAPI snapshot story stays green (`tests/stories/openapi-snapshot.story.test.ts`)

## Friction-log entries closed

- 2026-05-03T20:19 (tests · medium · doc-gap) — `Test.createTestingModule().createNestApplication()` does not register `ProblemDetailsExceptionFilter`
- 2026-05-03T20:16 (tests · medium · bug) — fake-prisma's `where: { col: null }` doesn't match an undefined column
- 2026-05-03T20:11 (backend · medium · DX) — `add:module` scaffold ignores domain shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)