### PR TITLE
feat(multi-tenancy): TenantInterceptor falls back to session.activeOrganizationId (#103)

### DIFF
--- a/src/core/auth/session-middleware.ts
+++ b/src/core/auth/session-middleware.ts
@@ -18,10 +18,24 @@ import { BETTER_AUTH_INSTANCE, type BetterAuthInstance } from "./better-auth.tok
  *
  * Mirrors what `PermissionInterceptor` and the `@Ability()` param
  * decorator already expect on the request. Kept minimal — middleware
- * downstream / domain code only reads `id` and `tenantId`.
+ * downstream / domain code only reads `id`, `tenantId`, and (when the
+ * Better-Auth organization plugin is active) `activeOrganizationId`.
  */
 export interface AuthenticatedRequest extends Request {
-  user?: { id: string; tenantId: string | null };
+  user?: {
+    id: string;
+    tenantId: string | null;
+    /**
+     * Active organization id set by the Better-Auth organization plugin
+     * when the client calls `POST /api/auth/organization/set-active`.
+     * Projected from the session's `activeOrganizationId` field;
+     * undefined when the org plugin is disabled or no org has been
+     * activated for this session. Used by `resolveRequestTenantId` as
+     * the preferred tenant fallback when no `x-tenant-id` header is
+     * present (issue #103).
+     */
+    activeOrganizationId?: string | null;
+  };
 }
 
 /**
@@ -90,6 +104,11 @@ export class BetterAuthSessionMiddleware implements NestMiddleware {
       req.user = {
         id: session.user.id,
         tenantId: extractTenantId(session.user),
+        // Project the Better-Auth organization plugin's `activeOrganizationId`
+        // from the session row onto req.user so `resolveRequestTenantId` can
+        // use it as a per-request tenant fallback without requiring clients to
+        // send `x-tenant-id` on every request (issue #103).
+        activeOrganizationId: extractActiveOrganizationId(session),
       };
       next();
       return;
@@ -107,13 +126,37 @@ interface SessionUser {
   tenantId?: string | null;
 }
 
-type SessionLookup = { user: SessionUser } | null;
+interface SessionRecord {
+  /**
+   * The session row fields. When the Better-Auth organization plugin is
+   * active, the session row carries `activeOrganizationId` (set by the
+   * client calling `POST /api/auth/organization/set-active`). The field
+   * is optional because it is absent when the plugin is disabled or no
+   * org has been activated for this session.
+   */
+  activeOrganizationId?: string | null;
+}
+
+type SessionLookup = { user: SessionUser; session: SessionRecord } | null;
 
 function extractTenantId(user: SessionUser): string | null {
   // `tenantId` is declared as `additionalFields.tenantId` on the
   // Better-Auth user; the adapter projects it through. May be null
   // for users that haven't been linked to a tenant yet.
   return user.tenantId ?? null;
+}
+
+function extractActiveOrganizationId(lookup: {
+  user: SessionUser;
+  session: SessionRecord;
+}): string | null {
+  // The Better-Auth organization plugin stores the user's active org in
+  // the session row so the server knows which tenant context to use
+  // without requiring the client to send a header on every request.
+  // This is undefined when the plugin is off; null when the plugin is on
+  // but no org has been activated. Both map to null here — the resolver
+  // treats them identically (fall through to `req.user.tenantId`).
+  return lookup.session.activeOrganizationId ?? null;
 }
 
 function stripQuery(path: string): string {

--- a/src/core/multi-tenancy/resolve-request-tenant.ts
+++ b/src/core/multi-tenancy/resolve-request-tenant.ts
@@ -37,9 +37,15 @@ import type { PrismaService } from "../prisma/prisma.service.js";
  *      `ForbiddenException`. Storage failure → re-throw (callers
  *      decide; the middleware fails closed = empty ability rather
  *      than fail open = silent fallback to a foreign tenant).
- *   4. No header, `req.user.tenantId` non-null → return it. This is
+ *   4. No header, `req.user.activeOrganizationId` non-null → return it.
+ *      The Better-Auth organization plugin writes this to the session
+ *      when the client calls POST /api/auth/organization/set-active.
+ *      `BetterAuthSessionMiddleware` projects it onto `req.user` so
+ *      clients can omit the x-tenant-id header after activating an org
+ *      (issue #103).
+ *   5. No header, `req.user.tenantId` non-null → return it. This is
  *      the "session tenant" for users with a single primary tenant.
- *   5. No header, no session tenant → return `null`.
+ *   6. No header, no session tenant → return `null`.
  *
  * The cache hint on `req.__resolvedTenantId` is intentionally not set
  * here — both call sites are independent (interceptor runs before
@@ -56,7 +62,19 @@ const TENANT_HEADER = "x-tenant-id";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface AuthenticatedRequest extends Request {
-  user?: { id: string; tenantId: string | null };
+  user?: {
+    id: string;
+    tenantId: string | null;
+    /**
+     * Active organization id set by the Better-Auth organization plugin
+     * when the client called `POST /api/auth/organization/set-active`.
+     * The session row carries this value; `BetterAuthSessionMiddleware`
+     * projects it onto `req.user` so downstream code never has to reach
+     * back into the session. May be undefined when the org plugin is
+     * disabled or when no org has been activated for this session.
+     */
+    activeOrganizationId?: string | null;
+  };
 }
 
 export async function resolveRequestTenantId(
@@ -113,8 +131,13 @@ export async function resolveRequestTenantId(
     return tenantId;
   }
 
-  // No header → fall back to the user's primary / session tenant.
-  // May be null on anonymous routes; callers (interceptor on exempt
-  // paths, middleware for unauthenticated requests) decide.
-  return req.user?.tenantId ?? null;
+  // No header → fall back to the session's active organization id first
+  // (issue #103). When the Better-Auth organization plugin is enabled,
+  // the client can call POST /api/auth/organization/set-active once and
+  // then omit the x-tenant-id header on subsequent requests; the active
+  // org id travels in the session and is projected here by
+  // BetterAuthSessionMiddleware. If that is absent, fall back to the
+  // user's primary tenant id. Either value may be null (anonymous route,
+  // or user not yet linked to a tenant); callers decide what null means.
+  return req.user?.activeOrganizationId ?? req.user?.tenantId ?? null;
 }

--- a/src/core/multi-tenancy/tenant.interceptor.ts
+++ b/src/core/multi-tenancy/tenant.interceptor.ts
@@ -48,7 +48,16 @@ import { parseTenantHeader } from "./tenant-header.js";
 export { getCurrentTenantId, runWithTenant };
 
 interface AuthenticatedRequest extends Request {
-  user?: { id: string; tenantId: string | null };
+  user?: {
+    id: string;
+    tenantId: string | null;
+    /**
+     * Active organization id from the Better-Auth session (issue #103).
+     * Projected by `BetterAuthSessionMiddleware`; undefined when the
+     * org plugin is off or no org has been activated this session.
+     */
+    activeOrganizationId?: string | null;
+  };
 }
 
 @Injectable()

--- a/src/core/permissions/ability.middleware.ts
+++ b/src/core/permissions/ability.middleware.ts
@@ -8,7 +8,18 @@ import { type Ability, buildAbility } from "./casl-ability.js";
 import { PermissionService } from "./permission.service.js";
 
 interface AuthenticatedRequest extends Request {
-  user?: { id: string; tenantId: string | null };
+  user?: {
+    id: string;
+    tenantId: string | null;
+    /**
+     * Active organization id from the Better-Auth session (issue #103).
+     * Projected by `BetterAuthSessionMiddleware`; undefined when the
+     * org plugin is off or no org has been activated this session.
+     * `resolveRequestTenantId` reads this as the preferred fallback
+     * when no `x-tenant-id` header is present.
+     */
+    activeOrganizationId?: string | null;
+  };
   ability?: Ability;
 }
 

--- a/tests/stories/resolve-request-tenant.story.test.ts
+++ b/tests/stories/resolve-request-tenant.story.test.ts
@@ -35,7 +35,7 @@ describe("Story · resolveRequestTenantId", () => {
   const VALID_TENANT_B = "00000000-0000-4000-8000-000000000002";
 
   type Req = {
-    user?: { id: string; tenantId: string | null };
+    user?: { id: string; tenantId: string | null; activeOrganizationId?: string | null };
     headers?: Record<string, string | string[] | undefined>;
   };
 
@@ -211,5 +211,64 @@ describe("Story · resolveRequestTenantId", () => {
     const result = await resolveRequestTenantId(req as never, prisma);
     expect(result).toBeNull();
     expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  // Issue #103 — session.activeOrganizationId fallback
+  it("falls back to session.activeOrganizationId when no header is present (issue #103)", async () => {
+    // When the caller has authenticated and the Better-Auth organization
+    // plugin wrote an `activeOrganizationId` to the session, that value
+    // should serve as the tenant id for requests that arrive without an
+    // explicit `x-tenant-id` header. This allows mobile / web clients
+    // that set the active org once (via /api/auth/organization/set-active)
+    // to omit the header on every subsequent request.
+    const prisma = makePrismaWithRow(null);
+    const req: Req = {
+      user: { id: "u1", tenantId: null, activeOrganizationId: VALID_TENANT_A },
+      headers: {},
+    };
+    const result = await resolveRequestTenantId(req as never, prisma);
+    expect(result).toBe(VALID_TENANT_A);
+    // No header → no DB lookup needed (same short-circuit as the tenantId path).
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("prefers header over session.activeOrganizationId when both are present (header wins)", async () => {
+    // The `x-tenant-id` header is the explicit per-request override.
+    // A client that wants to act in a different tenant than the session
+    // default can always supply the header — the header always wins.
+    const prisma = makePrismaWithRow({ id: "m1", status: "ACTIVE" });
+    const req: Req = {
+      user: { id: "u1", tenantId: null, activeOrganizationId: VALID_TENANT_B },
+      headers: { "x-tenant-id": VALID_TENANT_A },
+    };
+    const result = await resolveRequestTenantId(req as never, prisma);
+    expect(result).toBe(VALID_TENANT_A);
+  });
+
+  it("prefers session.activeOrganizationId over req.user.tenantId when no header is set", async () => {
+    // When the user has both a primary tenant (tenantId) and an active
+    // organization in their session (activeOrganizationId), the session
+    // active organization wins — it is the more specific, user-selected
+    // context. The primary tenantId remains as the ultimate fallback
+    // when activeOrganizationId is absent.
+    const prisma = makePrismaWithRow(null);
+    const req: Req = {
+      user: { id: "u1", tenantId: VALID_TENANT_B, activeOrganizationId: VALID_TENANT_A },
+      headers: {},
+    };
+    const result = await resolveRequestTenantId(req as never, prisma);
+    expect(result).toBe(VALID_TENANT_A);
+  });
+
+  it("falls back to req.user.tenantId when activeOrganizationId is null and no header is set", async () => {
+    // Preserves existing behaviour: users without an active organization
+    // still get their primary tenant as the resolved tenant id.
+    const prisma = makePrismaWithRow(null);
+    const req: Req = {
+      user: { id: "u1", tenantId: VALID_TENANT_B, activeOrganizationId: null },
+      headers: {},
+    };
+    const result = await resolveRequestTenantId(req as never, prisma);
+    expect(result).toBe(VALID_TENANT_B);
   });
 });

--- a/tests/stories/tenant-interceptor.story.test.ts
+++ b/tests/stories/tenant-interceptor.story.test.ts
@@ -115,6 +115,50 @@ describe("Story · Tenant-Interceptor + RLS", () => {
       await expect(Promise.resolve(result).then((r) => lastValueFrom(r))).rejects.toThrow();
     });
 
+    // Issue #103 — session.activeOrganizationId fallback
+    it("resolves the tenant from session.activeOrganizationId when no header is present (issue #103)", async () => {
+      // Authenticated request with an active organization in the session but
+      // without an x-tenant-id header: the interceptor must use the session's
+      // activeOrganizationId as the tenant id. This allows clients that invoke
+      // POST /api/auth/organization/set-active once to omit the header on
+      // subsequent requests.
+      const tenantId = "0af76519-16cd-43dd-8448-eb211c80319c";
+      const fakePrisma = {
+        tenantMember: {
+          findFirst: async () => null,
+        },
+      };
+      // The unauthenticated code-path only uses parseTenantHeader and
+      // never calls `resolveRequestTenantId`, so we test the authenticated
+      // path by passing a user + prisma stub. `TenantInterceptor` uses
+      // `resolveRequestTenantId` for auth'd requests, which now reads
+      // `req.user.activeOrganizationId` when no header is present.
+      const interceptor = new TenantInterceptor(fakePrisma as never);
+      const req = {
+        headers: {},
+        originalUrl: "/api/users",
+        url: "/api/users",
+        user: { id: "u1", tenantId: null, activeOrganizationId: tenantId },
+      };
+      const ctx = {
+        switchToHttp: () => ({
+          getRequest: () => req,
+          getResponse: () => ({}),
+          getNext: () => null,
+        }),
+        getType: () => "http",
+      } as unknown as import("@nestjs/common").ExecutionContext;
+      let observed: string | undefined;
+      const result$ = interceptor.intercept(ctx, {
+        handle: () => {
+          observed = getCurrentTenantId();
+          return of("ok");
+        },
+      });
+      await lastValueFrom(await Promise.resolve(result$));
+      expect(observed).toBe(tenantId);
+    });
+
     it("integrates with request-context — tenant is visible alongside requestId/traceId", async () => {
       const tenantId = "0af76519-16cd-43dd-8448-eb211c80319c";
       const interceptor = new TenantInterceptor();

--- a/tests/unit/resolve-request-tenant-active-org.spec.ts
+++ b/tests/unit/resolve-request-tenant-active-org.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveRequestTenantId } from "../../src/core/multi-tenancy/resolve-request-tenant.js";
+import type { PrismaService } from "../../src/core/prisma/prisma.service.js";
+
+/**
+ * Unit tests for the `session.activeOrganizationId` fallback in
+ * `resolveRequestTenantId` (issue #103).
+ *
+ * These tests exercise the pure-function logic of the tenant resolver
+ * in isolation — no NestJS bootstrap, no DB, no HTTP layer. The scenario:
+ * an authenticated user whose Better-Auth session carries an
+ * `activeOrganizationId` should have that id resolved as the tenant
+ * context when no explicit `x-tenant-id` header is present.
+ */
+describe("resolveRequestTenantId · activeOrganizationId fallback (issue #103)", () => {
+  const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+  type Req = {
+    user?: { id: string; tenantId: string | null; activeOrganizationId?: string | null };
+    headers?: Record<string, string | string[] | undefined>;
+  };
+
+  function noDbPrisma(): PrismaService {
+    return {
+      tenantMember: { findFirst: vi.fn(async () => null) },
+    } as unknown as PrismaService;
+  }
+
+  it("returns activeOrganizationId when no header is present", async () => {
+    const prisma = noDbPrisma();
+    const req: Req = {
+      user: { id: "u1", tenantId: null, activeOrganizationId: TENANT_A },
+      headers: {},
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBe(TENANT_A);
+    // No membership lookup — the org id comes straight from the session.
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("prefers activeOrganizationId over tenantId when both are set and no header is present", async () => {
+    const prisma = noDbPrisma();
+    const req: Req = {
+      user: { id: "u1", tenantId: TENANT_B, activeOrganizationId: TENANT_A },
+      headers: {},
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBe(TENANT_A);
+  });
+
+  it("falls back to tenantId when activeOrganizationId is null", async () => {
+    const prisma = noDbPrisma();
+    const req: Req = {
+      user: { id: "u1", tenantId: TENANT_B, activeOrganizationId: null },
+      headers: {},
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBe(TENANT_B);
+  });
+
+  it("falls back to tenantId when activeOrganizationId is undefined (plugin disabled)", async () => {
+    const prisma = noDbPrisma();
+    const req: Req = {
+      user: { id: "u1", tenantId: TENANT_B, activeOrganizationId: undefined },
+      headers: {},
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBe(TENANT_B);
+  });
+
+  it("header still wins over activeOrganizationId when both are present", async () => {
+    // The x-tenant-id header is the explicit per-request override and
+    // always takes precedence over any session-derived value.
+    const prisma = {
+      tenantMember: {
+        findFirst: vi.fn(async () => ({ id: "m1", status: "ACTIVE" })),
+      },
+    } as unknown as PrismaService;
+    const req: Req = {
+      user: { id: "u1", tenantId: null, activeOrganizationId: TENANT_B },
+      headers: { "x-tenant-id": TENANT_A },
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBe(TENANT_A);
+  });
+
+  it("returns null when user has no activeOrganizationId and no tenantId and no header", async () => {
+    const prisma = noDbPrisma();
+    const req: Req = {
+      user: { id: "u1", tenantId: null, activeOrganizationId: null },
+      headers: {},
+    };
+    expect(await resolveRequestTenantId(req as never, prisma)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `TenantInterceptor` now falls back to `req.user.activeOrganizationId` when the `X-Tenant-Id` header is absent
- Fixes 403 errors on initial bootstrap / deep-link flows before org-switcher has hydrated
- Explicit header still wins; fallback only activates when header is missing
- New unit test + updated story tests cover all three cases (header, fallback, neither)

## Test plan
- [ ] `bun run test:unit` passes (187 tests including 6 new)
- [ ] New story tests pass
- [ ] CI e2e suite passes

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)