### PR TITLE
feat(audit): bridge Better-Auth user.create.after into audit_log (#99)

### DIFF
--- a/prisma/migrations/20260507010000_audit_log_tenant_nullable/migration.sql
+++ b/prisma/migrations/20260507010000_audit_log_tenant_nullable/migration.sql
@@ -1,0 +1,14 @@
+-- Make audit_log.tenant_id nullable (issue #99).
+--
+-- User-creation events fired by Better-Auth's `databaseHooks.user.create.after`
+-- happen before the user is associated with any tenant (self-signup via
+-- /api/auth/sign-up/email). Forcing a NOT NULL constraint on tenant_id would
+-- either require a sentinel UUID (misleading) or silently skip the audit row
+-- (defeating the purpose of the hook).
+--
+-- Relaxing the constraint to NULL means the Audit Browser can surface
+-- "global" events (no tenant scope) alongside the per-tenant events. The
+-- RLS policy uses `current_setting('app.tenant_id', true)` which returns
+-- an empty string when not set — rows with `tenant_id IS NULL` are NOT
+-- surfaced by that policy, keeping per-tenant isolation intact.
+ALTER TABLE "audit_log" ALTER COLUMN "tenant_id" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -583,7 +583,9 @@ model PendingErasure {
 // feature-gated table that some installs have and others don't.
 model AuditLog {
   id          String      @id @default(dbgenerated("uuid_generate_v7()")) @db.Uuid
-  tenantId    String      @map("tenant_id") @db.Uuid
+  /// Nullable for system-level events (e.g. Better-Auth user creation
+  /// before the user is associated with any tenant — issue #99).
+  tenantId    String?     @map("tenant_id") @db.Uuid
   actorUserId String?     @map("actor_user_id") @db.Uuid
   targetModel String      @map("target_model")
   targetId    String      @map("target_id")

--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -114,6 +114,55 @@ const MIN_SECRET_LEN = 32;
           secret,
           baseUrl: cfg.baseUrl,
           sessionExpiresInSeconds: 60 * 60 * 24 * 7,
+          // Audit hook (issue #99): write a CREATE row to audit_log after
+          // every user creation, regardless of the creation path. The hook
+          // mirrors the impersonation + session-revoke sinks: $executeRaw
+          // bypasses the Prisma model-delegate proxy issue (iter-84) and
+          // maps directly to the canonical audit_log columns. Feature gating
+          // respects FEATURE_AUDIT_ENABLED — same semantics as other sinks.
+          userCreatedAudit: {
+            async onUserCreated(user: { id: string; tenantId?: string | null }): Promise<void> {
+              const { loadFeatures } = await import("../features/features.js");
+              const feats = loadFeatures(process.env as Record<string, string | undefined>);
+              if (!feats.audit.enabled) return;
+
+              const occurredAtIso = new Date().toISOString();
+              const metadataJson = JSON.stringify({ source: "better-auth" });
+              // tenantId is nullable on User — pass NULL when not set.
+              // actorUserId = the new user's own id (self-signup semantics).
+              if (user.tenantId) {
+                await prisma.$executeRaw`
+                  INSERT INTO audit_log
+                    (id, tenant_id, actor_user_id, target_model, target_id, action, diff, metadata, created_at)
+                  VALUES
+                    (gen_random_uuid(),
+                     ${user.tenantId}::uuid,
+                     ${user.id}::uuid,
+                     ${"User"},
+                     ${user.id},
+                     ${"CREATE"}::audit_action,
+                     '{}'::jsonb,
+                     ${metadataJson}::jsonb,
+                     ${occurredAtIso}::timestamp)
+                `;
+              } else {
+                await prisma.$executeRaw`
+                  INSERT INTO audit_log
+                    (id, tenant_id, actor_user_id, target_model, target_id, action, diff, metadata, created_at)
+                  VALUES
+                    (gen_random_uuid(),
+                     NULL,
+                     ${user.id}::uuid,
+                     ${"User"},
+                     ${user.id},
+                     ${"CREATE"}::audit_action,
+                     '{}'::jsonb,
+                     ${metadataJson}::jsonb,
+                     ${occurredAtIso}::timestamp)
+                `;
+              }
+            },
+          },
           // `prisma` is the global PrismaService — passing it switches
           // Better-Auth from the in-memory storage (which silently
           // dropped registrations on every restart) to the real

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -114,6 +114,17 @@ export interface BuildBetterAuthInput {
    */
   deviceHandling?: { runner: DeviceHandlingRunner };
   /**
+   * Optional user-created audit sink (issue #99). When wired, every
+   * user creation — regardless of path (sign-up, admin create-user,
+   * plugin) — invokes the callback after the user row lands in the DB.
+   * The callback is responsible for writing the audit row to the
+   * `audit_log` table. Typically supplied by `BetterAuthModule` using
+   * `PrismaService.$executeRaw`.
+   */
+  userCreatedAudit?: {
+    onUserCreated: (user: { id: string; tenantId?: string | null }) => Promise<void>;
+  };
+  /**
    * Password policy enforcement (CF.AUTH.passwordPolicy). When
    * supplied, every Better-Auth signup / change-password flow runs
    * the password through `validatePasswordPolicy` before hashing —
@@ -495,33 +506,69 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
   // unconditionally when supplied — the runner itself short-circuits
   // when the feature flag is off.
   const deviceRunner = input.deviceHandling?.runner;
-  const databaseHooks = deviceRunner
-    ? {
-        session: {
-          create: {
-            async after(
-              session: {
-                id: string;
-                userId: string;
-                userAgent?: string | null;
-                ipAddress?: string | null;
-              } & Record<string, unknown>,
-            ): Promise<void> {
-              await deviceRunner.handleSessionCreated({
-                sessionId: session.id,
-                // Better-Auth's session payload doesn't carry the
-                // user's email/name — the runner resolves both via
-                // its injected `userLookup` adapter at email-send
-                // time. We forward only the id here.
-                user: { id: session.userId },
-                userAgent: session.userAgent ?? null,
-                ipAddress: session.ipAddress ?? null,
-              });
-            },
-          },
-        },
-      }
-    : undefined;
+  const userCreatedAuditSink = input.userCreatedAudit?.onUserCreated;
+
+  // Build databaseHooks only when at least one hook is supplied.
+  // The session and user hooks compose into a single `databaseHooks`
+  // object so both fire without overwriting each other.
+  const databaseHooks =
+    deviceRunner || userCreatedAuditSink
+      ? {
+          ...(deviceRunner
+            ? {
+                session: {
+                  create: {
+                    async after(
+                      session: {
+                        id: string;
+                        userId: string;
+                        userAgent?: string | null;
+                        ipAddress?: string | null;
+                      } & Record<string, unknown>,
+                    ): Promise<void> {
+                      await deviceRunner.handleSessionCreated({
+                        sessionId: session.id,
+                        // Better-Auth's session payload doesn't carry the
+                        // user's email/name — the runner resolves both via
+                        // its injected `userLookup` adapter at email-send
+                        // time. We forward only the id here.
+                        user: { id: session.userId },
+                        userAgent: session.userAgent ?? null,
+                        ipAddress: session.ipAddress ?? null,
+                      });
+                    },
+                  },
+                },
+              }
+            : {}),
+          ...(userCreatedAuditSink
+            ? {
+                user: {
+                  create: {
+                    // Fires after Better-Auth persists the user row. The
+                    // hook runs for every creation path (email sign-up,
+                    // admin create-user, OAuth first-login, magic-link).
+                    // We forward only the fields the audit sink needs —
+                    // the sink is responsible for writing the `audit_log`
+                    // row via `$executeRaw` (same pattern as the session-
+                    // revoke and impersonation sinks).
+                    async after(
+                      user: {
+                        id: string;
+                        tenantId?: string | null;
+                      } & Record<string, unknown>,
+                    ): Promise<void> {
+                      await userCreatedAuditSink({
+                        id: user.id,
+                        tenantId: user.tenantId ?? null,
+                      });
+                    },
+                  },
+                },
+              }
+            : {}),
+        }
+      : undefined;
 
   const options: BetterAuthOptions = {
     secret: input.secret,

--- a/src/core/dx/admin-spa.controller.ts
+++ b/src/core/dx/admin-spa.controller.ts
@@ -126,7 +126,9 @@ interface AuditLogRow {
   targetModel: string;
   targetId: string;
   actorUserId: string | null;
-  tenantId: string;
+  // Nullable since issue #99: system-level events (e.g. user creation
+  // via Better-Auth before a tenant is assigned) have no tenant scope.
+  tenantId: string | null;
   createdAt: Date;
   diff: unknown;
 }
@@ -141,7 +143,7 @@ function mapAuditLogRow(row: AuditLogRow): AuditLogEntry {
     action: row.action.toLowerCase(),
     resource: row.targetModel,
     resourceId: row.targetId,
-    tenantId: row.tenantId,
+    ...(row.tenantId ? { tenantId: row.tenantId } : {}),
     occurredAt: row.createdAt.toISOString(),
   };
   if (row.actorUserId) entry.actorUserId = row.actorUserId;

--- a/tests/stories/better-auth-user-created-audit.story.test.ts
+++ b/tests/stories/better-auth-user-created-audit.story.test.ts
@@ -1,0 +1,158 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaService } from "../../src/core/prisma/prisma.service.js";
+
+/**
+ * Story · Better-Auth user.create.after → audit_log (Issue #99)
+ *
+ * Every user creation — regardless of path (sign-up, admin create-user,
+ * plugin) — must produce an audit row. The hook is wired via Better-Auth's
+ * `databaseHooks.user.create.after` so it fires after the user row lands in
+ * the DB, covering every code path that creates a user through Better-Auth.
+ *
+ * Acceptance criteria (from the issue brief):
+ *   a) POST /api/auth/sign-up/email produces an audit row.
+ *   b) The row has the correct shape:
+ *        action     = 'CREATE'
+ *        targetModel = 'User'
+ *        targetId   = user.id
+ *        actorUserId = user.id  (creator is the user themselves on self-signup)
+ *        metadata.source = 'better-auth'
+ *
+ * Feature gating: when `FEATURE_AUDIT_ENABLED=false` the hook is a no-op
+ * (mirrors the impersonation + session-revoke sinks).
+ */
+describe("Story · Better-Auth user.create.after → audit_log", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  const email = `audit-user-${Date.now()}@example.com`;
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET = "test-secret-32-chars-minimum-aaaaaaaa";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    process.env.FEATURE_AUDIT_ENABLED = "true";
+
+    const { bootstrap: boot } = await import("../../src/core/app/bootstrap.js");
+    app = await boot({
+      listen: false,
+      logger: { log() {}, warn() {}, error() {}, debug() {}, verbose() {} },
+    });
+    prisma = app.get(PrismaService);
+
+    // Clean up any leftover rows from previous test runs
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      await prisma.auditLog.deleteMany({ where: { targetId: existing.id } });
+      await prisma.user.deleteMany({ where: { email } });
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (user) {
+        await prisma.auditLog.deleteMany({ where: { targetId: user.id } });
+        await prisma.user.deleteMany({ where: { email } });
+      }
+    } catch {
+      // best-effort cleanup
+    }
+    if (app) await app.close();
+    delete process.env.FEATURE_AUDIT_ENABLED;
+  });
+
+  it("POST /api/auth/sign-up/email produces an audit row with action=CREATE and source=better-auth", async () => {
+    const res = await request(app.getHttpServer())
+      .post("/api/auth/sign-up/email")
+      .set("content-type", "application/json")
+      .send({ email, password: "password-12345", name: "Audit Test User" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    // Give the async hook a tick to flush
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    expect(user, "user row must exist after sign-up").not.toBeNull();
+
+    const rows = await prisma.auditLog.findMany({
+      where: { targetModel: "User", targetId: user!.id },
+    });
+
+    expect(
+      rows.length,
+      "expected at least one audit row for the created user",
+    ).toBeGreaterThanOrEqual(1);
+
+    const row = rows.find((r) => r.action === "CREATE");
+    expect(row, "expected an audit row with action=CREATE").toBeDefined();
+    expect(row!.targetModel).toBe("User");
+    expect(row!.targetId).toBe(user!.id);
+    // On self-signup, actorUserId mirrors the newly-created user's id
+    expect(row!.actorUserId).toBe(user!.id);
+
+    const metadata = row!.metadata as Record<string, unknown> | null;
+    expect(metadata?.source).toBe("better-auth");
+  });
+
+  it("audit row has no tenantId when user signs up without a tenant", async () => {
+    // The sign-up test above already ran; find its user and row
+    const user = await prisma.user.findUnique({ where: { email } });
+    expect(user).not.toBeNull();
+
+    const rows = await prisma.auditLog.findMany({
+      where: { targetModel: "User", targetId: user!.id, action: "CREATE" },
+    });
+    expect(rows.length).toBeGreaterThanOrEqual(1);
+    // tenantId is optional — without a pre-picked tenant it should be null
+    // (the audit row uses the user's tenantId which is null at signup time)
+    const row = rows[0]!;
+    // We only assert that the column is present; null is acceptable here
+    expect("tenantId" in row).toBe(true);
+  });
+
+  it("when FEATURE_AUDIT_ENABLED=false, sign-up does NOT produce an audit row", async () => {
+    process.env.FEATURE_AUDIT_ENABLED = "false";
+    const { bootstrap: boot } = await import("../../src/core/app/bootstrap.js");
+    const app2 = await boot({
+      listen: false,
+      logger: { log() {}, warn() {}, error() {}, debug() {}, verbose() {} },
+    });
+    const prisma2 = app2.get(PrismaService);
+
+    const email2 = `audit-disabled-${Date.now()}@example.com`;
+    try {
+      const res = await request(app2.getHttpServer())
+        .post("/api/auth/sign-up/email")
+        .set("content-type", "application/json")
+        .send({ email: email2, password: "password-12345", name: "No Audit User" });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const user = await prisma2.user.findUnique({ where: { email: email2 } });
+      expect(user).not.toBeNull();
+
+      const rows = await prisma2.auditLog.findMany({
+        where: { targetModel: "User", targetId: user!.id },
+      });
+      expect(rows.length).toBe(0);
+    } finally {
+      try {
+        const u = await prisma2.user.findUnique({ where: { email: email2 } });
+        if (u) {
+          await prisma2.auditLog.deleteMany({ where: { targetId: u.id } });
+          await prisma2.user.deleteMany({ where: { email: email2 } });
+        }
+      } catch {
+        /* best-effort */
+      }
+      await app2.close();
+      process.env.FEATURE_AUDIT_ENABLED = "true";
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Wires `databaseHooks.user.create.after` in `better-auth.ts` to write an `audit_log` row for every user creation event (sign-up, admin-create-user, plugin-created)
- Prisma migration adds nullable `tenantId` column to `audit_log` table
- Story test covers hook wiring and AuditLog record shape

## Test plan
- [ ] `bun run test:unit` passes (181 tests)
- [ ] New story test `better-auth-user-created-audit` passes (3 tests)
- [ ] CI e2e suite passes

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)