### PR TITLE
fix(tooling): check:rls loads project .env + skill mentions openapi snapshot + setup-wizard env-bridge audit

### DIFF
--- a/.claude/QUICKSTART.md
+++ b/.claude/QUICKSTART.md
@@ -34,6 +34,13 @@ docker compose up -d postgres   # boot Postgres only (others optional)
 bun run dev                     # auto-spawns Prisma Studio + opens /dev
 ```
 
+> **Fresh `lt fullstack init --next` workspace?** Run `bun run setup`
+> first — the CLI ships the API `.env` template but does NOT invoke
+> the wizard, so the frontend env-bridge (which retargets
+> `projects/app/.env` away from the upstream `localhost:3000`
+> literal) has not fired yet. `bun run setup` is idempotent: it
+> refuses to overwrite an existing `.env` but still runs the bridge.
+
 > **Recover from a stale Postgres volume?** `docker compose down -v && docker compose up -d postgres` followed by `bun run prisma:migrate`. Don't delete `.env` first — the existing password initialises the recreated volume.
 
 Server is at the URL the dev runner prints — `https://api.nest-base.localhost`

--- a/.claude/skills/adding-feature-module.md
+++ b/.claude/skills/adding-feature-module.md
@@ -597,7 +597,27 @@ Skip this step entirely if the resource is admin-only (only the
 `/admin/*` UI / a seeded admin Role should reach it) or framework-
 internal (`Role`, `Policy`, `Permission`, `Tenant`, `WebhookEndpoint`).
 
-## Step 9 — Quality gates
+## Step 9 — Regenerate the OpenAPI snapshot (after adding a route)
+
+`tests/stories/openapi-snapshot.story.test.ts` diffs the live OpenAPI
+document against the committed `docs/openapi.snapshot.json`. Adding
+any new operation (which a fresh feature module always does) will fail
+the test until you regenerate the snapshot. Without this step the
+six-gates run goes red on what looks like a Todo-related assertion —
+fresh contributors lose half an hour chasing it.
+
+```bash
+bun run dump:openapi
+# OR run the test with the in-place self-update flag:
+UPDATE_OPENAPI_SNAPSHOT=1 bun run test:e2e tests/stories/openapi-snapshot.story.test.ts
+```
+
+The snapshot is the offline contract the frontend SDK targets — see
+[`docs/api-stability-promise.md`](../../docs/api-stability-promise.md).
+Commit the regenerated `docs/openapi.snapshot.json` alongside the
+module so reviewers can see the API surface change.
+
+## Step 10 — Quality gates
 
 ```bash
 bun run lint && bun run format && bun run test:types \
@@ -608,7 +628,7 @@ bun run lint && bun run format && bun run test:types \
 Coverage on `src/modules/` is gated at **≥ 80 %**. New code without a
 story drags the average — write more story tests.
 
-## Step 10 — Commit
+## Step 11 — Commit
 
 ```bash
 git add -A

--- a/scripts/check-rls.ts
+++ b/scripts/check-rls.ts
@@ -1,4 +1,14 @@
 #!/usr/bin/env bun
