### PR TITLE
feat(auth): accept pre-hashed SHA-256 passwords from trusted clients (#100)

### DIFF
--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -13,6 +13,7 @@ import { twoFactor } from "better-auth/plugins/two-factor";
 
 import type { DeviceHandlingRunner } from "../devices/device-handling.runner.js";
 import { validatePasswordPolicy } from "./password-policy.js";
+import { isPreHashedSha256 } from "./prehashed-password.js";
 import { resolveBetterAuthMountPath } from "./better-auth-config.js";
 import {
   createEmailHookRunner,
@@ -409,6 +410,15 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
       ? {
           password: {
             async hash(password: string): Promise<string> {
+              // SDK clients that hash the password locally before
+              // transmission send `sha256:<64-char-hex>`. The entropy
+              // check would reject a single-class hex digest even though
+              // the original password may be arbitrarily strong, so we
+              // skip policy validation for this sentinel and hash as-is.
+              if (isPreHashedSha256(password)) {
+                const { hashPassword } = await import("better-auth/crypto");
+                return hashPassword(password);
+              }
               const opts: { minEntropyBits?: number } = {};
               if (passwordPolicyInput.minEntropyBits !== undefined) {
                 opts.minEntropyBits = passwordPolicyInput.minEntropyBits;

--- a/src/core/auth/prehashed-password.ts
+++ b/src/core/auth/prehashed-password.ts
@@ -1,0 +1,22 @@
+/**
+ * Sentinel prefix that SDK clients prepend to a locally-computed
+ * SHA-256 digest before transmitting the password field. The server's
+ * character-class entropy check would otherwise reject a 64-char
+ * lowercase hex string (only one class present) even though the
+ * underlying password may be arbitrarily strong.
+ */
+export const PRE_HASH_PREFIX = "sha256:";
+
+// sha256: followed by exactly 64 lowercase hex chars — the only
+// shape that unambiguously signals a client-side pre-hash.
+const PRE_HASH_RE = /^sha256:[0-9a-f]{64}$/;
+
+/**
+ * Returns true when `value` carries the `sha256:<64-char-hex>` sentinel
+ * that trusted SDK clients use to signal a locally-computed SHA-256
+ * digest. Uppercase hex chars are rejected because SHA-256 digests
+ * produced by the reference SDK are always lowercase.
+ */
+export function isPreHashedSha256(value: string): boolean {
+  return PRE_HASH_RE.test(value);
+}

--- a/tests/stories/prehashed-password.story.test.ts
+++ b/tests/stories/prehashed-password.story.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBetterAuth } from "../../src/core/auth/better-auth.js";
+import { PRE_HASH_PREFIX, isPreHashedSha256 } from "../../src/core/auth/prehashed-password.js";
+
+/**
+ * Story · Pre-hashed SHA-256 password bypass (issue #100).
+ *
+ * When a trusted SDK client hashes the password locally before
+ * transmission it sends the value as `sha256:<64-char-lowercase-hex>`.
+ * The server's character-class entropy check would otherwise reject the
+ * hex digest (low diversity despite 64 chars). The prefix sentinel lets
+ * the `password.hash` hook detect this case and skip the policy check
+ * while still applying the server's own scrypt hash on top.
+ *
+ * Two layers covered:
+ *   1. `isPreHashedSha256(value)` — pure shape detector.
+ *   2. Integration: the `buildBetterAuth` `password.hash` hook accepts
+ *      a valid sentinel but still rejects a plaintext weak password.
+ */
+describe("Story · isPreHashedSha256 (pre-hashed password shape detector)", () => {
+  it("accepts a valid sha256-prefixed 64-char lowercase hex string", () => {
+    expect(isPreHashedSha256(`sha256:${"a".repeat(64)}`)).toBe(true);
+  });
+
+  it("rejects uppercase hex digits — the sentinel requires lowercase", () => {
+    expect(isPreHashedSha256(`sha256:${"A".repeat(64)}`)).toBe(false);
+  });
+
+  it("rejects a hex digest that is one char too short (63 hex chars)", () => {
+    expect(isPreHashedSha256(`sha256:${"a".repeat(63)}`)).toBe(false);
+  });
+
+  it("rejects a raw 64-char hex string without the sha256: prefix", () => {
+    expect(isPreHashedSha256("a".repeat(64))).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(isPreHashedSha256("")).toBe(false);
+  });
+
+  it("exports the PRE_HASH_PREFIX constant as 'sha256:'", () => {
+    expect(PRE_HASH_PREFIX).toBe("sha256:");
+  });
+
+  it("rejects a hex digest that is one char too long (65 hex chars)", () => {
+    expect(isPreHashedSha256(`sha256:${"a".repeat(65)}`)).toBe(false);
+  });
+
+  it("rejects mixed-case hex digits", () => {
+    expect(isPreHashedSha256(`sha256:${"aB".repeat(32)}`)).toBe(false);
+  });
+});
+
+describe("Story · buildBetterAuth password.hash hook — pre-hashed bypass (issue #100)", () => {
+  it("resolves without throwing when password carries the sha256: sentinel", async () => {
+    const auth = buildBetterAuth({
+      secret: "a".repeat(32),
+      baseUrl: "http://localhost:3000",
+      sessionExpiresInSeconds: 60,
+      passwordPolicy: { minEntropyBits: 50 },
+    });
+
+    // Access the hash function via the Better-Auth options object.
+    const hashFn = auth.options.emailAndPassword?.password?.hash;
+    expect(hashFn).toBeDefined();
+
+    const validSentinel = `sha256:${"a".repeat(64)}`;
+    // Should resolve to a non-empty hash string without throwing.
+    const result = await hashFn!(validSentinel);
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a short plaintext password with a PasswordPolicyError when policy is configured", async () => {
+    const { PasswordPolicyError } = await import("../../src/core/auth/password-policy.js");
+
+    const auth = buildBetterAuth({
+      secret: "a".repeat(32),
+      baseUrl: "http://localhost:3000",
+      sessionExpiresInSeconds: 60,
+      passwordPolicy: { minEntropyBits: 50 },
+    });
+
+    const hashFn = auth.options.emailAndPassword?.password?.hash;
+    expect(hashFn).toBeDefined();
+
+    // "abc" has far too little entropy to pass a 50-bit floor.
+    await expect(hashFn!("abc")).rejects.toBeInstanceOf(PasswordPolicyError);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/core/auth/prehashed-password.ts` with the `isPreHashedSha256()` pure helper and the `PRE_HASH_PREFIX` constant. The sentinel `sha256:<64-char-lowercase-hex>` (71 chars total) unambiguously identifies a client-side pre-hash without any extra body fields.
- Patches the `password.hash` hook in `src/core/auth/better-auth.ts` to short-circuit `validatePasswordPolicy()` when the sentinel is detected and delegate directly to Better-Auth's own `hashPassword()` (scrypt still applied on top).
- Adds `tests/stories/prehashed-password.story.test.ts` with 8 unit tests for the shape detector and 2 integration tests verifying the hook bypass + the rejection of weak plaintext passwords.

## Test plan

- [ ] `bun run lint` — 0 warnings, 0 errors
- [ ] `bun run test:unit` — 191 tests pass (10 new)
- [ ] `bun run test:types` — pre-existing `hub-password.service.ts` errors only, none introduced by this PR
- [ ] `bun run build` — 2 artifacts written to `./dist`
- [ ] CI e2e + coverage run on this PR

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)