### PR TITLE
fix(docker): upgrade PowerSync service image to 1.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,13 @@ services:
       retries: 5
 
   powersync:
-    # PowerSync sync engine. Pulls the WAL from
-    # Postgres, applies sync-rules.yaml, exposes WebSocket+HTTP for clients.
+    # PowerSync sync engine. Pulls the WAL from Postgres, applies sync-rules.yaml,
+    # exposes WebSocket+HTTP for clients. v1.x needs powersync.yaml (see docker/powersync/).
     # Pin to a specific release to avoid unexpected breaking changes on `docker compose pull`.
     # Check https://github.com/powersync-ja/powersync-service/releases for the latest tag.
-    image: journeyapps/powersync-service:0.9.5
+    image: journeyapps/powersync-service:1.21.0
     restart: unless-stopped
+    command: ['start', '-r', 'unified']
     depends_on:
       postgres:
         condition: service_healthy
@@ -65,17 +66,19 @@ services:
     env_file:
       - .env
     environment:
-      POWERSYNC_DATABASE_URI: postgresql://powersync:$${POWERSYNC_DB_PASSWORD}@postgres:5432/$${POSTGRES_DB}
-      POWERSYNC_PORT: '8080'
+      POWERSYNC_CONFIG_PATH: /config/powersync.yaml
+      # Templated into powersync.yaml via !env (PS_ prefix required by PowerSync).
+      PS_PG_URI: postgresql://powersync:${POWERSYNC_DB_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      # Dev-only: superuser creates the powersync bucket-storage schema on first boot.
+      PS_STORAGE_URI: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      PS_PORT: '8080'
       # Better-Auth exposes JWKS at /.well-known/jwks (see Phase 5b-5).
-      # The host.docker.internal host lets the container reach the bun-watched
-      # API running on the docker host (not inside compose).
-      POWERSYNC_JWKS_URL: ${POWERSYNC_JWKS_URL:-http://host.docker.internal:3000/.well-known/jwks}
-      POWERSYNC_JWT_AUDIENCE: powersync
+      # host.docker.internal lets the container reach bun dev on the docker host.
+      PS_JWKS_URL: ${POWERSYNC_JWKS_URL:-http://host.docker.internal:3000/.well-known/jwks}
     ports:
       - '8080:8080'
     volumes:
-      - ./docker/powersync/sync-rules.yaml:/config/sync-rules.yaml:ro
+      - ./docker/powersync:/config:ro
 
   rustfs:
     image: rustfs/rustfs:latest

--- a/docker/powersync/powersync.yaml
+++ b/docker/powersync/powersync.yaml
@@ -1,0 +1,29 @@
+# PowerSync Service config for local docker-compose.
+# PS_* env vars are substituted at startup (!env requires PS_ prefix).
+# See https://docs.powersync.com/configuration/powersync-service/self-hosted-instances
+
+replication:
+  connections:
+    - type: postgresql
+      uri: !env PS_PG_URI
+      sslmode: disable
+
+# Bucket storage on the same Postgres 18 instance (supported since PG 14+).
+storage:
+  type: postgresql
+  uri: !env PS_STORAGE_URI
+  sslmode: disable
+
+port: !env PS_PORT
+
+sync_config:
+  path: sync-rules.yaml
+
+client_auth:
+  # host.docker.internal JWKS from bun dev on the host.
+  allow_local_jwks: true
+  jwks_uri: !env PS_JWKS_URL
+  audience: ['powersync']
+
+telemetry:
+  disable_telemetry_sharing: true

--- a/tests/stories/powersync-service-compose.story.test.ts
+++ b/tests/stories/powersync-service-compose.story.test.ts
@@ -64,15 +64,14 @@ describe("Story · PowerSync service in docker-compose", () => {
     expect(ports.some((p) => p.includes("8080"))).toBe(true);
   });
 
-  it("mounts sync-rules.yaml read-only", () => {
+  it("mounts the PowerSync config directory read-only", () => {
     const c = readCompose();
     const volumes = c.services.powersync?.volumes ?? [];
-    expect(volumes.some((v) => v.includes("sync-rules.yaml"))).toBe(true);
-    // Read-only suffix is required so the container can't mutate the rules.
-    expect(volumes.some((v) => v.includes("sync-rules.yaml") && v.endsWith(":ro"))).toBe(true);
+    expect(volumes.some((v) => v.includes("docker/powersync"))).toBe(true);
+    expect(volumes.some((v) => v.includes("docker/powersync") && v.endsWith(":ro"))).toBe(true);
   });
 
-  it("passes the powersync database connection via env (DSN with the dedicated role)", () => {
+  it("points the service at powersync.yaml and supplies Postgres + JWKS via PS_* env", () => {
     const c = readCompose();
     const env = c.services.powersync?.environment;
     const flat = Array.isArray(env)
@@ -80,17 +79,8 @@ describe("Story · PowerSync service in docker-compose", () => {
       : Object.entries(env ?? {})
           .map(([k, v]) => `${k}=${v}`)
           .join(" ");
-    expect(flat).toMatch(/POWERSYNC_DATABASE_URI|POWERSYNC_DATABASE_URL|PG.+CONNECTION/i);
-  });
-
-  it("passes the JWKS issuer URL for the Better-Auth JWT plugin", () => {
-    const c = readCompose();
-    const env = c.services.powersync?.environment;
-    const flat = Array.isArray(env)
-      ? env.join(" ")
-      : Object.entries(env ?? {})
-          .map(([k, v]) => `${k}=${v}`)
-          .join(" ");
-    expect(flat).toMatch(/POWERSYNC_JWKS_URL|POWERSYNC_JWT|JWKS/i);
+    expect(flat).toMatch(/POWERSYNC_CONFIG_PATH/);
+    expect(flat).toMatch(/PS_PG_URI/);
+    expect(flat).toMatch(/PS_JWKS_URL|JWKS/i);
   });
 });


### PR DESCRIPTION
## Summary

- Replace removed `journeyapps/powersync-service:0.9.5` image tag with `1.21.0` so `docker compose up` can pull again.
- Add `docker/powersync/powersync.yaml` required by PowerSync Service v1.x (replication, Postgres bucket storage, sync rules, JWKS).
- Mount `./docker/powersync:/config:ro` and pass `POWERSYNC_CONFIG_PATH` + `PS_*` env vars; update compose story test.

## Test plan

- [x] `docker compose pull powersync rustfs`
- [x] `docker compose up -d` — all services start
- [x] `bun run test:e2e tests/stories/powersync-service-compose.story.test.ts`

**Note:** If PowerSync logs `password authentication failed for user "powersync"`, align the Postgres role password with `POWERSYNC_DB_PASSWORD` in `.env` (migration seeds `change-me-at-runtime`).