+// Force the workspace `.env` to win over inherited shell env. Without
+// this, a stale `DATABASE_URL` exported in the parent shell silently
+// shadows the workspace's `projects/api/.env`, so the runtime scan
+// connects to the wrong DB and reports false missing-tables. Matches
+// the pattern in `prisma.config.ts` + `scripts/dev.ts` so every
+// per-workspace tool agrees on the same DB regardless of shell state.
+import { config as loadEnv } from "dotenv";
+
+loadEnv({ override: true });
+
 /**
  * `bun run check:rls` — fails when a tenant-scoped Prisma model has
  * no `ENABLE ROW LEVEL SECURITY` migration anywhere in the tree

--- a/scripts/setup-wizard.ts
+++ b/scripts/setup-wizard.ts
@@ -38,7 +38,19 @@ const result = runSetupWizard({
   postgresHostPort,
 });
 
+// `.env` already on disk (typical after `lt fullstack init --next`,
+// where the CLI ships the API `.env` from the template). We still
+// reach this branch AFTER `runSetupWizard()` ran — which means the
+// frontend env-bridge has already fired and `projects/app/.env`
+// (when present) is now retargeted away from the upstream
+// `localhost:3000` literal. Surface that to the operator so a
+// re-run of `bun run setup` looks like progress, not a failure.
 if (!result.created) {
+  console.log("");
+  console.log(
+    "[setup] `.env` already exists — leaving it untouched. " +
+      "If `projects/app/` was added later, re-run `bun run setup` to fire the frontend env-bridge.",
+  );
   process.exit(1);
 }
 
@@ -90,6 +102,9 @@ console.log('  1. Review and adjust values in .env');
 console.log('  2. Start dependencies: docker compose up -d');
 console.log('  3. Run migrations:     bun run prisma:migrate');
 console.log('  4. Boot the server:    bun run dev');
+console.log(
+  '     (frontend env-bridge has retargeted projects/app/.env to follow the API automatically)',
+);
 
 function readComposeProjectName(cwd: string): string | undefined {
   // The wizard just wrote `.env`; read the value back rather than

--- a/src/core/dx/scaffold-module-planner.ts
+++ b/src/core/dx/scaffold-module-planner.ts
@@ -787,10 +787,20 @@ function renderNextSteps(ctx: NameContext): string {
      import { ${ctx.pascal}Module } from "../../modules/${ctx.kebab}/${ctx.kebab}.module.js";
      // …add ${ctx.pascal}Module to the @Module({ imports: [...] }) array.
 
-  5. (Optional) If non-admin tenant members manage ${ctx.pascal}, add it
+  5. Regenerate docs/openapi.snapshot.json so the snapshot test stays green:
+
+     bun run dump:openapi
+     # OR: UPDATE_OPENAPI_SNAPSHOT=1 bun run test:e2e tests/stories/openapi-snapshot.story.test.ts
+
+     The committed snapshot is the offline contract the frontend SDK
+     targets — adding a route changes it. Skipping this step turns
+     the snapshot-story test red on what looks like a ${ctx.pascal}-
+     related assertion.
+
+  6. (Optional) If non-admin tenant members manage ${ctx.pascal}, add it
      to EXTRA_MEMBER_RESOURCES (PR #66's multi-provider hook).
 
-  6. Story test ships RED on purpose. Edit assertions for your
+  7. Story test ships RED on purpose. Edit assertions for your
      domain, then run
 
      bun run test:e2e tests/stories/${ctx.kebab}-module.story.test.ts
@@ -800,7 +810,7 @@ function renderNextSteps(ctx: NameContext): string {
      past the gate without a deliberate edit — that's the project's
      RED-first TDD discipline.
 
-  7. Run the six quality gates:
+  8. Run the six quality gates:
 
      bun run lint && bun run test:unit && bun run test:e2e \\
        && bun run test:types && bun run test:coverage && bun run build

--- a/tests/stories/check-rls-loads-project-env.story.test.ts
+++ b/tests/stories/check-rls-loads-project-env.story.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
+const CHECK_RLS_SCRIPT = readFileSync(resolve(REPO_ROOT, "scripts/check-rls.ts"), "utf8");
+
+/**
+ * Story · `bun run check:rls` loads the workspace `.env` with
+ * `override: true` so a stale shell `DATABASE_URL` cannot point the
+ * runtime check at the wrong database.
+ *
+ * Friction-log entry (LLM-test 2026-05-04 #5 medium): a leftover
+ * `DATABASE_URL=postgresql://nest-base:...@localhost:5432/nest-base`
+ * exported from a prior session silently shadowed the workspace's
+ * `projects/api/.env`, so `bun run check:rls --runtime` connected to
+ * the wrong DB and reported every tenant-scoped table as "Table
+ * missing at runtime" — false negatives that derail the setup gate.
+ *
+ * `prisma.config.ts` already solves this for `prisma migrate` /
+ * `prisma:generate` by importing `dotenv` with `override: true`. The
+ * RLS runtime checker is per-workspace too, so the same pattern is the
+ * only correct answer here. Both the static scan and the runtime scan
+ * should agree on a freshly-migrated workspace, regardless of what the
+ * parent shell has exported.
+ *
+ * This is a "loader call shape" test — we assert that the script
+ * imports `dotenv` and invokes its loader with `override: true` BEFORE
+ * any code that reads `process.env.DATABASE_URL`. We deliberately do
+ * NOT execute the runner here (it would hit the file system + a real
+ * Postgres). The companion unit/integration tests for the planners
+ * (`rls-audit-planner`, `rls-runtime-planner`) cover behaviour.
+ */
+describe("Story · check:rls loads the workspace .env (override:true)", () => {
+  it("imports `config as loadEnv` from dotenv at the top of the script", () => {
+    expect(CHECK_RLS_SCRIPT).toMatch(
+      /import\s+\{\s*config\s+as\s+loadEnv\s*\}\s+from\s+["']dotenv["']/,
+    );
+  });
+
+  it("invokes the dotenv loader with `override: true`", () => {
+    // Match `loadEnv({ override: true })` allowing any whitespace or
+    // additional trailing keys (we only require override:true to be
+    // among them so a stale shell value can never win).
+    expect(CHECK_RLS_SCRIPT).toMatch(/loadEnv\(\s*\{[^}]*override:\s*true[^}]*\}\s*\)/);
+  });
+
+  it("loads `.env` BEFORE the first `process.env.DATABASE_URL` read", () => {
+    const loaderIdx = CHECK_RLS_SCRIPT.indexOf("loadEnv(");
+    const dbUrlIdx = CHECK_RLS_SCRIPT.indexOf("process.env.DATABASE_URL");
+    expect(loaderIdx).toBeGreaterThan(-1);
+    expect(dbUrlIdx).toBeGreaterThan(-1);
+    expect(loaderIdx).toBeLessThan(dbUrlIdx);
+  });
+});

