### PR TITLE
fix(multi-tenancy): exempt /hub/static from tenant guard (+ stale error wording)

### DIFF
--- a/src/core/errors/problem-details.filter.ts
+++ b/src/core/errors/problem-details.filter.ts
@@ -72,7 +72,8 @@ export class ProblemDetailsExceptionFilter implements ExceptionFilter {
         code: CORE_ERROR_CODES.VALIDATION,
         status: HttpStatus.BAD_REQUEST,
         title: "Tenant Context Required",
-        detail: "No active organization for this request — activate one via POST /api/auth/organization/set-active",
+        detail:
+          "No active organization for this request — activate one via POST /api/auth/organization/set-active",
         instance: req.originalUrl ?? req.url,
       });
       return { ...detail, ...correlation };

--- a/src/core/errors/problem-details.filter.ts
+++ b/src/core/errors/problem-details.filter.ts
@@ -71,8 +71,8 @@ export class ProblemDetailsExceptionFilter implements ExceptionFilter {
       const detail = problemDetails({
         code: CORE_ERROR_CODES.VALIDATION,
         status: HttpStatus.BAD_REQUEST,
-        title: "Tenant Header Required",
-        detail: "Tenant header could not be resolved for this request",
+        title: "Tenant Context Required",
+        detail: "No active organization for this request — activate one via POST /api/auth/organization/set-active",
         instance: req.originalUrl ?? req.url,
       });
       return { ...detail, ...correlation };

--- a/src/core/multi-tenancy/tenant-guard.ts
+++ b/src/core/multi-tenancy/tenant-guard.ts
@@ -55,6 +55,12 @@ const STATIC_EXEMPT_PREFIXES = [
   "/health/",
   "/docs/",
   "/errors/",
+  // Hub login SPA bundle (JS/CSS). Served before any tenant exists —
+  // the login page is how a user activates an organization, so its
+  // assets cannot require a tenant. `/hub/*` (non-static) stays
+  // tenant-required; this prefix is more specific and wins. Matches the
+  // exemption already present in jwt-/session-/ability-middleware.
+  "/hub/static/",
   "/api/me/",
   "/api/tenants/",
   // Share-token endpoints — the token's HMAC envelope encodes the

--- a/tests/problem-details.e2e-spec.ts
+++ b/tests/problem-details.e2e-spec.ts
@@ -182,7 +182,8 @@ describe("Problem-Details exception filter", () => {
     expect(response.body).toMatchObject({
       code: "CORE_VALIDATION",
       title: "Tenant Context Required",
-      detail: "No active organization for this request — activate one via POST /api/auth/organization/set-active",
+      detail:
+        "No active organization for this request — activate one via POST /api/auth/organization/set-active",
       status: 400,
     });
     // The raw internal exception.message must NOT leak verbatim into the body.

--- a/tests/problem-details.e2e-spec.ts
+++ b/tests/problem-details.e2e-spec.ts
@@ -181,11 +181,12 @@ describe("Problem-Details exception filter", () => {
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({
       code: "CORE_VALIDATION",
-      title: "Tenant Header Required",
-      detail: "Tenant header could not be resolved for this request",
+      title: "Tenant Context Required",
+      detail: "No active organization for this request — activate one via POST /api/auth/organization/set-active",
       status: 400,
     });
-    // The internal message must NOT leak into the response body.
+    // The raw internal exception.message must NOT leak verbatim into the body.
+    // The fixture throws `new TenantIsolationError("tenant header is required")`.
     expect(JSON.stringify(response.body)).not.toContain("tenant header is required");
   });
 

--- a/tests/tenant-guard.e2e-spec.ts
+++ b/tests/tenant-guard.e2e-spec.ts
@@ -57,7 +57,7 @@ describe("Tenant Guard", () => {
   // before any tenant exists — otherwise the login page (which is how a
   // user activates an organization in the first place) can never boot.
   // It is exempt in jwt-/session-/ability-middleware; the tenant guard
-  // must agree or the page renders blank with 400 "Tenant Header Required".
+  // must agree or the page renders blank with 400 "Tenant Context Required".
   it.each(["/hub/static/main.js", "/hub/static/main.css", "/hub/static/tokens.css"])(
     "treats %s as tenant-exempt (public Hub SPA assets)",
     (path) => {

--- a/tests/tenant-guard.e2e-spec.ts
+++ b/tests/tenant-guard.e2e-spec.ts
@@ -53,6 +53,19 @@ describe("Tenant Guard", () => {
     },
   );
 
+  // The Hub login SPA bundle is served at /hub/static/* and must load
+  // before any tenant exists — otherwise the login page (which is how a
+  // user activates an organization in the first place) can never boot.
+  // It is exempt in jwt-/session-/ability-middleware; the tenant guard
+  // must agree or the page renders blank with 400 "Tenant Header Required".
+  it.each(["/hub/static/main.js", "/hub/static/main.css", "/hub/static/tokens.css"])(
+    "treats %s as tenant-exempt (public Hub SPA assets)",
+    (path) => {
+      expect(isTenantExempt(path)).toBe(true);
+      expect(requiresTenant(path)).toBe(false);
+    },
+  );
+
   it("rejects empty input defensively", () => {
     expect(() => requiresTenant("")).toThrow();
   });


### PR DESCRIPTION
## Problem

The Hub login SPA renders as a blank/black page. The HTML loads at `/`, but the bundle at `/hub/static/main.js` (and `main.css`, `tokens.css`) is rejected by the tenant guard with **400 "Tenant Header Required"** — so `#root` never hydrates.

`/hub/static/*` is already exempt in `jwt-middleware`, `session-middleware` and `ability-middleware`, but `STATIC_EXEMPT_PREFIXES` in `tenant-guard.ts` was missing it. The login page is how a user activates an organization in the first place, so its own assets cannot require a tenant.

Reproduced live in a downstream project: `/hub/static/main.js` returned **400 before**, **200 after**.

## Secondary fix — stale error wording

The `x-tenant-id` header was removed from the template; tenant scope now comes from `session.activeOrganizationId` (Better-Auth `set-active`). The exception filter still labelled `TenantIsolationError` as **"Tenant Header Required"** / *"Tenant header could not be resolved for this request"* — referencing a header that no longer exists. Corrected to the session-org model.

## Changes
- `src/core/multi-tenancy/tenant-guard.ts` — add `/hub/static/` to `STATIC_EXEMPT_PREFIXES`. `/hub/*` (non-static) stays tenant-required (more-specific prefix wins).
- `src/core/errors/problem-details.filter.ts` — title → `Tenant Context Required`, detail now points to `POST /api/auth/organization/set-active`. Still a static (redacted) message for both internal variants.
- `tests/tenant-guard.e2e-spec.ts` — RED-first cases asserting `/hub/static/*` is tenant-exempt.
- `tests/problem-details.e2e-spec.ts` — RED-first case for the corrected wording; leak-check keeps asserting the raw thrown message is not echoed.

## TDD + gates
- Strict RED-first: each slice verified failing before its fix (3 cases "expected false to be true"; wording mismatch).
- All six gates pass: `lint`, `test:unit`, `test:e2e`, `test:types`, `test:coverage`, `build`.

🤖 Generated with Claude Code