### PR TITLE
feat(hub): fix inline code spacing and add copy-to-clipboard for code blocks

### DIFF
--- a/src/core/dx/clients/components/CopyButton.tsx
+++ b/src/core/dx/clients/components/CopyButton.tsx
@@ -1,0 +1,78 @@
+/**
+ * CopyButton — clipboard icon button that copies a text value on click.
+ *
+ * Pure vanilla React with no external deps: uses the standard
+ * `navigator.clipboard.writeText` API and shows transient "Copied!" feedback
+ * for 1.5 s before resetting to the default icon. No third-party clipboard
+ * library needed because hub pages are server-rendered for developer
+ * environments where the Clipboard API is always available over HTTPS / localhost.
+ */
+import { useState } from "react";
+import type { ReactNode } from "react";
+
+import { cn } from "../lib/utils.js";
+
+export interface CopyButtonProps {
+  /** Text to copy to the clipboard when the button is clicked. */
+  text: string;
+  className?: string;
+}
+
+export function CopyButton({ text, className }: CopyButtonProps): ReactNode {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      // Reset the icon after a short delay so the user sees the confirmation.
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={copied ? "Kopiert!" : "In Zwischenablage kopieren"}
+      aria-label={copied ? "Kopiert!" : "In Zwischenablage kopieren"}
+      className={cn(
+        "inline-flex items-center justify-center rounded p-0.5 text-fg-faint transition-colors hover:bg-surface-3 hover:text-fg-muted",
+        copied && "text-ok",
+        className,
+      )}
+    >
+      {copied ? (
+        // Checkmark icon — signals successful copy.
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        // Clipboard icon — communicates "copy" affordance.
+        <svg
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="2" width="10" height="4" rx="1" />
+          <path d="M9 2H7a2 2 0 00-2 2v16a2 2 0 002 2h10a2 2 0 002-2V4a2 2 0 00-2-2h-2" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/core/dx/clients/pages/CoveragePage.tsx
+++ b/src/core/dx/clients/pages/CoveragePage.tsx
@@ -17,6 +17,7 @@ import {
   TableHeader,
   TableRow,
 } from "../components/ui/table.js";
+import { CopyButton } from "../components/CopyButton.js";
 import { PageEmpty, PageError, PageLoading } from "../components/PageState.js";
 import { AdminShell } from "../layout/AdminShell.js";
 import { fetchJson } from "../lib/api.js";
@@ -63,8 +64,9 @@ export function CoveragePage(): ReactNode {
         ) : (
           <PageEmpty>
             Coverage report not generated yet. Run{" "}
-            <code className="font-mono text-accent">bun run test:coverage</code> to populate the
-            dashboard.
+            <code className="mx-0.5 font-mono text-accent">bun run test:coverage</code>
+            <CopyButton text="bun run test:coverage" className="mx-0.5" />
+            {" "}to populate the dashboard.
           </PageEmpty>
         )
       ) : data.isError ? (

--- a/src/core/dx/clients/pages/TestsPage.tsx
+++ b/src/core/dx/clients/pages/TestsPage.tsx
@@ -4,6 +4,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
+import { CopyButton } from "../components/CopyButton.js";
 import { Badge } from "../components/ui/badge.js";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import {
@@ -64,8 +65,9 @@ export function TestsPage(): ReactNode {
         ) : (
           <PageEmpty>
             Test summary not generated yet. Run{" "}
-            <code className="font-mono text-accent">bun run test:summary</code> to populate the
-            dashboard.
+            <code className="mx-0.5 font-mono text-accent">bun run test:summary</code>
+            <CopyButton text="bun run test:summary" className="mx-0.5" />
+            {" "}to populate the dashboard.
           </PageEmpty>
         )
       ) : data.isError ? (

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -33,6 +33,9 @@ const GLOBALS_CSS = read("src/core/dx/clients/styles/globals.css");
 const TOKENS_CSS = read("src/core/dx/clients/styles/tokens.css");
 const ADMIN_SHELL = read("src/core/dx/clients/layout/AdminShell.tsx");
 const ICONS_TSX = read("src/core/dx/clients/layout/icons.tsx");
+const TESTS_PAGE = read("src/core/dx/clients/pages/TestsPage.tsx");
+const COVERAGE_PAGE = read("src/core/dx/clients/pages/CoveragePage.tsx");
+const COPY_BUTTON = read("src/core/dx/clients/components/CopyButton.tsx");
 
 describe("Story · Dev-Portal SPA route + nav contract", () => {
   describe("React route table covers every SPA-owned page", () => {
@@ -311,6 +314,51 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
 
     it('icons.tsx COMMON declares strokeLinejoin: "round"', () => {
       expect(ICONS_TSX).toMatch(/strokeLinejoin:\s*"round"/);
+    });
+  });
+
+  describe("CopyButton component — copy-to-clipboard for code blocks (fix · #126)", () => {
+    // Issue #126: hub pages lacked a copy-to-clipboard affordance on code
+    // snippets and inline commands. CopyButton is a pure React component
+    // (no external deps) that uses the Clipboard API and shows transient
+    // visual feedback on success.
+
+    it("CopyButton.tsx exists as a standalone component file", () => {
+      expect(COPY_BUTTON).toBeTruthy();
+    });
+
+    it("CopyButton.tsx uses the Clipboard API (navigator.clipboard.writeText)", () => {
+      expect(COPY_BUTTON).toContain("navigator.clipboard.writeText");
+    });
+
+    it("CopyButton.tsx renders a button element", () => {
+      expect(COPY_BUTTON).toMatch(/<button/);
+    });
+
+    it("CopyButton.tsx exports CopyButton function", () => {
+      expect(COPY_BUTTON).toMatch(/export function CopyButton/);
+    });
+
+    it("TestsPage.tsx imports CopyButton", () => {
+      expect(TESTS_PAGE).toContain("CopyButton");
+    });
+
+    it("CoveragePage.tsx imports CopyButton", () => {
+      expect(COVERAGE_PAGE).toContain("CopyButton");
+    });
+  });
+
+  describe("Inline code spacing fix (fix · #126)", () => {
+    // Issue #126: inline <code> elements adjacent to text had no visual
+    // breathing room. mx-0.5 adds a half-unit margin on each side so the
+    // text and code element don't visually collide.
+
+    it("TestsPage.tsx inline command code uses mx-0.5 for spacing", () => {
+      expect(TESTS_PAGE).toContain("mx-0.5");
+    });
+
+    it("CoveragePage.tsx inline command code uses mx-0.5 for spacing", () => {
+      expect(COVERAGE_PAGE).toContain("mx-0.5");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Whitespace fix**: Added `mx-0.5` margin to inline `<code>` elements in the empty-state banners on `/hub/tests` and `/hub/coverage` so the command text doesn't visually collide with adjacent prose text.
- **Copy-to-clipboard**: Introduced a new `CopyButton` component (`src/core/dx/clients/components/CopyButton.tsx`) — pure React, no external deps — that uses `navigator.clipboard.writeText` with transient checkmark feedback (1.5 s). Placed next to `bun run test:summary` and `bun run test:coverage` commands so developers can copy them without manual text selection.

## Changes

- `src/core/dx/clients/components/CopyButton.tsx` — new component
- `src/core/dx/clients/pages/TestsPage.tsx` — import + use `CopyButton`, add `mx-0.5` to inline code
- `src/core/dx/clients/pages/CoveragePage.tsx` — import + use `CopyButton`, add `mx-0.5` to inline code  
- `tests/stories/dev-portal-pages.story.test.ts` — TDD story assertions for `CopyButton` contract and spacing fix

## Test plan

- [x] New story assertions pin: `CopyButton.tsx` exists, exports `CopyButton`, uses Clipboard API, renders a `<button>` element
- [x] `TestsPage.tsx` and `CoveragePage.tsx` both import `CopyButton` and use `mx-0.5` — asserted in story tests
- [x] `bun run lint` — 0 errors
- [x] `bun run test:unit` — 186/186 passed
- [x] `bun run test:e2e` — 4149/4149 passed (story + e2e suite)
- [x] `bun run test:types` — clean
- [x] `bun run test:coverage` — coverage at 89%+ statements, 91%+ lines (above thresholds)
- [x] `bun run build` — succeeds, bundle built to `dist/dev-portal/`

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)