--- a/tests/stories/scaffold-module-planner.story.test.ts
+++ b/tests/stories/scaffold-module-planner.story.test.ts
@@ -254,5 +254,17 @@ describe("Story · scaffold-module-planner", () => {
       expect(plan.nextSteps).toMatch(/AppModule|app\.module/);
       expect(plan.nextSteps).toMatch(/RLS|row[- ]level security/i);
     });
+
+    it("tells the operator to regenerate docs/openapi.snapshot.json after wiring the route", () => {
+      // Friction-log entry (LLM-test 2026-05-04 #5 medium): the
+      // openapi-snapshot story test fails on every new route until
+      // the snapshot is regenerated. Without this hint, fresh
+      // contributors lose half an hour chasing what looks like a
+      // module-level test failure.
+      const plan = planScaffoldModule({ name: "todo", existingResources: [] });
+      if (plan.action !== "write") throw new Error("expected write plan");
+      expect(plan.nextSteps).toMatch(/dump:openapi/);
+      expect(plan.nextSteps).toMatch(/openapi\.snapshot\.json/);
+    });
   });
 });

--- a/tests/stories/setup-wizard-frontend-env-bridge.story.test.ts
+++ b/tests/stories/setup-wizard-frontend-env-bridge.story.test.ts
@@ -274,4 +274,39 @@ describe("Story · setup-wizard runner writes projects/app/.env when present", (
     const frontendEnv = readFileSync(join(workspace, "projects/app/.env"), "utf8");
     expect(frontendEnv).toContain(customLine);
   });
+
+  it("still runs the env-bridge when projects/api/.env already exists (lt fullstack init --next flow)", () => {
+    // Friction-log entry (LLM-test 2026-05-04 #5 medium): in the
+    // `lt fullstack init --next` flow the API `.env` is already on
+    // disk before the user thinks to run `bun run setup`. The wizard
+    // refuses to overwrite the API `.env` (correct), but it must
+    // still fire the frontend env-bridge so the second `bun run
+    // setup` invocation actually retargets `projects/app/.env` away
+    // from the upstream `localhost:3000` literal. Without this
+    // contract, the only path to a working frontend is to delete
+    // `projects/api/.env` first — which destroys the operator's
+    // already-edited values.
+    writeFileSync(
+      join(workspace, "package.json"),
+      '{\n  "name": "my-fs",\n  "version": "0.0.0"\n}\n',
+    );
+    writeFileSync(join(workspace, ".env.example"), "PORT=3000\n");
+    // API .env already exists (lt fullstack init shipped it).
+    writeFileSync(join(workspace, ".env"), "PORT=3000\nDATABASE_URL=postgresql://x\n");
+    mkdirSync(join(workspace, "projects/app"), { recursive: true });
+    // Frontend .env still ships with the upstream sentinel.
+    writeFileSync(
+      join(workspace, "projects/app/.env"),
+      "NUXT_API_URL=http://localhost:3000\nNUXT_PUBLIC_API_URL=http://localhost:3000\n",
+    );
+
+    const result = runSetupWizard({ projectRoot: workspace, logger });
+    expect(result.created).toBe(false);
+
+    // The bridge MUST still have fired despite the wizard refusing to
+    // touch the API `.env`.
+    const frontendEnv = readFileSync(join(workspace, "projects/app/.env"), "utf8");
+    expect(frontendEnv).toMatch(/^NUXT_API_URL=https:\/\/api\.my-fs\.localhost$/m);
+    expect(frontendEnv).toMatch(/^NUXT_PUBLIC_API_URL=https:\/\/api\.my-fs\.localhost$/m);
+  });
 });


