### PR TITLE
fix(hub): exact-match active state for admin sidebar entries

### DIFF
--- a/src/core/dx/clients/pages/PermissionsAdminPage.tsx
+++ b/src/core/dx/clients/pages/PermissionsAdminPage.tsx
@@ -138,7 +138,7 @@ export function PermissionsAdminPage(): ReactNode {
     <AdminShell
       title="Permissions"
       subtitle="Action × Resource grants attached to a Policy"
-      currentNav="permissions"
+      currentNav="permissions-crud"
     >
       <div className="space-y-4">
         {/* Berechtigungsmatrix */}

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -33,6 +33,14 @@ const GLOBALS_CSS = read("src/core/dx/clients/styles/globals.css");
 const TOKENS_CSS = read("src/core/dx/clients/styles/tokens.css");
 const ADMIN_SHELL = read("src/core/dx/clients/layout/AdminShell.tsx");
 const ICONS_TSX = read("src/core/dx/clients/layout/icons.tsx");
+const PERMISSIONS_ADMIN_PAGE = read(
+  'src/core/dx/clients/pages/PermissionsAdminPage.tsx',
+);
+const PERMISSION_TESTER_PAGE = read(
+  'src/core/dx/clients/pages/PermissionTesterPage.tsx',
+);
+
+
 
 describe("Story · Dev-Portal SPA route + nav contract", () => {
   describe("React route table covers every SPA-owned page", () => {
@@ -313,4 +321,32 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       expect(ICONS_TSX).toMatch(/strokeLinejoin:\s*"round"/);
     });
   });
+
+  describe("Sidebar active-state: permissions pages use distinct currentNav ids (regression pin · #125)", () => {
+    // Issue #125: visiting /admin/permissions highlighted both "Permissions"
+    // and "Permission Tester" simultaneously because PermissionsAdminPage
+    // passed currentNav="permissions" — the same id as the Tester nav entry.
+    // The CRUD page's nav entry is id="permissions-crud"; each page must use
+    // the id that belongs to its own entry so only one item is active.
+    it('PermissionsAdminPage passes currentNav="permissions-crud" to AdminShell', () => {
+      expect(PERMISSIONS_ADMIN_PAGE).toContain('currentNav="permissions-crud"');
+    });
+
+    it('PermissionTesterPage passes currentNav="permissions" to AdminShell', () => {
+      expect(PERMISSION_TESTER_PAGE).toContain('currentNav="permissions"');
+    });
+
+    it('nav.ts assigns id "permissions-crud" to the /admin/permissions CRUD entry', () => {
+      // Ensures the id used by PermissionsAdminPage actually exists in the nav model.
+      expect(NAV_TS).toContain('id: "permissions-crud"');
+    });
+
+    it('nav.ts "permissions-crud" entry has href "/admin/permissions" (exact path)', () => {
+      // Guards against the href changing to a prefix that would collide with /test.
+      expect(NAV_TS).toMatch(
+        /id: "permissions-crud"[^}]+href: "\/admin\/permissions"/s,
+      );
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `PermissionsAdminPage` passed `currentNav="permissions"` to `AdminShell`, but the sidebar nav assigns `id: "permissions-crud"` to the `/admin/permissions` CRUD entry and `id: "permissions"` to the `/admin/permissions/test` tester entry.
- When visiting `/admin/permissions`, two conditions fired simultaneously: the `id === currentNav` check activated "Permission Tester" (matching `"permissions"`), and the `location.pathname === item.href` fallback activated "Permissions" (matching `/admin/permissions`).
- **Fix**: Change `currentNav="permissions-crud"` in `PermissionsAdminPage` so it matches its own nav entry id exactly.
- **Regression pin**: Added a `describe` block in `tests/stories/dev-portal-pages.story.test.ts` that locks both pages to their correct nav ids and guards the `nav.ts` entry definition.

Closes #125

## Test plan

- [x] `bun run lint` — 1 pre-existing warning, 0 errors
- [x] `bun run test:unit` — 186 passed
- [x] `bun run test:e2e tests/stories/dev-portal-pages.story.test.ts` — 162 passed (4 new #125 tests)
- [x] `bun run test:types` — passes
- [x] `bun run build` — passes
- [x] `bun run test:e2e` — 4160 passed; 9 pre-existing failures from issue #127 untracked test file on this machine (verified identical failures on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)