### PR TITLE
feat(auth): BETTER_AUTH_RATE_LIMIT_ENABLED env switch (#98)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ POSTGRES_HOST_PORT=5432
 
 # ── Auth (Better-Auth) ─────────────────────────────────────────
 BETTER_AUTH_SECRET=change-me-32-chars-minimum-XXXXXX
+# Rate-limiter for /api/auth/* routes (credential-stuffing protection).
+# Defaults to false in test/development (rapid runs exhaust the window),
+# true in production. Set explicitly to override the NODE_ENV default.
+# BETTER_AUTH_RATE_LIMIT_ENABLED=false
 
 # ── System bootstrap (matched pair, unset to skip auto-admin) ──
 SYSTEM_SETUP_ADMIN_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -381,6 +381,11 @@ APP_BASE_URL=https://api.your-project.localhost   # or http://localhost:3000
 DATABASE_URL=postgresql://user:pass@localhost:5432/db
 BETTER_AUTH_SECRET=<32 bytes>
 
+# Better-Auth rate-limiter for /api/auth/* (credential-stuffing protection).
+# Default: false in test/development, true in production.
+# Override: BETTER_AUTH_RATE_LIMIT_ENABLED=true|false
+# BETTER_AUTH_RATE_LIMIT_ENABLED=false
+
 # Optional but useful in dev
 MAILPIT_WEB_URL=http://localhost:8025
 POWERSYNC_URL=http://localhost:8080

--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -29,6 +29,7 @@ import { resolveAppName } from "./better-auth-email-hooks.js";
 import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from "./better-auth.token.js";
 import { type SocialProviderConfig, buildBetterAuth } from "./better-auth.js";
 import { defaultAuthRateLimits } from "./rate-limit.js";
+import { isBetterAuthRateLimitEnabled } from "./rate-limit-flag.js";
 
 const MIN_SECRET_LEN = 32;
 
@@ -152,6 +153,10 @@ const MIN_SECRET_LEN = 32;
           // on `/api/auth/sign-in/*` rides on this surface alongside
           // the global @nestjs/throttler.
           authRateLimits: defaultAuthRateLimits(),
+          // BETTER_AUTH_RATE_LIMIT_ENABLED: defaults false in test/dev
+          // (rapid runs exhaust the window and generate spurious 429s),
+          // true in production and staging. Explicit env override wins.
+          rateLimitEnabled: isBetterAuthRateLimitEnabled(process.env as Record<string, string | undefined>),
           // Password policy enforcement is opt-in via env. The
           // service exposes the policy validator (entropy + optional
           // HIBP breach check) so signup / change-password run the

--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -156,7 +156,9 @@ const MIN_SECRET_LEN = 32;
           // BETTER_AUTH_RATE_LIMIT_ENABLED: defaults false in test/dev
           // (rapid runs exhaust the window and generate spurious 429s),
           // true in production and staging. Explicit env override wins.
-          rateLimitEnabled: isBetterAuthRateLimitEnabled(process.env as Record<string, string | undefined>),
+          rateLimitEnabled: isBetterAuthRateLimitEnabled(
+            process.env as Record<string, string | undefined>,
+          ),
           // Password policy enforcement is opt-in via env. The
           // service exposes the policy validator (entropy + optional
           // HIBP breach check) so signup / change-password run the

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -172,6 +172,14 @@ export interface BuildBetterAuthInput {
    * for the auth surface where brute-force resistance matters most.
    */
   authRateLimits?: AuthRateLimitsInput;
+  /**
+   * When `false`, the `authRateLimits` block is not forwarded to
+   * Better-Auth even if `authRateLimits` is set. Driven by
+   * `BETTER_AUTH_RATE_LIMIT_ENABLED` in `BetterAuthModule`; defaults
+   * to `true` so callers that omit this field keep the existing
+   * behaviour unchanged.
+   */
+  rateLimitEnabled?: boolean;
 }
 
 export interface AuthRateLimitWindow {
@@ -562,7 +570,10 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
     ...(input.socialProviders && Object.keys(input.socialProviders).length > 0
       ? { socialProviders: input.socialProviders as BetterAuthOptions["socialProviders"] }
       : {}),
-    ...(input.authRateLimits
+    // `rateLimitEnabled` defaults to true when absent — only suppress the
+    // block when the caller has explicitly set it to false (driven by the
+    // BETTER_AUTH_RATE_LIMIT_ENABLED env flag in BetterAuthModule).
+    ...(input.authRateLimits && input.rateLimitEnabled !== false
       ? {
           rateLimit: {
             // The global rate-limit defaults (window/max) cover every

--- a/src/core/auth/rate-limit-flag.ts
+++ b/src/core/auth/rate-limit-flag.ts
@@ -18,9 +18,7 @@
  * Override: set `BETTER_AUTH_RATE_LIMIT_ENABLED=true|false` to force a
  * specific value regardless of NODE_ENV.
  */
-export function isBetterAuthRateLimitEnabled(
-  env: Record<string, string | undefined>,
-): boolean {
+export function isBetterAuthRateLimitEnabled(env: Record<string, string | undefined>): boolean {
   const explicit = env["BETTER_AUTH_RATE_LIMIT_ENABLED"];
   if (explicit !== undefined) {
     return explicit !== "false";

--- a/src/core/auth/rate-limit-flag.ts
+++ b/src/core/auth/rate-limit-flag.ts
@@ -1,0 +1,31 @@
+/**
+ * `isBetterAuthRateLimitEnabled` — reads `BETTER_AUTH_RATE_LIMIT_ENABLED`
+ * from the supplied env-map and returns whether the Better-Auth rate-limiter
+ * should be active.
+ *
+ * WHY a separate helper instead of inline logic in BetterAuthModule:
+ * - Keeps the decision pure and fully unit-testable without a NestJS DI
+ *   context or process.env mutation.
+ * - A single export makes it easy to import in both the module and the
+ *   story tests.
+ *
+ * Default behaviour:
+ *   - `false` when NODE_ENV is "test" or "development" — rapid dev/CI runs
+ *     exhaust the window and generate spurious 429s, hurting DX.
+ *   - `true` in all other envs (production, staging, …) — brute-force
+ *     protection must be on by default where it matters.
+ *
+ * Override: set `BETTER_AUTH_RATE_LIMIT_ENABLED=true|false` to force a
+ * specific value regardless of NODE_ENV.
+ */
+export function isBetterAuthRateLimitEnabled(
+  env: Record<string, string | undefined>,
+): boolean {
+  const explicit = env["BETTER_AUTH_RATE_LIMIT_ENABLED"];
+  if (explicit !== undefined) {
+    return explicit !== "false";
+  }
+  // No explicit override — derive from NODE_ENV.
+  const nodeEnv = env["NODE_ENV"] ?? "";
+  return nodeEnv !== "test" && nodeEnv !== "development";
+}

--- a/src/core/setup/setup-wizard.ts
+++ b/src/core/setup/setup-wizard.ts
@@ -137,15 +137,9 @@ function renderEnvExample(answers: WizardAnswers): string {
   lines.push("");
   lines.push("# ── Auth (Better-Auth) ─────────────────────────────────────────");
   lines.push("BETTER_AUTH_SECRET=change-me-32-chars-minimum-XXXXXX");
-  lines.push(
-    "# Rate-limiter for /api/auth/* routes (credential-stuffing protection).",
-  );
-  lines.push(
-    "# Defaults to false in test/development (rapid runs exhaust the window),",
-  );
-  lines.push(
-    "# true in production. Set explicitly to override the NODE_ENV default.",
-  );
+  lines.push("# Rate-limiter for /api/auth/* routes (credential-stuffing protection).");
+  lines.push("# Defaults to false in test/development (rapid runs exhaust the window),");
+  lines.push("# true in production. Set explicitly to override the NODE_ENV default.");
   lines.push("# BETTER_AUTH_RATE_LIMIT_ENABLED=false");
   lines.push("");
   lines.push("# ── System bootstrap (matched pair, unset to skip auto-admin) ──");

--- a/src/core/setup/setup-wizard.ts
+++ b/src/core/setup/setup-wizard.ts
@@ -137,6 +137,16 @@ function renderEnvExample(answers: WizardAnswers): string {
   lines.push("");
   lines.push("# ── Auth (Better-Auth) ─────────────────────────────────────────");
   lines.push("BETTER_AUTH_SECRET=change-me-32-chars-minimum-XXXXXX");
+  lines.push(
+    "# Rate-limiter for /api/auth/* routes (credential-stuffing protection).",
+  );
+  lines.push(
+    "# Defaults to false in test/development (rapid runs exhaust the window),",
+  );
+  lines.push(
+    "# true in production. Set explicitly to override the NODE_ENV default.",
+  );
+  lines.push("# BETTER_AUTH_RATE_LIMIT_ENABLED=false");
   lines.push("");
   lines.push("# ── System bootstrap (matched pair, unset to skip auto-admin) ──");
   lines.push("SYSTEM_SETUP_ADMIN_EMAIL=admin@example.com");

--- a/tests/stories/better-auth-rate-limit-flag.story.test.ts
+++ b/tests/stories/better-auth-rate-limit-flag.story.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { buildBetterAuth } from "../../src/core/auth/better-auth.js";
+import { isBetterAuthRateLimitEnabled } from "../../src/core/auth/rate-limit-flag.js";
+
+/**
+ * Story · BETTER_AUTH_RATE_LIMIT_ENABLED env flag (issue #98).
+ *
+ * WHY: The Better-Auth rate-limiter trips up local dev + CI — every
+ * rapid test run or hot-reload sequence exhausts the window and returns
+ * 429s. Introducing BETTER_AUTH_RATE_LIMIT_ENABLED lets operators opt
+ * out of the limiter in those environments without touching production.
+ *
+ * Contract:
+ *   - Flag is `false` by default when NODE_ENV is "test" or "development".
+ *   - Flag is `true` by default in all other envs (production, staging, …).
+ *   - When BETTER_AUTH_RATE_LIMIT_ENABLED="false" the factory receives
+ *     no `authRateLimits`, so Better-Auth boots without its rate-limiter.
+ *   - When BETTER_AUTH_RATE_LIMIT_ENABLED="true" (or absent in production)
+ *     the full rate-limit config is wired.
+ *   - BetterAuthModule reads the flag at provider-init time (not at module
+ *     decoration time) so tests that set process.env in beforeAll see it.
+ */
+
+const ROOT = resolve(import.meta.dirname, "..", "..");
+
+describe("Story · BETTER_AUTH_RATE_LIMIT_ENABLED flag", () => {
+  describe("isBetterAuthRateLimitEnabled()", () => {
+    it("returns false when NODE_ENV=test and flag is unset", () => {
+      expect(isBetterAuthRateLimitEnabled({ NODE_ENV: "test" })).toBe(false);
+    });
+
+    it("returns false when NODE_ENV=development and flag is unset", () => {
+      expect(isBetterAuthRateLimitEnabled({ NODE_ENV: "development" })).toBe(false);
+    });
+
+    it("returns true when NODE_ENV=production and flag is unset", () => {
+      expect(isBetterAuthRateLimitEnabled({ NODE_ENV: "production" })).toBe(true);
+    });
+
+    it("returns true when NODE_ENV=staging and flag is unset", () => {
+      expect(isBetterAuthRateLimitEnabled({ NODE_ENV: "staging" })).toBe(true);
+    });
+
+    it("explicit BETTER_AUTH_RATE_LIMIT_ENABLED=false overrides production default", () => {
+      expect(
+        isBetterAuthRateLimitEnabled({
+          NODE_ENV: "production",
+          BETTER_AUTH_RATE_LIMIT_ENABLED: "false",
+        }),
+      ).toBe(false);
+    });
+
+    it("explicit BETTER_AUTH_RATE_LIMIT_ENABLED=true overrides test default", () => {
+      expect(
+        isBetterAuthRateLimitEnabled({
+          NODE_ENV: "test",
+          BETTER_AUTH_RATE_LIMIT_ENABLED: "true",
+        }),
+      ).toBe(true);
+    });
+
+    it("explicit BETTER_AUTH_RATE_LIMIT_ENABLED=true overrides development default", () => {
+      expect(
+        isBetterAuthRateLimitEnabled({
+          NODE_ENV: "development",
+          BETTER_AUTH_RATE_LIMIT_ENABLED: "true",
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when NODE_ENV is absent (unset = assume production-like)", () => {
+      expect(isBetterAuthRateLimitEnabled({})).toBe(true);
+    });
+  });
+
+  describe("buildBetterAuth() respects the flag via rateLimitEnabled input", () => {
+    const BASE_INPUT = {
+      secret: "test-secret-32-chars-minimum-aaaaaaaa",
+      baseUrl: "http://localhost:3000",
+      sessionExpiresInSeconds: 3600,
+    } as const;
+
+    it("when rateLimitEnabled=false the factory does not attach rateLimit config", () => {
+      const auth = buildBetterAuth({
+        ...BASE_INPUT,
+        rateLimitEnabled: false,
+      });
+      // Better-Auth's options shape is available at auth.options; when
+      // no authRateLimits were wired the rateLimit key is absent.
+      expect((auth.options as Record<string, unknown>).rateLimit).toBeUndefined();
+    });
+
+    it("when rateLimitEnabled=true the factory attaches rateLimit customRules", () => {
+      const auth = buildBetterAuth({
+        ...BASE_INPUT,
+        rateLimitEnabled: true,
+        authRateLimits: { signIn: { windowSeconds: 60, maxRequests: 5 } },
+      });
+      expect((auth.options as Record<string, unknown>).rateLimit).toBeDefined();
+    });
+
+    it("rateLimitEnabled defaults to true when not supplied (backward compat)", () => {
+      const auth = buildBetterAuth({
+        ...BASE_INPUT,
+        authRateLimits: { signIn: { windowSeconds: 60, maxRequests: 5 } },
+      });
+      // Rate limits should still be wired when rateLimitEnabled is absent.
+      expect((auth.options as Record<string, unknown>).rateLimit).toBeDefined();
+    });
+  });
+
+  describe("BetterAuthModule source wires the flag", () => {
+    it("module reads BETTER_AUTH_RATE_LIMIT_ENABLED at factory time", () => {
+      const src = readFileSync(
+        resolve(ROOT, "src/core/auth/better-auth.module.ts"),
+        "utf8",
+      );
+      expect(src).toContain("BETTER_AUTH_RATE_LIMIT_ENABLED");
+    });
+
+    it("module imports isBetterAuthRateLimitEnabled", () => {
+      const src = readFileSync(
+        resolve(ROOT, "src/core/auth/better-auth.module.ts"),
+        "utf8",
+      );
+      expect(src).toContain("isBetterAuthRateLimitEnabled");
+    });
+  });
+
+  describe(".env.example documents the flag", () => {
+    it("BETTER_AUTH_RATE_LIMIT_ENABLED appears in .env.example", () => {
+      const committed = readFileSync(resolve(ROOT, ".env.example"), "utf8");
+      expect(committed).toContain("BETTER_AUTH_RATE_LIMIT_ENABLED");
+    });
+  });
+});

--- a/tests/stories/better-auth-rate-limit-flag.story.test.ts
+++ b/tests/stories/better-auth-rate-limit-flag.story.test.ts
@@ -115,18 +115,12 @@ describe("Story · BETTER_AUTH_RATE_LIMIT_ENABLED flag", () => {
 
   describe("BetterAuthModule source wires the flag", () => {
     it("module reads BETTER_AUTH_RATE_LIMIT_ENABLED at factory time", () => {
-      const src = readFileSync(
-        resolve(ROOT, "src/core/auth/better-auth.module.ts"),
-        "utf8",
-      );
+      const src = readFileSync(resolve(ROOT, "src/core/auth/better-auth.module.ts"), "utf8");
       expect(src).toContain("BETTER_AUTH_RATE_LIMIT_ENABLED");
     });
 
     it("module imports isBetterAuthRateLimitEnabled", () => {
-      const src = readFileSync(
-        resolve(ROOT, "src/core/auth/better-auth.module.ts"),
-        "utf8",
-      );
+      const src = readFileSync(resolve(ROOT, "src/core/auth/better-auth.module.ts"), "utf8");
       expect(src).toContain("isBetterAuthRateLimitEnabled");
     });
   });


### PR DESCRIPTION
## Summary

- Adds `BETTER_AUTH_RATE_LIMIT_ENABLED` env flag with smart defaults: `false` in `test`/`development`, `true` in production/staging
- Introduces `isBetterAuthRateLimitEnabled(env)` pure helper in `src/core/auth/rate-limit-flag.ts` — fully unit-testable without DI context
- Gates `authRateLimits` forwarding in `buildBetterAuth()` via new `rateLimitEnabled?: boolean` input field
- `BetterAuthModule` reads the flag at provider-init time so test `beforeAll()` env mutations are respected
- Documents the flag in `.env.example` (Auth section) and `README.md` Environment Variables section
- 14 new story tests covering all flag combinations (test/dev/prod defaults + explicit overrides + factory behaviour + module source + .env.example)

## Test plan

- [x] `bun run test:e2e tests/stories/better-auth-rate-limit-flag.story.test.ts` — 14 tests green
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run test:unit` — 181 tests green
- [x] `bun run test:types` — no type errors
- [x] `bun run test:e2e` — 440/441 files pass (1 pre-existing flaky heap/latency test unrelated to this change)
- [x] `bun run build` — clean build
- [x] Related story tests (`env-example-file`, `better-auth-build`, `better-auth-rate-limit`, `better-auth-rate-limit-customrules`) all pass

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)