### PR DESCRIPTION
## Summary

Three medium-severity friction-log entries from LLM-test 2026-05-04
run #5, batched into one cohesive PR. Each fix has its own commit
for clean history; full details in the per-commit messages.

| Friction (timestamp) | Severity | Type | Fix |
|---|---|---|---|
| 07:58 — `bun run check:rls --runtime` is fooled by stale shell `DATABASE_URL` | medium | bug | Load workspace `.env` with `dotenv` `override:true` (matches `prisma.config.ts`) |
| 08:09 — `adding-feature-module.md` skill never mentions OpenAPI snapshot regenerate | medium | doc-gap | New Step 9 in the skill + line 5 in `add:module` "Next steps" output |
| 08:14 — Setup-wizard env-bridge doesn't propagate in `lt fullstack init --next` | medium | bug (cli-side, see below) | Document in QUICKSTART, surface bridge in `bun run setup` output, pin re-run contract with story test |

### Fix #1 — `check:rls` loads project `.env` with override

`scripts/check-rls.ts` now imports `dotenv` and calls `loadEnv({
override: true })` at the top of the script, matching the pattern
in `prisma.config.ts` and `scripts/dev.ts`. A stale shell
`DATABASE_URL` exported from a prior session can no longer shadow the
workspace's own `.env` — the runtime scan and the static scan now
always agree on a freshly-migrated workspace. Pinned by a new
loader-call-shape story test.

### Fix #2 — Skill + `add:module` output mention OpenAPI snapshot

`adding-feature-module.md` Step 9 ("Regenerate the OpenAPI snapshot")
explains why and how to keep `docs/openapi.snapshot.json` in sync
when adding a new route. The `add:module` scaffolder's printed "Next
steps" gains the same guidance as step 5 so operators don't need to
read the skill to find it.

### Fix #3 — Setup-wizard env-bridge audit

**Investigation revealed the env-bridge code is correct**: the planner
correctly retargets the upstream `localhost:3000` sentinel, and the
runner fires the bridge even when `projects/api/.env` already exists
(typical post-`lt fullstack init --next` state). 

**Root cause** of the friction author's observation: `lt fullstack
init --next` (in
`npm-Packages/cli/src/commands/fullstack/init.ts:670-672`) does NOT
invoke `bun run setup` — it only prints "Configure projects/api/.env
(see .env.example)" — so the wizard never runs in that flow, and the
bridge never fires.

**In-scope fix on this side:**

- `.claude/QUICKSTART.md` gains a callout: fresh `lt fullstack init
  --next` workspaces must run `bun run setup` to fire the bridge.
- `scripts/setup-wizard.ts` operator-visible output now states the
  bridge ran even when `.env` was untouched, and the final "Next
  steps" block mentions the bridge effect.
- `tests/stories/setup-wizard-frontend-env-bridge.story.test.ts`
  pins the contract: the bridge MUST fire even when
  `projects/api/.env` already exists.

**Out-of-scope (orchestrator pickup):** update `lt fullstack init
--next` to invoke `bun run setup` automatically, or at minimum
mention it in the printed "Next:" steps. Tracking it here so the
orchestrator can decide whether to spawn a CLI release.

## Test plan

- [x] `bun run lint` — green
- [x] `bun run format` — green (auto-fixed one new test file)
- [x] `bun run test:types` — green
- [x] `bun run test:unit` — 174/174 green
- [x] `bun run test:e2e` — 2902/2902 green
- [x] `bun run test:coverage` — green (testcontainer flake required one retry; second run clean, coverage thresholds met)
- [x] `bun run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)