### PR TITLE
fix(jobs): set maxRetriesPerRequest null on BullMQ ioredis client

### DIFF
--- a/src/core/jobs/bullmq-redis-connection.ts
+++ b/src/core/jobs/bullmq-redis-connection.ts
@@ -4,6 +4,15 @@ import type { RedisDuplex } from "./bullmq-job-queue.js";
 import { unwrapIoredisRaw } from "./ioredis-duplex.js";
 
 /**
+ * ioredis options required for BullMQ queues/workers.
+ * Workers use blocking commands (BRPOP); ioredis defaults `maxRetriesPerRequest`
+ * to 20, which BullMQ rejects — it must be `null`.
+ */
+export const BULLMQ_IORedis_OPTIONS = {
+  maxRetriesPerRequest: null,
+} as const;
+
+/**
  * Bridge our `RedisDuplex` wrapper to BullMQ's `ConnectionOptions`.
  * BullMQ must receive the real ioredis instance (auth, duplicate, etc.).
  */

--- a/src/core/jobs/jobs.module.ts
+++ b/src/core/jobs/jobs.module.ts
@@ -12,6 +12,7 @@ const bullmqRedisLogger = new Logger("BullMQRedis");
 import { DiscoveryModule } from "@nestjs/core";
 
 import { BullMQJobQueue, type RedisDuplex } from "./bullmq-job-queue.js";
+import { BULLMQ_IORedis_OPTIONS } from "./bullmq-redis-connection.js";
 import { toRedisDuplex } from "./ioredis-duplex.js";
 import { DiscoveryScheduledJobRegistry, SCHEDULED_JOB_REGISTRY } from "./scheduled-job.registry.js";
 import { ScheduledJobBullMQAdapter } from "./scheduled-job-bullmq-adapter.js";
@@ -41,7 +42,7 @@ async function resolveBullMQRedis(): Promise<RedisDuplex | null> {
   }
   try {
     const { default: Redis } = await import("ioredis");
-    const client = new Redis(url);
+    const client = new Redis(url, BULLMQ_IORedis_OPTIONS);
     // Prevent unhandled 'error' event crash on auth failures, network drops,
     // or TLS rejections. ioredis surfaces these via its internal retry logic;
     // commands reject individually instead of crashing the process.

--- a/tests/stories/bullmq-job-queue.story.test.ts
+++ b/tests/stories/bullmq-job-queue.story.test.ts
@@ -154,6 +154,14 @@ describe("Story · BullMQ-only — REDIS_URL required at startup in non-test env
 // 6. BullMQ cleanup planner still works (regression guard)
 // ---------------------------------------------------------------------------
 
+describe("Story · BullMQ ioredis connection options", () => {
+  it("BULLMQ_IORedis_OPTIONS sets maxRetriesPerRequest to null for blocking workers", async () => {
+    const { BULLMQ_IORedis_OPTIONS } =
+      await import("../../src/core/jobs/bullmq-redis-connection.js");
+    expect(BULLMQ_IORedis_OPTIONS.maxRetriesPerRequest).toBeNull();
+  });
+});
+
 describe("Story · BullMQ cron-repeat plan", () => {
   it("buildBullMQCleanupJobPlan() returns a repeat config with cron + jobId", async () => {
     const { buildBullMQCleanupJobPlan } =


### PR DESCRIPTION
## Summary

- BullMQ workers use blocking Redis commands and require `maxRetriesPerRequest: null` on the ioredis client.
- Without it, worker registration fails at startup (`lt.cleanup.throttler`, scheduled jobs, etc.) and BullMQ may throw `blockingConnection.client` errors.

## Changes

- Add `BULLMQ_IORedis_OPTIONS` in `bullmq-redis-connection.ts`
- Pass it when creating the BullMQ-dedicated ioredis client in `jobs.module.ts`
- Story test guards the option

## Test plan

- [x] `bun run test:e2e tests/stories/bullmq-job-queue.story.test.ts`
- [ ] Restart API with `REDIS_URL` set — no BullMQ worker registration errors in logs