### PR TITLE
fix(health): wire JobsModule into readiness + harden setup-smoke

### DIFF
--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Pull docker-compose images
         run: |
           set -a; . ./.env; set +a
-          docker compose pull
+          # Postgres is `nest-base-postgres:local` (built below) — skip it.
+          docker compose pull --ignore-buildable
 
       - name: Boot Postgres + Redis (custom image / redis service)
         run: |

--- a/.github/workflows/setup-smoke.yml
+++ b/.github/workflows/setup-smoke.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Pull every declared image before `up` so a removed tag (e.g. an
+      # obsolete powersync pin) fails here instead of on a dev laptop.
+      - name: Pull docker-compose images
+        run: |
+          set -a; . ./.env; set +a
+          docker compose pull
+
       - name: Boot Postgres + Redis (custom image / redis service)
         run: |
           # Source the wizard-generated POSTGRES_* so docker-compose
@@ -118,9 +125,23 @@ jobs:
             fi
             sleep 1
           done
-          # Final readiness check (fail loud if still not up).
-          curl -fsS "http://127.0.0.1:${PORT:-3000}/health/ready" | head -c 200
+          # Final readiness check (fail loud if still not up). Allow a short
+          # settle window so async BullMQ worker registration finishes.
+          sleep 3
+          ready_json=$(curl -fsS "http://127.0.0.1:${PORT:-3000}/health/ready")
+          echo "$ready_json" | head -c 400
           echo
+          jobs_status=$(echo "$ready_json" | jq -r '.checks.jobs.status // empty')
+          if [ "$jobs_status" != "ok" ]; then
+            echo "::error::/health/ready jobs check is not ok (got: ${jobs_status:-missing})"
+            grep -E 'BullMQ Worker registration|Fatal startup' /tmp/server.log || true
+            exit 1
+          fi
+          if grep -qE 'BullMQ Worker registration for .* failed:' /tmp/server.log; then
+            echo "::error::BullMQ worker registration failed during boot (see /tmp/server.log)"
+            grep 'BullMQ Worker registration' /tmp/server.log || true
+            exit 1
+          fi
           # OpenAPI spec must be valid JSON with an info.title.
           title=$(curl -fsS "http://127.0.0.1:${PORT:-3000}/api/openapi.json" | jq -r .info.title)
           if [ -z "$title" ] || [ "$title" = "null" ]; then

--- a/src/core/health/health.module.ts
+++ b/src/core/health/health.module.ts
@@ -1,9 +1,13 @@
 import { Module } from "@nestjs/common";
 
+import { JobsModule } from "../jobs/jobs.module.js";
 import { HealthController } from "./health.controller.js";
 import { HealthService } from "./health.service.js";
 
 @Module({
+  // JobsModule export is required so HealthService can inject BullMQJobQueue
+  // and surface `checks.jobs` on /health/ready (CRIT-1 worker registration).
+  imports: [JobsModule],
   controllers: [HealthController],
   providers: [HealthService],
   exports: [HealthService],

--- a/src/core/health/health.service.ts
+++ b/src/core/health/health.service.ts
@@ -7,7 +7,7 @@ import {
 import { EMAIL_OUTBOX_STORAGE } from "../email/email-outbox.module.js";
 import type { EmailOutboxStorage } from "../email/email-outbox.js";
 import { PrismaService } from "../prisma/prisma.service.js";
-import type { BullMQJobQueue } from "../jobs/bullmq-job-queue.js";
+import { BullMQJobQueue } from "../jobs/bullmq-job-queue.js";
 
 export interface CheckResult {
   status: "ok" | "fail";

--- a/src/core/health/health.service.ts
+++ b/src/core/health/health.service.ts
@@ -47,9 +47,8 @@ export class HealthService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() @Inject(EMAIL_OUTBOX_STORAGE) private readonly emailOutbox?: EmailOutboxStorage,
-    // BullMQJobQueue is exported under the class token in JobsModule.
-    // @Optional() so HealthModule does not need to import JobsModule —
-    // it receives null when the job queue is not loaded (test bootstraps).
+    // BullMQJobQueue token is re-exported by JobsModule (HealthModule imports it).
+    // @Optional() for test bootstraps that omit JobsModule.
     @Optional() private readonly jobQueue?: BullMQJobQueue,
   ) {}
 

--- a/src/core/jobs/jobs.module.ts
+++ b/src/core/jobs/jobs.module.ts
@@ -147,6 +147,6 @@ export class JobQueueService extends BullMQJobQueue implements OnModuleInit, OnM
     // via setInterval-based scheduling at OnApplicationBootstrap (C1 fix).
     ScheduledJobBullMQAdapter,
   ],
-  exports: [JobQueueService, SCHEDULED_JOB_REGISTRY, ScheduledJobBullMQAdapter],
+  exports: [JobQueueService, BullMQJobQueue, SCHEDULED_JOB_REGISTRY, ScheduledJobBullMQAdapter],
 })
 export class JobsModule {}

--- a/tests/stories/health-jobs-readiness.story.test.ts
+++ b/tests/stories/health-jobs-readiness.story.test.ts
@@ -24,6 +24,12 @@ describe("Story · Health readiness includes BullMQ worker health", () => {
     expect(src).toMatch(/exports:\s*\[[^\]]*BullMQJobQueue/s);
   });
 
+  it("HealthService value-imports BullMQJobQueue so Nest DI emits the class token", () => {
+    const src = readFileSync(resolve(ROOT, "src/core/health/health.service.ts"), "utf8");
+    expect(src).toMatch(/import \{ BullMQJobQueue \} from/);
+    expect(src).not.toMatch(/import type \{ BullMQJobQueue \}/);
+  });
+
   it("HealthService readiness() consults jobQueue.isReady() when the queue is wired", () => {
     const src = readFileSync(resolve(ROOT, "src/core/health/health.service.ts"), "utf8");
     expect(src).toMatch(/isReady\(\)/);

--- a/tests/stories/health-jobs-readiness.story.test.ts
+++ b/tests/stories/health-jobs-readiness.story.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..", "..");
+
+/**
+ * Story · /health/ready must observe BullMQ worker registration (CRIT-1).
+ *
+ * Without JobsModule imported into HealthModule, `jobQueue` stays
+ * undefined and worker failures never surface on the readiness probe —
+ * setup-smoke stayed green while local `bun run dev` logged registration
+ * errors.
+ */
+describe("Story · Health readiness includes BullMQ worker health", () => {
+  it("HealthModule imports JobsModule so HealthService can inject BullMQJobQueue", () => {
+    const src = readFileSync(resolve(ROOT, "src/core/health/health.module.ts"), "utf8");
+    expect(src).toMatch(/imports:\s*\[[^\]]*JobsModule/s);
+  });
+
+  it("HealthService readiness() consults jobQueue.isReady() when the queue is wired", () => {
+    const src = readFileSync(resolve(ROOT, "src/core/health/health.service.ts"), "utf8");
+    expect(src).toMatch(/isReady\(\)/);
+    expect(src).toMatch(/checks\.jobs/);
+  });
+});

--- a/tests/stories/health-jobs-readiness.story.test.ts
+++ b/tests/stories/health-jobs-readiness.story.test.ts
@@ -19,6 +19,11 @@ describe("Story · Health readiness includes BullMQ worker health", () => {
     expect(src).toMatch(/imports:\s*\[[^\]]*JobsModule/s);
   });
 
+  it("JobsModule exports the BullMQJobQueue token (not only JobQueueService)", () => {
+    const src = readFileSync(resolve(ROOT, "src/core/jobs/jobs.module.ts"), "utf8");
+    expect(src).toMatch(/exports:\s*\[[^\]]*BullMQJobQueue/s);
+  });
+
   it("HealthService readiness() consults jobQueue.isReady() when the queue is wired", () => {
     const src = readFileSync(resolve(ROOT, "src/core/health/health.service.ts"), "utf8");
     expect(src).toMatch(/isReady\(\)/);

--- a/tests/stories/setup-smoke-workflow.story.test.ts
+++ b/tests/stories/setup-smoke-workflow.story.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const ROOT = resolve(import.meta.dirname, "..", "..");
+const WORKFLOW = resolve(ROOT, ".github/workflows/setup-smoke.yml");
+
+/**
+ * Story · setup-smoke workflow guards the consumer bring-up path.
+ */
+describe("Story · setup-smoke.yml consumer bring-up guards", () => {
+  const yaml = readFileSync(WORKFLOW, "utf8");
+
+  it("pulls docker-compose images before starting services", () => {
+    expect(yaml).toMatch(/docker compose pull/);
+  });
+
+  it("asserts BullMQ worker health via /health/ready and boot log", () => {
+    expect(yaml).toMatch(/checks\.jobs\.status/);
+    expect(yaml).toMatch(/BullMQ Worker registration/);
+  });
+
+  it("boots via bun src/main.ts (not bun run dev) so portless is out of scope here", () => {
+    expect(yaml).toMatch(/bun src\/main\.ts/);
+    expect(yaml).not.toMatch(/bun run dev/);
+  });
+});

--- a/tests/stories/setup-smoke-workflow.story.test.ts
+++ b/tests/stories/setup-smoke-workflow.story.test.ts
@@ -12,8 +12,8 @@ const WORKFLOW = resolve(ROOT, ".github/workflows/setup-smoke.yml");
 describe("Story · setup-smoke.yml consumer bring-up guards", () => {
   const yaml = readFileSync(WORKFLOW, "utf8");
 
-  it("pulls docker-compose images before starting services", () => {
-    expect(yaml).toMatch(/docker compose pull/);
+  it("pulls remote compose images before starting services (skips local postgres build)", () => {
+    expect(yaml).toMatch(/docker compose pull --ignore-buildable/);
   });
 
   it("asserts BullMQ worker health via /health/ready and boot log", () => {


### PR DESCRIPTION
## Summary

Closes the gap where **setup-smoke stayed green** while local `bun run dev` logged BullMQ worker failures and `docker compose up` failed on a removed PowerSync image tag.

- **HealthModule** now imports **JobsModule** so `/health/ready` exposes `checks.jobs` and fails when BullMQ worker registration fails (CRIT-1 was wired in code but never injected).
- **setup-smoke**: `docker compose pull` before `up` (catches invalid image tags like removed `powersync-service:0.9.5`); after boot, assert `checks.jobs.status == "ok"` and grep server log for `BullMQ Worker registration … failed`.
- Story tests lock the health wiring and smoke workflow contract.

## Why smoke missed the earlier bugs

| Issue | Gap |
|-------|-----|
| PowerSync image | Smoke only started `postgres` + `redis`, never pulled `powersync` |
| BullMQ `maxRetriesPerRequest` | `jobQueue` was never injected into `HealthService` → readiness ignored workers |
| Portless URL | Smoke uses `bun src/main.ts`, not `bun run dev` (documented in story test) |

## Test plan

- [x] `bun run test:e2e tests/stories/health-jobs-readiness.story.test.ts tests/stories/setup-smoke-workflow.story.test.ts`
- [x] `bun run test:e2e tests/health.e2e-spec.ts`
- [ ] CI setup-smoke (pull + jobs readiness assertions)