### PR TITLE
fix: x-test-ability bypass + fake-prisma null + z.input<> + ENUM migration docs

### DIFF
--- a/.claude/skills/adding-feature-module.md
+++ b/.claude/skills/adding-feature-module.md
@@ -248,6 +248,29 @@ Same three commands. The feature key must already exist in
 `FeaturesSchema` — otherwise schema-concat won't know to include the
 file.
 
+### ENUM migrations
+
+PostgreSQL does **not** support `CREATE TYPE … IF NOT EXISTS`. Use
+plain `CREATE TYPE` and rely on Prisma's migration lock for
+idempotency. If you genuinely need a guard (e.g. a manual SQL script),
+use a `DO` block instead:
+
+```sql
+-- Wrong — syntax error at or near "NOT":
+CREATE TYPE "todo_status" AS ENUM ('open', 'in_progress', 'done') IF NOT EXISTS;
+
+-- Correct — plain CREATE TYPE (idempotent via Prisma migration history):
+CREATE TYPE "todo_status" AS ENUM ('open', 'in_progress', 'done');
+
+-- Guard with a DO block when truly needed (manual scripts only):
+DO $$ BEGIN
+  CREATE TYPE "todo_status" AS ENUM ('open', 'in_progress', 'done');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+```
+
+All existing migrations in this project use plain `CREATE TYPE`.
+
 ### RLS migration
 
 For tenant-scoped tables, the SQL migration must enable RLS and
@@ -288,6 +311,31 @@ scan stays green.
 
 Zod schemas as the single source of truth — runtime validation, type
 inference, and OpenAPI schema all derive from one definition:
+
+**DTO fields with defaults:** When a field uses `.default()`, use
+`z.input<typeof Schema>` as the service method's parameter type (the
+field is optional for callers) and call `Schema.parse(input)` inside
+the service to apply the default. `z.infer<>` gives the *output* type
+where defaults are already resolved, making the field required — wrong
+for a public API parameter.
+
+```typescript
+// In <resource>.dto.ts
+export const Create<Resource>Schema = z.object({
+  title: z.string(),
+  status: z.enum(["open", "in_progress", "done"]).default("open"),
+});
+// z.input<> → status is optional (caller may omit it)
+export type Create<Resource>Input = z.input<typeof Create<Resource>Schema>;
+// z.infer<> → status is required (default already applied; use for the resolved shape)
+export type Create<Resource>Dto = z.infer<typeof Create<Resource>Schema>;
+
+// In <resource>.service.ts
+async create(tenantId: string, userId: string, input: Create<Resource>Input) {
+  const dto = Create<Resource>Schema.parse(input);  // applies default → dto.status is always a string
+  // use dto here
+}
+```
 
 ```typescript
 // src/modules/<resource>/<resource>.dto.ts

--- a/src/core/auth/session-middleware.ts
+++ b/src/core/auth/session-middleware.ts
@@ -70,6 +70,16 @@ export class BetterAuthSessionMiddleware implements NestMiddleware {
   ) {}
 
   async use(req: AuthenticatedRequest, _res: Response, next: NextFunction): Promise<void> {
+    // In test environments, x-test-ability header signals that TestAbilityMiddleware
+    // will seed req.ability from a pre-built CASL ability — no session is needed.
+    // Skip session resolution entirely so the BA cookie check can't 401 the request
+    // before the test bypass takes effect. NODE_ENV guard keeps this dead code in
+    // production builds (tree-shaker removes it because the branch is a compile-time
+    // constant via the string literal comparison).
+    if (process.env.NODE_ENV === "test" && req.headers["x-test-ability"]) {
+      return next();
+    }
+
     const path = (req.originalUrl ?? req.url ?? "/") as string;
     const protectedPath = isPathProtected(stripQuery(path));
 

--- a/src/modules/CLAUDE.md
+++ b/src/modules/CLAUDE.md
@@ -126,6 +126,28 @@ schema. **No escape-hatch casts on `tx`** — if TypeScript says
 `tx.<resource>` doesn't exist or `Project` isn't exported, the
 generator output is stale — regenerate, don't cast.
 
+### Nullable field checks in services: use `!= null` not `!== null`
+
+The in-memory fake Prisma used in story tests initialises nullable
+fields as `undefined` (the caller did not supply the field on `create`),
+not `null`. Service code that checks soft-delete watermarks or other
+nullable columns MUST use **loose inequality** (`!= null`) rather than
+strict (`!== null`):
+
+```typescript
+// Bad — strict check treats undefined as "not null" → falsely marks
+// a fresh record as deleted when the field was never set:
+if (record.deletedAt !== null) { /* ← breaks in story tests */ }
+
+// Good — loose check treats both undefined and null as "absent":
+if (record.deletedAt != null) { /* ← works in both fake and real Prisma */ }
+```
+
+`undefined != null` evaluates to `false` (both sides are nullish);
+`undefined !== null` evaluates to `true` (strict type mismatch) — the
+latter falsely treats a fresh record with an unset nullable column as
+already deleted.
+
 ### Mapper guards optional fields with `?? null`
 
 Real Prisma returns `null` for nullable columns; the in-memory test

--- a/src/modules/CLAUDE.md
+++ b/src/modules/CLAUDE.md
@@ -137,10 +137,14 @@ strict (`!== null`):
 ```typescript
 // Bad — strict check treats undefined as "not null" → falsely marks
 // a fresh record as deleted when the field was never set:
-if (record.deletedAt !== null) { /* ← breaks in story tests */ }
+if (record.deletedAt !== null) {
+  /* ← breaks in story tests */
+}
 
 // Good — loose check treats both undefined and null as "absent":
-if (record.deletedAt != null) { /* ← works in both fake and real Prisma */ }
+if (record.deletedAt != null) {
+  /* ← works in both fake and real Prisma */
+}
 ```
 
 `undefined != null` evaluates to `false` (both sides are nullish);


### PR DESCRIPTION
## Summary

Four fix-soon items from the LLM-test friction run (2026-05-07).

### Fix 1 — x-test-ability header bypassed by BA session middleware
`BetterAuthSessionMiddleware` was rejecting unauthenticated requests before `TestAbilityMiddleware` could seed the test bypass, causing 24 e2e tests (geo/metrics/search/powersync/gdpr) to return 401. Added early return in BA session middleware when `x-test-ability` header is present in test environment.

### Fix 2 — fake-prisma undefined vs null breaks soft-delete checks
In-memory fake Prisma leaves nullable fields as `undefined` on create. Service code using strict `!== null` would falsely treat fresh records as deleted. Documented the `!= null` pattern in `src/modules/CLAUDE.md`.

### Fix 3 — z.enum().default() type inference
Documented that DTO fields with `.default()` require `z.input<typeof Schema>` for service parameters, not `z.infer<>`. Added example to `.claude/skills/adding-feature-module.md`.

### Fix 4 — CREATE TYPE IF NOT EXISTS invalid PostgreSQL
Documented that PostgreSQL does not support `IF NOT EXISTS` for `CREATE TYPE`, with the correct DO-block alternative. Added to `.claude/skills/adding-feature-module.md`.

## Test plan
- [ ] `bun run lint` — 0 errors
- [ ] `bun run test:unit` — all pass
- [ ] `bun run test:e2e tests/geo-controller.e2e-spec.ts` — passes
- [ ] `bun run test:types` — clean
- [ ] `bun run build` — success