### PR TITLE
fix(seed): dotenv override + org-first ordering + Prisma BA schema drift

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -128,7 +128,7 @@ model TenantSettings {
 model Member {
   id             String       @id
   organizationId String       @map("organization_id")
-  userId         String       @map("user_id")
+  userId         String       @map("user_id") @db.Uuid
   role           String
   createdAt      DateTime     @map("created_at")
 
@@ -145,7 +145,7 @@ model Invitation {
   role           String?
   status         String
   expiresAt      DateTime     @map("expires_at")
-  inviterId      String       @map("inviter_id")
+  inviterId      String       @map("inviter_id") @db.Uuid
 
   organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   inviter        User         @relation("InviterUser", fields: [inviterId], references: [id], onDelete: Cascade)

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -20,10 +20,16 @@
 
 import { createHash } from "node:crypto";
 
+import { config as loadEnv } from "dotenv";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
 import { buildSeedPlan } from "../src/core/setup/seed-plan.js";
+
+// Override existing shell env vars so a stale DATABASE_URL from a
+// different project doesn't send the seed to the wrong database.
+// (Bun auto-loads .env but never overrides existing process.env values.)
+loadEnv({ override: true });
 
 if (process.env.NODE_ENV === "production") {
   console.error("[seed] refusing: NODE_ENV=production. `bun run seed` is dev-only.");
@@ -67,6 +73,25 @@ const { hashPassword } = await import("better-auth/crypto");
 const passwordHashes = await Promise.all(plan.users.map((user) => hashPassword(user.password)));
 
 try {
+  // BA Organization rows (issue #118) — canonical tenant layer. Must be
+  // first: roles carry a tenantId that references the organization UUID,
+  // so the org rows must exist before role upserts run.
+  // The prisma adapter writes TEXT ids; our UUIDs are valid TEXT so
+  // no cast is needed here — Prisma handles the mapping.
+  for (const org of plan.organizations) {
+    await prisma.organization.upsert({
+      where: { id: org.id },
+      create: {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        createdAt: org.createdAt,
+      },
+      update: { name: org.name, slug: org.slug },
+    });
+  }
+  console.log(`[seed]   BA orgs:     ${plan.organizations.length}`);
+
   // Roles
   for (const role of plan.roles) {
     await prisma.role.upsert({
@@ -246,23 +271,6 @@ try {
     });
   }
   console.log(`[seed]   profiles:    ${plan.userProfiles.length}`);
-
-  // BA Organization rows (issue #118) — canonical tenant layer.
-  // The prisma adapter writes TEXT ids; our UUIDs are valid TEXT so
-  // no cast is needed here — Prisma handles the mapping.
-  for (const org of plan.organizations) {
-    await prisma.organization.upsert({
-      where: { id: org.id },
-      create: {
-        id: org.id,
-        name: org.name,
-        slug: org.slug,
-        createdAt: org.createdAt,
-      },
-      update: { name: org.name, slug: org.slug },
-    });
-  }
-  console.log(`[seed]   BA orgs:     ${plan.organizations.length}`);
 
   // BA Member rows (issue #118) — canonical membership layer.
   for (const baMember of plan.baMembers) {


### PR DESCRIPTION
## Summary

Three `fix-now` findings from the LLM-test friction run (2026-05-07).

### Fix 1 — `bun run seed` connects to wrong DB (stale shell `DATABASE_URL`)

Added `loadEnv({ override: true })` (dotenv) at the top of `scripts/seed.ts`. Bun's auto `.env` loading never overrides existing `process.env` values, so a stale `DATABASE_URL` from another project in the shell would send the seed to the wrong database. `prisma.config.ts` already used this pattern — now seed.ts does too.

### Fix 2 — Seed ordering: roles created before BA organizations

Moved the BA organizations upsert block to be the **first** step in the try block, before roles. Roles carry a `tenantId` that references the organization UUID, so the org rows must exist first. The previous order (roles → … → organizations) triggered an FK/RLS constraint violation when the org didn't exist yet.

### Fix 3 — `prisma migrate dev` regenerates BA org table FK constraints

`Member.userId` and `Invitation.inviterId` were typed as `String` (TEXT) in `schema.prisma`, but the actual DB columns are `UUID` (as defined in the `20260508100000_ba_organization_models` migration). Prisma saw the mismatch and re-emitted FK + column-type changes on every `prisma migrate dev`. Added `@db.Uuid` to both fields to align the schema with the database.

## Not included (different repo)

**Vite proxy strips `/api` prefix** — the `rewrite: (path) => path.replace(/^\/api/, '')` in `nuxt-base-starter`'s proxy config forwards `/api/todos` to `/todos` but NestJS serves at `/api/todos`. Fix lives in nuxt-base-starter.

## Test plan
- [x] `bun run lint` — 0 errors
- [x] `bun run test:unit` — 186 pass
- [x] `bun run test:types` — clean
- [x] `bun run build` — success