### PR TITLE
feat(prisma): check:rls runtime mode — verify pg_class.relrowsecurity matches expectations

### DIFF
--- a/.claude/skills/adding-feature-module.md
+++ b/.claude/skills/adding-feature-module.md
@@ -272,8 +272,17 @@ exists. Run it locally after `prisma migrate dev` to catch a missed
 sibling migration before pushing:
 
 ```bash
-bun run check:rls   # exits 1 + lists offenders if any
+bun run check:rls           # static (always) + runtime (if DATABASE_URL set)
+bun run check:rls --runtime # force the live pg_class.relrowsecurity check
+bun run check:rls --strict  # fail when runtime check is skipped
 ```
+
+The runtime mode connects to Postgres and asserts
+`pg_class.relrowsecurity = true` per tenant-scoped table — it catches
+the failure mode the static scan can't: a migration file edited
+*after* it has been applied (Prisma records the file's hash but
+doesn't re-run it), leaving the live DB unprotected while the static
+scan stays green.
 
 ## Step 3 — DTOs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,17 @@ jobs:
       # multi-tenant isolation contract is silently bypassed. The audit is
       # cheap (no DB / no Nest bootstrap), so it lives in the lint job
       # rather than as its own ~30s checkout-and-install pipeline.
-      - name: RLS coverage audit
+      #
+      # Static-only on purpose: this job has no Postgres available, and
+      # `bun run check:rls` (without DATABASE_URL) auto-skips the runtime
+      # half with an info note. The runtime mode is a developer-side /
+      # downstream-consumer defense-in-depth — it catches the failure
+      # mode where a consumer edits an applied migration file post-deploy,
+      # leaving the live DB unprotected while the static scan stays green.
+      # Run `bun run check:rls --runtime` locally (or wire it into a
+      # consumer's prod CI gate that already has a DB) to verify
+      # `pg_class.relrowsecurity` against the live cluster.
+      - name: RLS coverage audit (static)
         run: bun run check:rls
 
   format:

--- a/prisma/CLAUDE.md
+++ b/prisma/CLAUDE.md
@@ -133,13 +133,33 @@ with a migration that enables Postgres RLS on the resolved table —
 See `prisma/migrations/20260428000150_rls_tenant_isolation_extended/`
 for the canonical shape.
 
-The CI gate `bun run check:rls` (planner:
-`src/core/permissions/rls-audit-planner.ts`, runner:
-`scripts/check-rls.ts`) walks every model + every migration and fails
-when a tenant-scoped model has no RLS-enabling migration anywhere in
-the tree. Run it locally before commit; the lint job runs it on every
-PR. There's no auto-fix — RLS is a load-bearing security layer, opt-in
-per table is the safer default.
+The CI gate `bun run check:rls` (planners:
+`src/core/permissions/rls-audit-planner.ts` +
+`src/core/permissions/rls-runtime-planner.ts`, runner:
+`scripts/check-rls.ts`) operates in two modes:
+
+- **Static** (always runs) — walks every model + every migration and
+  fails when a tenant-scoped model has no RLS-enabling migration
+  anywhere in the tree. The lint CI job runs this; no DB needed.
+- **Runtime** (auto-enabled when `DATABASE_URL` is set, or forced via
+  `--runtime`) — connects to Postgres and asserts
+  `pg_class.relrowsecurity = true` for every tenant-scoped table.
+  Catches the failure mode the static scan can't see: a consumer
+  edits a migration file *after* it has been applied (Prisma records
+  the file's hash but doesn't re-run it), so the live DB is
+  unprotected even though the static scan stays green.
+
+```bash
+bun run check:rls            # static + runtime (if DATABASE_URL set)
+bun run check:rls --runtime  # force runtime; exit 2 if no DATABASE_URL
+bun run check:rls --strict   # fail when runtime is skipped (prod CI)
+```
+
+There's no auto-fix — RLS is a load-bearing security layer, opt-in
+per table is the safer default. If runtime findings disagree with the
+static scan, ship a NEW migration that re-enables RLS — never edit a
+shipped migration (forward-only history per
+`docs/api-stability-promise.md`).
 
 ## Migrations are forward-only
 

--- a/scripts/check-rls.ts
+++ b/scripts/check-rls.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 /**
  * `bun run check:rls` — fails when a tenant-scoped Prisma model has
- * no `ENABLE ROW LEVEL SECURITY` migration anywhere in the tree.
+ * no `ENABLE ROW LEVEL SECURITY` migration anywhere in the tree
+ * AND/OR (in runtime mode) the live Postgres has
+ * `pg_class.relrowsecurity = false` on a tenant-scoped table.
  *
  * Tenant isolation in this template rests on Postgres RLS — every
  * `runWithRlsTenant` wrapper, every `tenant_isolation_<table>`
@@ -11,21 +13,33 @@
  * `tenantId` column — so a forgotten manual migration ships a
  * tenant-leaky table without warning.
  *
- * This runner is deliberately a separate CI gate (not a Prisma plugin
- * / migrate hook): the audit lives next to `bun run test:e2e`, runs
- * in CI exactly once per push, and surfaces with an actionable error
- * message. Wrapping `prisma migrate dev` would need a custom Prisma
- * plugin trampoline + a `postinstall` shim to make the hook
- * discoverable for everyone — too much surface area for a single
- * lint rule.
+ * Two modes coexist on purpose:
  *
- * The runner is the thin I/O layer. The pure planner
- * (`auditRlsCoverage`) is exhaustively unit-tested in
- * `tests/stories/rls-audit-planner.story.test.ts`.
+ *   - **Static** (always runs) — scans the migration files on disk
+ *     for the `ENABLE ROW LEVEL SECURITY` statement. Cheap, no DB,
+ *     this is what the `lint` CI job runs.
+ *
+ *   - **Runtime** (when `DATABASE_URL` is set OR `--runtime` is
+ *     passed) — connects to Postgres and reads `pg_class.relrowsecurity`
+ *     for every tenant-scoped table. This catches the failure mode the
+ *     static scan can't: a consumer edits a migration file *after* it
+ *     was applied (Prisma records the migration's hash but doesn't
+ *     re-check the file), and the live table ends up unprotected
+ *     even though the static scan stays green.
+ *
+ * Use `--strict` to fail when the runtime check is skipped — useful
+ * in pre-prod CI gates that should never accept a static-only pass.
+ *
+ * The runner is the thin I/O layer. The two pure planners
+ * (`auditRlsCoverage`, `auditRlsRuntime`) are exhaustively unit-tested
+ * in `tests/stories/rls-audit-planner.story.test.ts` and
+ * `tests/stories/rls-runtime-planner.story.test.ts`.
  *
  * Exit code:
  *   - 0 — no findings (clean).
- *   - 1 — one or more tenant-scoped models lack an RLS migration.
+ *   - 1 — one or more tenant-scoped models lack an RLS migration,
+ *         OR the live DB has RLS off on a tenant-scoped table,
+ *         OR `--strict` was set and the runtime check was skipped.
  *   - 2 — runner failure (missing schema / migrations dir / read err).
  */
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
@@ -34,13 +48,22 @@ import { resolve } from "node:path";
 import {
   type RlsAuditFinding,
   auditRlsCoverage,
+  listTenantScopedModels,
 } from "../src/core/permissions/rls-audit-planner.js";
+import {
+  type RlsRuntimeFinding,
+  connectAndCheckRlsAtRuntime,
+} from "../src/core/permissions/rls-runtime-check.js";
 
 const ROOT = process.cwd();
 const PRISMA_DIR = resolve(ROOT, "prisma");
 const SCHEMA_PATH = resolve(PRISMA_DIR, "schema.prisma");
 const GENERATED_SCHEMA_PATH = resolve(PRISMA_DIR, "schema.generated.prisma");
 const MIGRATIONS_DIR = resolve(PRISMA_DIR, "migrations");
+
+const argv = process.argv.slice(2);
+const FORCE_RUNTIME = argv.includes("--runtime");
+const STRICT = argv.includes("--strict");
 
 function fail(message: string, code = 2): never {
   console.error(`[check:rls] ${message}`);
@@ -70,33 +93,104 @@ for (const entry of readdirSync(MIGRATIONS_DIR)) {
   migrations.push({ name: entry, sql: readFileSync(sqlPath, "utf8") });
 }
 
-const findings: RlsAuditFinding[] = auditRlsCoverage({ schemaSource, migrations });
+// ─── Static scan (always) ───────────────────────────────────────────
+const staticFindings: RlsAuditFinding[] = auditRlsCoverage({ schemaSource, migrations });
+const tenantScoped = listTenantScopedModels(schemaSource);
 
-// Count tenant-scoped models for an informative success line. Every
-// model that the planner reports against an empty-migrations input is
-// tenant-scoped (each one is "uncovered"); subtract nothing — that's
-// the canonical count regardless of how many were covered this run.
-const tenantScopedCount = auditRlsCoverage({ schemaSource, migrations: [] }).length;
+// ─── Runtime check (conditional) ────────────────────────────────────
+const databaseUrl = process.env.DATABASE_URL;
+const runtimeRequested = FORCE_RUNTIME || databaseUrl !== undefined;
 
-if (findings.length === 0) {
+let runtimeFindings: RlsRuntimeFinding[] = [];
+let runtimeSkipped = false;
+let runtimeSkipReason = "";
+
+if (runtimeRequested) {
+  if (!databaseUrl) {
+    // `--runtime` forced but no DATABASE_URL — escalate to exit 2:
+    // the user explicitly asked for runtime verification and we
+    // can't honour it.
+    fail("--runtime requested but DATABASE_URL is not set", 2);
+  }
+  try {
+    runtimeFindings = await connectAndCheckRlsAtRuntime({
+      tenantScopedModels: tenantScoped,
+      databaseUrl,
+    });
+  } catch (err) {
+    fail(
+      `runtime check failed to connect or query: ${err instanceof Error ? err.message : String(err)}`,
+      2,
+    );
+  }
+} else {
+  runtimeSkipped = true;
+  runtimeSkipReason =
+    "Runtime RLS check skipped (no DATABASE_URL). " +
+    "Run `bun run check:rls --runtime` locally to verify pg_class.relrowsecurity.";
+}
+
+// ─── Reporting ──────────────────────────────────────────────────────
+let exitCode = 0;
+
+if (staticFindings.length === 0) {
   console.log(
-    `[check:rls] clean (${tenantScopedCount} tenant-scoped model(s), ${migrations.length} migration(s) scanned)`,
+    `[check:rls] static: clean (${tenantScoped.length} tenant-scoped model(s), ${migrations.length} migration(s) scanned)`,
   );
-  process.exit(0);
+} else {
+  exitCode = 1;
+  console.error(
+    `[check:rls] static: ${staticFindings.length} tenant-scoped model(s) lack an ENABLE ROW LEVEL SECURITY migration:`,
+  );
+  for (const f of staticFindings) {
+    console.error(
+      `  - RLS missing: ${f.model} (table: ${f.table}) — add ENABLE ROW LEVEL SECURITY migration`,
+    );
+  }
 }
 
-console.error(
-  `[check:rls] ${findings.length} tenant-scoped model(s) lack an ENABLE ROW LEVEL SECURITY migration:`,
-);
-for (const f of findings) {
+if (runtimeSkipped) {
+  if (STRICT) {
+    exitCode = 1;
+    console.error(`[check:rls] runtime: STRICT failure — ${runtimeSkipReason}`);
+  } else {
+    console.log(`[check:rls] runtime: ${runtimeSkipReason}`);
+  }
+} else if (runtimeFindings.length === 0) {
+  console.log(
+    `[check:rls] runtime: clean (${tenantScoped.length} tenant-scoped table(s) verified against pg_class.relrowsecurity)`,
+  );
+} else {
+  exitCode = 1;
   console.error(
-    `  - RLS missing: ${f.model} (table: ${f.table}) — add ENABLE ROW LEVEL SECURITY migration`,
+    `[check:rls] runtime: ${runtimeFindings.length} tenant-scoped table(s) failed the live pg_class.relrowsecurity check:`,
+  );
+  for (const f of runtimeFindings) {
+    if (f.reason === "rls-disabled") {
+      console.error(
+        `  - RLS disabled at runtime: ${f.model} (table: ${f.table}) — pg_class.relrowsecurity is false`,
+      );
+    } else {
+      console.error(
+        `  - Table missing at runtime: ${f.model} (table: ${f.table}) — no row in pg_class for this table in the public schema`,
+      );
+    }
+  }
+}
+
+if (exitCode === 1) {
+  console.error("");
+  console.error(
+    "Fix: ensure each tenant-scoped table has `ALTER TABLE \"<table>\" ENABLE ROW LEVEL SECURITY;`",
+  );
+  console.error("plus a `CREATE POLICY` matching tenant_id = current_setting('app.tenant_id').");
+  console.error("See prisma/migrations/20260428000150_rls_tenant_isolation_extended/ for the shape.");
+  console.error(
+    "If runtime findings disagree with the static scan, the migration file was edited after",
+  );
+  console.error(
+    "deploy — re-apply RLS in a NEW migration (forward-only); never edit a shipped migration.",
   );
 }
-console.error("");
-console.error(
-  "Fix: create a migration that runs `ALTER TABLE \"<table>\" ENABLE ROW LEVEL SECURITY;`",
-);
-console.error("plus a `CREATE POLICY` matching tenant_id = current_setting('app.tenant_id').");
-console.error("See prisma/migrations/20260428000150_rls_tenant_isolation_extended/ for the shape.");
-process.exit(1);
+
+process.exit(exitCode);

--- a/src/core/permissions/rls-audit-planner.ts
+++ b/src/core/permissions/rls-audit-planner.ts
@@ -58,20 +58,34 @@ export interface RlsAuditFinding {
  * finding per uncovered model.
  */
 export function auditRlsCoverage(input: RlsAuditPlannerInput): RlsAuditFinding[] {
-  const models = parseModels(input.schemaSource);
-  const tenantScoped = models.filter((m) => m.hasTenantIdField);
+  const tenantScoped = listTenantScopedModels(input.schemaSource);
   const findings: RlsAuditFinding[] = [];
   for (const model of tenantScoped) {
     const covered = input.migrations.some((mig) => migrationEnablesRls(mig.sql, model.table));
     if (!covered) {
       findings.push({
-        model: model.name,
+        model: model.model,
         table: model.table,
         migrationsScanned: input.migrations.length,
       });
     }
   }
   return findings;
+}
+
+/**
+ * Public helper: enumerate every tenant-scoped model in the schema
+ * source. The runtime check (`scripts/check-rls.ts --runtime`) needs
+ * the same list as the static audit but without the migration scan,
+ * so we expose the model resolver as its own pure function rather
+ * than duplicating the parser.
+ */
+export function listTenantScopedModels(
+  schemaSource: string,
+): ReadonlyArray<{ model: string; table: string }> {
+  return parseModels(schemaSource)
+    .filter((m) => m.hasTenantIdField)
+    .map((m) => ({ model: m.name, table: m.table }));
 }
 
 // ─── Schema parsing ─────────────────────────────────────────────────

--- a/src/core/permissions/rls-runtime-check.ts
+++ b/src/core/permissions/rls-runtime-check.ts
@@ -1,0 +1,102 @@
+/**
+ * Runtime RLS check — thin glue between Postgres + the runtime planner.
+ *
+ * Why this lives in `src/core/` rather than next to `scripts/`: the
+ * e2e test (`tests/check-rls-runtime.e2e-spec.ts`) needs to drive
+ * the same code path the CLI uses, against a live testcontainer DB.
+ * Shelling out to `bun run check:rls --runtime` from a test would
+ * couple the test to the script's argv parsing and exit-code
+ * conventions; calling the function directly keeps the test focused
+ * on the actual contract: "given a connected pg client, does the
+ * planner see the right state?".
+ *
+ * The planner is pure (`rls-runtime-planner.ts`); this module is the
+ * I/O boundary. Anything that reads from Postgres or constructs a
+ * client lives here.
+ */
+import { Client } from "pg";
+
+import {
+  type RlsRuntimeFinding,
+  type RlsRuntimeModel,
+  auditRlsRuntime,
+} from "./rls-runtime-planner.js";
+
+/**
+ * Minimal pg-client interface we need. Decouples the function from
+ * `pg.Client` for fake-injection in tests and lets callers pass a
+ * pooled client when one already exists.
+ */
+export interface PgQueryClient {
+  query<T = unknown>(text: string, values?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+export interface RuntimeCheckOptions {
+  /** Tenant-scoped models, typically from `listTenantScopedModels`. */
+  tenantScopedModels: ReadonlyArray<RlsRuntimeModel>;
+  /** Already-connected pg client / pool. */
+  client: PgQueryClient;
+  /** Schema to query — defaults to `public` (the only schema we use). */
+  schema?: string;
+}
+
+/**
+ * Query `pg_class.relrowsecurity` for every regular table in the
+ * given schema and feed the result into the pure runtime planner.
+ *
+ * We deliberately fetch ALL tables in the schema in one round-trip
+ * rather than `WHERE relname = ANY($1)` over the model list — the
+ * superset is cheap (low dozens of rows in this template), and the
+ * "table-missing" finding requires us to know which tables were
+ * looked up but absent.
+ */
+export async function checkRlsAtRuntime(
+  options: RuntimeCheckOptions,
+): Promise<RlsRuntimeFinding[]> {
+  const schema = options.schema ?? "public";
+  const result = await options.client.query<{ relname: string; relrowsecurity: boolean }>(
+    `SELECT relname, relrowsecurity
+       FROM pg_class
+       JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+      WHERE pg_class.relkind = 'r'
+        AND pg_namespace.nspname = $1`,
+    [schema],
+  );
+  const dbState: Record<string, boolean> = {};
+  for (const row of result.rows) {
+    dbState[row.relname] = row.relrowsecurity === true;
+  }
+  return auditRlsRuntime({
+    tenantScopedModels: options.tenantScopedModels,
+    dbState,
+  });
+}
+
+export interface ConnectAndCheckOptions {
+  tenantScopedModels: ReadonlyArray<RlsRuntimeModel>;
+  /** Postgres connection string (typically `process.env.DATABASE_URL`). */
+  databaseUrl: string;
+  schema?: string;
+}
+
+/**
+ * Convenience wrapper for the CLI runner: open a fresh `pg.Client`,
+ * run the check, close. The e2e test uses `checkRlsAtRuntime`
+ * directly with the existing client to share the testcontainer
+ * connection.
+ */
+export async function connectAndCheckRlsAtRuntime(
+  options: ConnectAndCheckOptions,
+): Promise<RlsRuntimeFinding[]> {
+  const client = new Client({ connectionString: options.databaseUrl });
+  await client.connect();
+  try {
+    return await checkRlsAtRuntime({
+      tenantScopedModels: options.tenantScopedModels,
+      client,
+      schema: options.schema,
+    });
+  } finally {
+    await client.end();
+  }
+}

--- a/src/core/permissions/rls-runtime-planner.ts
+++ b/src/core/permissions/rls-runtime-planner.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure planner for the runtime half of the RLS-coverage audit.
+ *
+ * Why this exists alongside `rls-audit-planner.ts`: the static planner
+ * only sees the migration files on disk, so a consumer who edits a
+ * migration file *after* it has been applied will get a green static
+ * scan even though `pg_class.relrowsecurity` on the live table is
+ * `false`. RLS is the load-bearing tenant-isolation guarantee — every
+ * `runWithRlsTenant` call assumes the policy actually fires — so we
+ * also need a check that asks the database the truth.
+ *
+ * The runner half (`scripts/check-rls.ts`) connects to Postgres,
+ * queries `pg_class` for `relrowsecurity` per table, and feeds the
+ * `{ table -> bool }` map into this planner. Two failure modes are
+ * reported as distinct `reason` values so the runner can render a
+ * useful message:
+ *   - `rls-disabled`  — row exists in `pg_class`, `relrowsecurity = false`.
+ *   - `table-missing` — no row at all (migration never ran, or the
+ *                       table lives in a non-public schema the runner
+ *                       didn't query).
+ *
+ * The planner stays a pure function — no Prisma, no DB connection —
+ * so it's trivially unit-testable with synthetic `dbState` snapshots.
+ */
+
+export interface RlsRuntimeModel {
+  /** PascalCase Prisma model name (for the finding label). */
+  model: string;
+  /** Resolved Postgres table name (the `pg_class.relname` to look up). */
+  table: string;
+}
+
+export interface RlsRuntimePlannerInput {
+  /** All tenant-scoped models, resolved by the static planner first. */
+  tenantScopedModels: ReadonlyArray<RlsRuntimeModel>;
+  /**
+   * Snapshot of `pg_class.relrowsecurity` keyed by `relname`. A missing
+   * key means the row was not found (treated as `table-missing`).
+   */
+  dbState: Readonly<Record<string, boolean>>;
+}
+
+export type RlsRuntimeFindingReason = "rls-disabled" | "table-missing";
+
+export interface RlsRuntimeFinding {
+  model: string;
+  table: string;
+  reason: RlsRuntimeFindingReason;
+}
+
+/**
+ * For each tenant-scoped model, look up its table in `dbState`. Emit
+ * a finding when `relrowsecurity` is `false` (rls-disabled) or the
+ * row is absent (table-missing). Empty `tenantScopedModels` short-
+ * circuits to no findings — there's nothing to protect.
+ */
+export function auditRlsRuntime(input: RlsRuntimePlannerInput): RlsRuntimeFinding[] {
+  const findings: RlsRuntimeFinding[] = [];
+  for (const m of input.tenantScopedModels) {
+    const has = Object.prototype.hasOwnProperty.call(input.dbState, m.table);
+    if (!has) {
+      findings.push({ model: m.model, table: m.table, reason: "table-missing" });
+      continue;
+    }
+    if (input.dbState[m.table] !== true) {
+      findings.push({ model: m.model, table: m.table, reason: "rls-disabled" });
+    }
+  }
+  return findings;
+}

--- a/tests/check-rls-runtime.e2e-spec.ts
+++ b/tests/check-rls-runtime.e2e-spec.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { Client } from "pg";
+
+import { listTenantScopedModels } from "../src/core/permissions/rls-audit-planner.js";
+import { checkRlsAtRuntime } from "../src/core/permissions/rls-runtime-check.js";
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * E2E · `check:rls --runtime` against a live Postgres.
+ *
+ * Verifies the runtime gate that the static migration-file scan
+ * cannot give: a consumer who edits an applied migration file post-
+ * deploy ends up with `pg_class.relrowsecurity = false` while the
+ * static planner stays green. This e2e drives the runtime check
+ * against the testcontainer Postgres, manually flips RLS off on a
+ * real tenant-scoped table, and asserts the finding shows up.
+ *
+ * The runtime check is called as a function (not via `bun run
+ * check:rls --runtime`) so the test stays focused on the contract
+ * — argv parsing + exit codes are covered by the runner's own
+ * inline reporting.
+ */
+describe("E2E · check:rls runtime — live pg_class.relrowsecurity verification", () => {
+  let client: Client;
+  let tenantScoped: ReadonlyArray<{ model: string; table: string }>;
+
+  beforeAll(async () => {
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("DATABASE_URL required for the check:rls runtime e2e");
+    client = new Client({ connectionString: url });
+    await client.connect();
+
+    // The static planner exposes the canonical model list; reuse it
+    // so the e2e doesn't drift from the source-of-truth schema.
+    const schemaPath = resolve(process.cwd(), "prisma", "schema.prisma");
+    const schemaSource = readFileSync(schemaPath, "utf8");
+    tenantScoped = listTenantScopedModels(schemaSource);
+  });
+
+  afterAll(async () => {
+    // Belt-and-braces: re-enable RLS on the table we toggled, in
+    // case a test exception bypassed the per-test cleanup. Other
+    // specs in the same run inherit this DB and assume RLS is on.
+    try {
+      await client.query("ALTER TABLE examples ENABLE ROW LEVEL SECURITY");
+    } catch {
+      // table may not exist on a stripped schema; ignore.
+    }
+    await client.end();
+  });
+
+  it("reports clean when every tenant-scoped table has RLS on at runtime", async () => {
+    const findings = await checkRlsAtRuntime({ tenantScopedModels: tenantScoped, client });
+    expect(findings).toEqual([]);
+  });
+
+  it("reports a finding when RLS is disabled on a tenant-scoped table at runtime", async () => {
+    // Simulate a post-deploy migration-file edit: live DB has RLS
+    // off even though the schema + static scan say it should be on.
+    await client.query("ALTER TABLE examples DISABLE ROW LEVEL SECURITY");
+    try {
+      const findings = await checkRlsAtRuntime({ tenantScopedModels: tenantScoped, client });
+      expect(findings.length).toBeGreaterThan(0);
+      const example = findings.find((f) => f.table === "examples");
+      expect(example).toBeDefined();
+      expect(example?.reason).toBe("rls-disabled");
+    } finally {
+      // Restore for the next test (and for any other e2e that runs
+      // after us against the same testcontainer DB).
+      await client.query("ALTER TABLE examples ENABLE ROW LEVEL SECURITY");
+    }
+  });
+
+  it("returns clean again once RLS is re-enabled on the table", async () => {
+    const findings = await checkRlsAtRuntime({ tenantScopedModels: tenantScoped, client });
+    expect(findings).toEqual([]);
+  });
+});

--- a/tests/stories/rls-runtime-planner.story.test.ts
+++ b/tests/stories/rls-runtime-planner.story.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { auditRlsRuntime } from "../../src/core/permissions/rls-runtime-planner.js";
+
+/**
+ * Story · RLS-runtime audit planner.
+ *
+ * The static `auditRlsCoverage` planner only sees the migration files
+ * on disk. A consumer can edit a migration file *after* it has run
+ * (`prisma migrate deploy` records its hash, but the file content
+ * stays editable) and the static scan will green even though the live
+ * database has `pg_class.relrowsecurity = false`. This planner closes
+ * that gap: given the list of tenant-scoped tables resolved from the
+ * Prisma schema and a snapshot of `pg_class.relrowsecurity`, it
+ * reports every tenant-scoped table whose runtime RLS flag is off
+ * (or whose row is missing entirely — the table was never created).
+ *
+ * Same finding shape as `rls-audit-planner.ts` for consistency, plus
+ * a `reason` discriminator so the runner can render a useful message
+ * for the two distinct failure modes.
+ */
+describe("Story · RLS-runtime planner — auditRlsRuntime", () => {
+  it("returns no findings when every tenant-scoped table has RLS on at runtime", () => {
+    const findings = auditRlsRuntime({
+      tenantScopedModels: [
+        { model: "Todo", table: "todos" },
+        { model: "Note", table: "notes" },
+      ],
+      dbState: {
+        todos: true,
+        notes: true,
+      },
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a tenant-scoped table whose runtime RLS flag is off", () => {
+    const findings = auditRlsRuntime({
+      tenantScopedModels: [
+        { model: "Todo", table: "todos" },
+        { model: "Note", table: "notes" },
+      ],
+      dbState: {
+        todos: true,
+        notes: false,
+      },
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      model: "Note",
+      table: "notes",
+      reason: "rls-disabled",
+    });
+  });
+
+  it("flags a tenant-scoped table whose row is missing from pg_class entirely", () => {
+    // Either the migration was never deployed, or the table lives in a
+    // non-public schema the runner did not query. Either way, the
+    // table is not protected as the schema promises.
+    const findings = auditRlsRuntime({
+      tenantScopedModels: [
+        { model: "Todo", table: "todos" },
+        { model: "Phantom", table: "phantoms" },
+      ],
+      dbState: {
+        todos: true,
+        // phantoms missing entirely.
+      },
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      model: "Phantom",
+      table: "phantoms",
+      reason: "table-missing",
+    });
+  });
+
+  it("returns no findings when the model list is empty (nothing to protect)", () => {
+    const findings = auditRlsRuntime({
+      tenantScopedModels: [],
+      dbState: {
+        todos: true,
+        notes: false,
+      },
+    });
+    expect(findings).toEqual([]);
+  });
+
+  it("reports each tenant-scoped table independently when a mix of issues is present", () => {
+    const findings = auditRlsRuntime({
+      tenantScopedModels: [
+        { model: "Todo", table: "todos" },
+        { model: "Note", table: "notes" },
+        { model: "Phantom", table: "phantoms" },
+      ],
+      dbState: {
+        todos: true,
+        notes: false,
+        // phantoms missing entirely.
+      },
+    });
+    expect(findings).toHaveLength(2);
+    expect(findings.map((f) => f.table).sort()).toEqual(["notes", "phantoms"]);
+    const note = findings.find((f) => f.table === "notes");
+    const phantom = findings.find((f) => f.table === "phantoms");
+    expect(note?.reason).toBe("rls-disabled");
+    expect(phantom?.reason).toBe("table-missing");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a runtime mode to `bun run check:rls` that connects to Postgres
and asserts every tenant-scoped table has `pg_class.relrowsecurity = true`.

The existing static-only scan only inspects migration files on disk —
a consumer who edits an applied migration file *after* deploy gets a
green check while the live database is unprotected (Prisma records
each migration's hash but doesn't re-execute the file). This closes
that gap as a developer-side defense-in-depth, while keeping the
static scan as the fast-path for the lint CI job (no DB needed).

**Friction-log entry:** LLM-test 2026-05-03 #4 entry 20:25
"check:rls static-only" (medium · bug).

## Why both modes coexist

- **Static** (always runs) — scans the migration files on disk for
  `ENABLE ROW LEVEL SECURITY`. Cheap, no DB, runs in the GitHub
  Actions `lint` job that has no Postgres available. Catches the
  90 % case: a brand-new tenant-scoped model that ships without an
  RLS-enabling migration.
- **Runtime** (auto-engages when `DATABASE_URL` is set, or forced via
  `--runtime`) — queries `pg_class` for `relrowsecurity` per
  tenant-scoped table. Catches the failure mode the static scan
  can't: post-deploy migration-file edits, manual `DISABLE ROW LEVEL
  SECURITY` interventions, tables that were never created. `--strict`
  upgrades a skipped runtime check to a hard fail (for downstream
  consumer prod CI gates that should never accept a static-only
  pass).

The CI lint job stays static-only on purpose — the runtime check is
a developer-side / downstream-consumer concern, and provisioning a
Postgres service container for it doesn't pull its weight against a
threat model that's already covered locally + in any consumer's prod
gate. The rationale is documented inline in `.github/workflows/ci.yml`.

## Design

- New pure planner `src/core/permissions/rls-runtime-planner.ts`
  takes `(tenantScopedModels, dbState: { table -> bool })` and
  returns findings with two reasons: `rls-disabled` (row exists,
  flag false) and `table-missing` (no row at all).
- New thin runner module `src/core/permissions/rls-runtime-check.ts`
  is the I/O boundary — opens a `pg.Client`, queries `pg_class`
  filtered to `relkind = 'r'` and the public schema, feeds the
  result into the planner.
- Existing `rls-audit-planner.ts` gains a `listTenantScopedModels`
  export so the runner doesn't duplicate the schema parser.
- `scripts/check-rls.ts` orchestrates: static scan first (planner
  #1), then runtime check (planner #2) when applicable, then unified
  reporting + exit code.

Pure planner + thin runner split mirrors the existing static gate
(`rls-audit-planner.ts` + `scripts/check-rls.ts`).

## Sample output

Clean, no DATABASE_URL (static-only fast-path):

```
$ bun run check:rls
[check:rls] static: clean (9 tenant-scoped model(s), 8 migration(s) scanned)
[check:rls] runtime: Runtime RLS check skipped (no DATABASE_URL). Run `bun run check:rls --runtime` locally to verify pg_class.relrowsecurity.
```

Strict + no DATABASE_URL (exits 1):

```
$ bun run check:rls --strict
[check:rls] static: clean (9 tenant-scoped model(s), 8 migration(s) scanned)
[check:rls] runtime: STRICT failure — Runtime RLS check skipped (no DATABASE_URL). Run `bun run check:rls --runtime` locally to verify pg_class.relrowsecurity.
…
```

Runtime finding (live DB has RLS off on `examples`):

```
$ bun run check:rls --runtime
[check:rls] static: clean (9 tenant-scoped model(s), 8 migration(s) scanned)
[check:rls] runtime: 1 tenant-scoped table(s) failed the live pg_class.relrowsecurity check:
  - RLS disabled at runtime: Example (table: examples) — pg_class.relrowsecurity is false

Fix: ensure each tenant-scoped table has `ALTER TABLE "<table>" ENABLE ROW LEVEL SECURITY;`
plus a `CREATE POLICY` matching tenant_id = current_setting('app.tenant_id').
See prisma/migrations/20260428000150_rls_tenant_isolation_extended/ for the shape.
If runtime findings disagree with the static scan, the migration file was edited after
deploy — re-apply RLS in a NEW migration (forward-only); never edit a shipped migration.
```

## Test plan

- [x] RED-first: `tests/stories/rls-runtime-planner.story.test.ts` (5 cases) added with no implementation, verified red.
- [x] GREEN: planner implemented; story tests pass.
- [x] E2E vs live testcontainer Postgres: `tests/check-rls-runtime.e2e-spec.ts` (3 cases) — clean run, then `ALTER TABLE examples DISABLE ROW LEVEL SECURITY`, expect `rls-disabled` finding, re-enable, expect clean.
- [x] Static-only fast-path still works (`check:rls` without `DATABASE_URL`).
- [x] `--runtime` without `DATABASE_URL` → exit 2 with clear error.
- [x] `--strict` without `DATABASE_URL` → exit 1.
- [x] Six gates locally: lint, test:unit, test:e2e (309/309 files, 2882/2882 tests), test:types, test:coverage (thresholds met), build.
- [x] Docs updated: `prisma/CLAUDE.md`, `.claude/skills/adding-feature-module.md`, `.github/workflows/ci.yml` rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)