### PR TITLE
fix(dev): inject APP_BASE_URL when portless or direct bind is active

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -45,6 +45,7 @@ import {
   buildPortlessRunCommand,
   decideRegistrationAction,
   isPortlessProxyRunning,
+  planDevChildEnv,
   resolveDevPort,
   shouldUsePortless,
 } from '../src/core/dev/portless.js';
@@ -118,6 +119,14 @@ function which(bin: string): string | undefined {
   return out === '' ? undefined : out;
 }
 
+/** Prefer PATH, then the workspace-local devDependency binary. */
+function resolvePortlessBinary(): string | undefined {
+  const fromPath = which('portless');
+  if (fromPath) return fromPath;
+  const local = resolve(process.cwd(), 'node_modules/.bin/portless');
+  return existsSync(local) ? local : undefined;
+}
+
 function readProjectName(): string {
   const pkgPath = resolve(process.cwd(), 'package.json');
   if (!existsSync(pkgPath)) return 'app';
@@ -125,7 +134,7 @@ function readProjectName(): string {
   return match?.[1] ?? 'app';
 }
 
-const portlessPath = which('portless');
+const portlessPath = resolvePortlessBinary();
 const useDisable = process.env.DISABLE_PORTLESS === '1';
 const usePortless = shouldUsePortless({ portlessPath, disable: useDisable });
 const projectName = readProjectName();
@@ -322,7 +331,12 @@ async function buildSpawnPlan(): Promise<SpawnPlan> {
     return {
       command: portlessPath!,
       args,
-      env: { ...process.env, PORTLESS_ACTIVE: '1' },
+      env: planDevChildEnv({
+        baseEnv: process.env,
+        projectName,
+        mode: 'portless',
+        app: 'api',
+      }),
     };
   }
   const requestedPort = resolveDevPort({
@@ -400,7 +414,12 @@ async function buildSpawnPlan(): Promise<SpawnPlan> {
   return {
     command: 'bun',
     args: ['--watch', 'src/main.ts'],
-    env: { ...process.env, PORT: String(port) },
+    env: planDevChildEnv({
+      baseEnv: process.env,
+      projectName,
+      mode: 'direct',
+      port,
+    }),
   };
 }
 

--- a/src/core/dev/portless.ts
+++ b/src/core/dev/portless.ts
@@ -80,6 +80,46 @@ export interface BuildPortlessRunCommandInput {
  * just `<projectName>`. Worktree branch prefixes are added by portless
  * itself if the repo is on a non-default branch.
  */
+/** Public HTTPS URL for `portless run --name <app>.<projectName>`. */
+export function buildPortlessAppBaseUrl(projectName: string, app = "api"): string {
+  if (!projectName) {
+    throw new Error("buildPortlessAppBaseUrl: projectName must not be empty");
+  }
+  const fullName = app ? `${app}.${projectName}` : projectName;
+  return `https://${fullName}.localhost`;
+}
+
+export interface PlanDevChildEnvInput {
+  baseEnv: NodeJS.ProcessEnv;
+  projectName: string;
+  mode: "portless" | "direct";
+  /** Required when `mode` is `direct` — concrete port the API child binds. */
+  port?: number;
+  app?: string;
+}
+
+/**
+ * Env overrides injected by `scripts/dev.ts` so `APP_BASE_URL` matches how
+ * the API is actually reached. `.env` may still say `http://localhost:3000`
+ * from an old wizard run; without these overrides the startup banner, Better
+ * Auth issuer, and OpenAPI links would point at the wrong host.
+ */
+export function planDevChildEnv(input: PlanDevChildEnvInput): NodeJS.ProcessEnv {
+  if (input.mode === "portless") {
+    return {
+      ...input.baseEnv,
+      PORTLESS_ACTIVE: "1",
+      APP_BASE_URL: buildPortlessAppBaseUrl(input.projectName, input.app),
+    };
+  }
+  const port = input.port ?? 3000;
+  return {
+    ...input.baseEnv,
+    PORT: String(port),
+    APP_BASE_URL: `http://localhost:${port}`,
+  };
+}
+
 export function buildPortlessRunCommand(input: BuildPortlessRunCommandInput): string[] {
   if (!input.projectName) {
     throw new Error("buildPortlessRunCommand: projectName must not be empty");

--- a/tests/unit/portless.spec.ts
+++ b/tests/unit/portless.spec.ts
@@ -4,7 +4,9 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  buildPortlessAppBaseUrl,
   buildPortlessRunCommand,
+  planDevChildEnv,
   resolveDevPort,
   shouldUsePortless,
 } from "../../src/core/dev/portless.js";
@@ -74,6 +76,38 @@ describe("dev runner", () => {
 
     it("throws when PORT is set but not numeric", () => {
       expect(() => resolveDevPort({ env: { PORT: "abc" }, portlessAvailable: true })).toThrow();
+    });
+  });
+
+  describe("buildPortlessAppBaseUrl()", () => {
+    it("returns https://api.<project>.localhost when app is api", () => {
+      expect(buildPortlessAppBaseUrl("nest-base")).toBe("https://api.nest-base.localhost");
+    });
+  });
+
+  describe("planDevChildEnv()", () => {
+    it("sets PORTLESS_ACTIVE and portless APP_BASE_URL in portless mode", () => {
+      const env = planDevChildEnv({
+        baseEnv: { APP_BASE_URL: "http://localhost:3000", FOO: "bar" },
+        projectName: "my-app",
+        mode: "portless",
+        app: "api",
+      });
+      expect(env.PORTLESS_ACTIVE).toBe("1");
+      expect(env.APP_BASE_URL).toBe("https://api.my-app.localhost");
+      expect(env.FOO).toBe("bar");
+    });
+
+    it("sets PORT and loopback APP_BASE_URL in direct mode", () => {
+      const env = planDevChildEnv({
+        baseEnv: { APP_BASE_URL: "https://api.old.localhost" },
+        projectName: "my-app",
+        mode: "direct",
+        port: 4266,
+      });
+      expect(env.PORT).toBe("4266");
+      expect(env.APP_BASE_URL).toBe("http://localhost:4266");
+      expect(env.PORTLESS_ACTIVE).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

- When `bun run dev` runs through portless, inject `APP_BASE_URL=https://api.<package-name>.localhost` (not only `PORTLESS_ACTIVE=1`) so the startup banner, Better Auth issuer, and OpenAPI links match the real URL even if `.env` still has `http://localhost:3000`.
- On the direct-bind fallback, inject `APP_BASE_URL=http://localhost:<port>` including dynamic ports.
- Resolve `portless` from `node_modules/.bin` when it is not on global PATH.

## Root cause

`resolveEffectiveBaseUrl()` uses `APP_BASE_URL` from env when `PORTLESS_ACTIVE=1`. The dev runner never overwrote a stale localhost value from an older wizard run.

## Test plan

- [x] `bun run test:unit tests/unit/portless.spec.ts`
- [ ] `portless proxy start` then `bun run dev` — banner shows `https://api.<project>.localhost`
- [ ] Without proxy — fallback banner uses `http://localhost:<port>` with matching `APP_BASE_URL`