### PR TITLE
fix(email): isolate module-template overlay dir for parallel-safe tests

### DIFF
--- a/src/core/dx/hub.controller.ts
+++ b/src/core/dx/hub.controller.ts
@@ -86,6 +86,10 @@ import {
   ReactEmailTemplateRenderer,
   discoverReactEmailTemplates,
 } from "../email/email-templates.react.js";
+import {
+  resolveModuleTemplateCoreImportPrefix,
+  resolveModuleTemplatesDir,
+} from "../email/email-templates-dir.js";
 import { resolveBrandConfig } from "../email/brand.js";
 import { getLogBuffer } from "./log-buffer.js";
 import { RouteInventoryService } from "./route-inventory-runner.js";
@@ -1028,15 +1032,19 @@ export class HubController {
     if (localeArg !== undefined && !isValidEmailTemplateLocale(localeArg)) {
       throw new BadRequestException(`invalid locale: ${localeArg}`);
     }
+    const moduleDir = resolveModuleTemplatesDir({ projectRoot: process.cwd(), env: process.env });
     const target = resolveEmailTemplateTarget({
       projectRoot: process.cwd(),
       slug: name,
+      moduleDir,
       ...(localeArg !== undefined ? { locale: localeArg } : {}),
     });
     if (!target.ok) throw new BadRequestException(target.error);
     // Belt-and-braces — runner-side anchor check, mirrors the save
-    // endpoint. Catches anything that slipped past the planner.
-    const expectedPrefix = resolve(process.cwd(), "src/modules/email/templates") + "/";
+    // endpoint. Catches anything that slipped past the planner. Anchored
+    // on the *configured* overlay dir so the guard holds under the
+    // EMAIL_MODULE_TEMPLATES_DIR override too.
+    const expectedPrefix = moduleDir + "/";
     if (!target.absolutePath.startsWith(expectedPrefix)) {
       throw new BadRequestException("resolved path escapes module-templates root");
     }
@@ -1125,20 +1133,33 @@ export class HubController {
     const composition = pickComposition(body);
     const validation = validateEmailComposition(composition);
     if (!validation.ok) throw new BadRequestException(validation.error);
+    const moduleDir = resolveModuleTemplatesDir({ projectRoot: process.cwd(), env: process.env });
     const target = resolveEmailTemplateTarget({
       projectRoot: process.cwd(),
       slug,
       locale,
+      moduleDir,
     });
     if (!target.ok) throw new BadRequestException(target.error);
     // Belt-and-braces — runner-side anchor check. Catches anything that
     // slipped past the planner (edge case: planner accepted, but the
-    // realpath of `process.cwd()` resolves elsewhere).
-    const expectedPrefix = resolve(process.cwd(), "src/modules/email/templates") + "/";
+    // realpath of `process.cwd()` resolves elsewhere). Anchored on the
+    // *configured* overlay dir so the guard holds under the
+    // EMAIL_MODULE_TEMPLATES_DIR override too.
+    const expectedPrefix = moduleDir + "/";
     if (!target.absolutePath.startsWith(expectedPrefix)) {
       throw new BadRequestException("resolved path escapes module-templates root");
     }
-    const source = composeEmailTemplateSource({ slug, composition });
+    // The generated file imports core (Barebone/blocks/BrandConfig)
+    // relative to its on-disk location. When the overlay dir is the
+    // default the relative prefix is correct; when overridden the
+    // resolver hands back an absolute prefix so the relocated file still
+    // resolves core.
+    const coreImportPrefix = resolveModuleTemplateCoreImportPrefix({
+      projectRoot: process.cwd(),
+      env: process.env,
+    });
+    const source = composeEmailTemplateSource({ slug, composition, coreImportPrefix });
     await mkdir(dirname(target.absolutePath), { recursive: true });
     await writeFile(target.absolutePath, source, "utf8");
     return {

--- a/src/core/email/email-builder.ts
+++ b/src/core/email/email-builder.ts
@@ -92,6 +92,13 @@ export interface ResolveTemplateTargetInput {
   slug: string;
   /** Optional locale suffix (must pass `isValidEmailTemplateLocale`). */
   locale?: string;
+  /**
+   * Absolute module-overlay templates directory. Defaults to
+   * `<projectRoot>/src/modules/email/templates`. Resolve it via
+   * `resolveModuleTemplatesDir()` so reader, writer, and the
+   * defense-in-depth anchor check all agree (test-isolation).
+   */
+  moduleDir?: string;
 }
 
 export type ResolveTemplateTargetResult =
@@ -123,23 +130,50 @@ export function resolveEmailTemplateTarget(
     return { ok: false, error: `invalid locale: ${input.locale}` };
   }
   const filename = input.locale ? `${input.slug}.${input.locale}.tsx` : `${input.slug}.tsx`;
-  const relRoot = "src/modules/email/templates";
-  const relative = `${relRoot}/${filename}`;
-  // Reject roots that look like absolute paths or include traversal —
+  // The overlay root is configurable (test-isolation). When unset it is
+  // the canonical `<projectRoot>/src/modules/email/templates`, keeping
+  // the output byte-identical for the default path.
+  const moduleRoot = stripTrailingSlash(
+    input.moduleDir ?? `${stripTrailingSlash(input.projectRoot)}/src/modules/email/templates`,
+  );
+  const absolute = `${moduleRoot}/${filename}`;
+  // Reject filenames that look like absolute paths or include traversal —
   // the slug regex already rejects `/` and `..` but we double-check the
-  // composed path. Cheap belt-and-braces.
-  if (relative.includes("..") || relative.includes("\\")) {
+  // composed filename. Cheap belt-and-braces.
+  if (filename.includes("..") || filename.includes("\\") || filename.includes("/")) {
     return { ok: false, error: "path traversal detected" };
   }
-  const absolute = `${stripTrailingSlash(input.projectRoot)}/${relative}`;
   // Anchor verification — the absolute path *must* start with the
-  // module-templates prefix relative to the project root. Belt-and-
-  // braces against a trailing backslash or smuggled separator.
-  const expectedPrefix = `${stripTrailingSlash(input.projectRoot)}/${relRoot}/`;
+  // module-templates root. Belt-and-braces against a trailing backslash
+  // or smuggled separator, now anchored on the *configured* dir so the
+  // guard holds whether or not the dir was overridden.
+  const expectedPrefix = `${moduleRoot}/`;
   if (!absolute.startsWith(expectedPrefix)) {
     return { ok: false, error: "resolved path escapes module-templates root" };
   }
+  // `relativePath` stays relative to the project root for UI/display.
+  // For the default dir this is the familiar
+  // `src/modules/email/templates/<file>`; for an overridden temp dir it
+  // is whatever path leads there from the root (may be `..`-prefixed).
+  const relative = posixRelative(stripTrailingSlash(input.projectRoot), absolute);
   return { ok: true, absolutePath: absolute, relativePath: relative };
+}
+
+/**
+ * Compute a POSIX relative path from `from` to `to` using string
+ * arithmetic on `/`-separated segments. We avoid `node:path`'s
+ * `relative()` so the planner stays pure and platform-independent
+ * (the rest of this module composes paths with literal `/`).
+ */
+function posixRelative(from: string, to: string): string {
+  const fromSegs = from.split("/").filter((s) => s.length > 0);
+  const toSegs = to.split("/").filter((s) => s.length > 0);
+  let i = 0;
+  while (i < fromSegs.length && i < toSegs.length && fromSegs[i] === toSegs[i]) i++;
+  const up = fromSegs.slice(i).map(() => "..");
+  const down = toSegs.slice(i);
+  const segs = [...up, ...down];
+  return segs.length > 0 ? segs.join("/") : ".";
 }
 
 function stripTrailingSlash(value: string): string {
@@ -194,6 +228,16 @@ export function validateEmailComposition(
 export interface ComposeEmailTemplateSourceInput {
   slug: string;
   composition: EmailComposition;
+  /**
+   * Import prefix the generated file uses for core imports (`Barebone`,
+   * blocks, `BrandConfig`). Defaults to the relative
+   * `MODULE_TEMPLATE_CORE_IMPORT_PREFIX` which is correct when the file
+   * lands at the canonical `src/modules/email/templates/` depth. When
+   * the overlay dir is overridden (test-isolation) the caller passes an
+   * ABSOLUTE prefix to `src/core/email` so the generated file still
+   * imports core correctly from its relocated location.
+   */
+  coreImportPrefix?: string;
 }
 
 /**
@@ -216,6 +260,7 @@ export interface ComposeEmailTemplateSourceInput {
  */
 export function composeEmailTemplateSource(input: ComposeEmailTemplateSourceInput): string {
   const { slug, composition } = input;
+  const corePrefix = input.coreImportPrefix ?? MODULE_TEMPLATE_CORE_IMPORT_PREFIX;
   const camelName = kebabToCamel(slug);
   const pascalName = kebabToPascal(slug);
   const vars = collectVariables(composition);
@@ -226,7 +271,7 @@ export function composeEmailTemplateSource(input: ComposeEmailTemplateSourceInpu
     .sort();
   const varsInterface = vars.map((v) => `  ${v}: string;`).join("\n");
   const blockImportLine = blockImports.length
-    ? `import { ${blockImports.join(", ")} } from "${MODULE_TEMPLATE_CORE_IMPORT_PREFIX}/blocks/index.js";\n`
+    ? `import { ${blockImports.join(", ")} } from "${corePrefix}/blocks/index.js";\n`
     : "";
 
   const subjectExpression = renderInterpolatedTemplateLiteral(composition.subject, "vars");
@@ -246,13 +291,10 @@ export function composeEmailTemplateSource(input: ComposeEmailTemplateSourceInpu
     " */",
     'import * as React from "react";',
     "",
-    `import { Barebone } from "${MODULE_TEMPLATE_CORE_IMPORT_PREFIX}/layouts/Barebone.js";`,
+    `import { Barebone } from "${corePrefix}/layouts/Barebone.js";`,
   ];
   if (blockImportLine) lines.push(blockImportLine.trimEnd());
-  lines.push(
-    `import type { BrandConfig } from "${MODULE_TEMPLATE_CORE_IMPORT_PREFIX}/brand.js";`,
-    "",
-  );
+  lines.push(`import type { BrandConfig } from "${corePrefix}/brand.js";`, "");
   lines.push(`export interface ${pascalName}Vars {`);
   if (varsInterface) lines.push(varsInterface);
   lines.push("}", "");

--- a/src/core/email/email-templates-dir.ts
+++ b/src/core/email/email-templates-dir.ts
@@ -1,0 +1,89 @@
+import { resolve } from "node:path";
+
+/**
+ * Single source of truth for the *module-overlay* email-templates
+ * directory — the place where project-specific `.tsx` templates live
+ * and where `/hub/email-builder/save` writes generated overlays.
+ *
+ * Why this exists (test-isolation):
+ *   Vitest runs e2e files in parallel forks (`pool: 'forks'`). The
+ *   email-builder save endpoint writes into the SHARED on-disk path
+ *   `src/modules/email/templates/`; a concurrent fork rendering
+ *   `/hub/email-preview` reads the same dir and sees the writer's
+ *   overlay (e.g. "Custom welcome") instead of the core template
+ *   ("Welcome to nest-server"). Making the dir env-overridable lets
+ *   the writer test point at a private temp dir, removing the race at
+ *   its root rather than racing a best-effort cleanup.
+ *
+ * Reader and writer MUST resolve through the same helper so they
+ * always agree on the active dir. The default is unchanged, so
+ * production behaviour and existing on-disk overlays are untouched.
+ *
+ * Pure planner: takes `projectRoot` + `env` explicitly (no implicit
+ * `process.cwd()` / `process.env` reads) so it's trivially testable
+ * and matches the repo's planner/runner split.
+ */
+
+/** Env var that overrides the module-overlay templates directory. */
+export const EMAIL_MODULE_TEMPLATES_DIR_ENV = "EMAIL_MODULE_TEMPLATES_DIR";
+
+/** Default module-overlay templates dir, relative to the project root. */
+export const DEFAULT_MODULE_TEMPLATES_REL = "src/modules/email/templates";
+
+/** Core templates dir, relative to the project root. */
+export const CORE_EMAIL_REL = "src/core/email";
+
+/**
+ * Relative import prefix from a generated overlay file to `src/core/email`.
+ *
+ * A file at `src/modules/email/templates/<slug>.tsx` reaches
+ * `src/core/email` via three `..` hops (templates → email → modules →
+ * src), so `../../../core/email` is correct *only* at the canonical
+ * depth. When the dir is overridden the prefix becomes absolute (see
+ * `resolveModuleTemplateCoreImportPrefix`).
+ */
+export const MODULE_TEMPLATE_CORE_IMPORT_PREFIX_RELATIVE = "../../../core/email";
+
+export interface ResolveModuleTemplatesDirInput {
+  /** Project root — usually `process.cwd()`. */
+  projectRoot: string;
+  /** Environment bag — usually `process.env`. */
+  env: Record<string, string | undefined>;
+}
+
+/**
+ * Resolve the active module-overlay templates directory.
+ *
+ * - `EMAIL_MODULE_TEMPLATES_DIR` set + non-empty → that path,
+ *   `resolve()`d to absolute (relative overrides anchor on the cwd).
+ * - otherwise → `<projectRoot>/src/modules/email/templates`.
+ */
+export function resolveModuleTemplatesDir(input: ResolveModuleTemplatesDirInput): string {
+  const override = input.env[EMAIL_MODULE_TEMPLATES_DIR_ENV];
+  if (override !== undefined && override.length > 0) {
+    return resolve(override);
+  }
+  return resolve(input.projectRoot, DEFAULT_MODULE_TEMPLATES_REL);
+}
+
+/**
+ * Resolve the import prefix the codegen should use for core imports
+ * (`Barebone`, blocks, `BrandConfig`) inside a generated overlay file.
+ *
+ * The generated file's relative imports resolve against the file's
+ * actual on-disk location at import time. At the canonical depth the
+ * relative prefix is correct and keeps codegen output byte-identical
+ * (round-trip tests depend on it). When the dir is overridden the file
+ * no longer sits at that depth, so we emit an ABSOLUTE path to
+ * `src/core/email`, which Bun resolves regardless of where the overlay
+ * lives.
+ */
+export function resolveModuleTemplateCoreImportPrefix(
+  input: ResolveModuleTemplatesDirInput,
+): string {
+  const override = input.env[EMAIL_MODULE_TEMPLATES_DIR_ENV];
+  if (override !== undefined && override.length > 0) {
+    return resolve(input.projectRoot, CORE_EMAIL_REL);
+  }
+  return MODULE_TEMPLATE_CORE_IMPORT_PREFIX_RELATIVE;
+}

--- a/src/core/email/email-templates.react.ts
+++ b/src/core/email/email-templates.react.ts
@@ -6,6 +6,7 @@ import * as React from "react";
 import { render, toPlainText } from "@react-email/render";
 
 import { defaultBrandConfig, type BrandConfig } from "./brand.js";
+import { resolveModuleTemplatesDir } from "./email-templates-dir.js";
 import type { EmailRenderedTemplate, EmailTemplateRenderer } from "./email.service.js";
 
 /**
@@ -80,7 +81,11 @@ export async function discoverReactEmailTemplates(
 ): Promise<DiscoveredTemplate[]> {
   const root = options.projectRoot ?? process.cwd();
   const coreDir = options.coreDir ?? resolve(root, "src/core/email/templates");
-  const moduleDir = options.moduleDir ?? resolve(root, "src/modules/email/templates");
+  // Reader and writer must agree on the overlay dir, so route the
+  // default through the shared resolver (env-overridable for test
+  // isolation). An explicit `moduleDir` still wins for unit tests.
+  const moduleDir =
+    options.moduleDir ?? resolveModuleTemplatesDir({ projectRoot: root, env: process.env });
 
   const out: DiscoveredTemplate[] = [];
   for (const file of listTsxFiles(coreDir)) {
@@ -157,7 +162,11 @@ export class ReactEmailTemplateRenderer implements EmailTemplateRenderer {
     this.brand = options.brand ?? defaultBrandConfig();
     this.projectRoot = options.projectRoot ?? process.cwd();
     this.coreDir = options.coreDir ?? resolve(this.projectRoot, "src/core/email/templates");
-    this.moduleDir = options.moduleDir ?? resolve(this.projectRoot, "src/modules/email/templates");
+    // Mirror the discovery default so a renderer + a discovery call in
+    // the same process resolve the same overlay dir (env-overridable).
+    this.moduleDir =
+      options.moduleDir ??
+      resolveModuleTemplatesDir({ projectRoot: this.projectRoot, env: process.env });
   }
 
   async render(template: string, locale: string, vars: object): Promise<EmailRenderedTemplate> {

--- a/tests/email-builder.e2e-spec.ts
+++ b/tests/email-builder.e2e-spec.ts
@@ -1,9 +1,12 @@
 import type { INestApplication } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { bootstrap } from "../src/core/app/bootstrap.js";
+import { EMAIL_MODULE_TEMPLATES_DIR_ENV } from "../src/core/email/email-templates-dir.js";
 import { hubReqScoped, pinHubTestAuthEnv } from "./helpers/hub-request.js";
 
 const TENANT = "11111111-1111-1111-1111-111111111111";
@@ -28,7 +31,16 @@ describe("Hub · /hub/email-builder", () => {
     let app: INestApplication;
     let hub: Awaited<ReturnType<typeof hubReqScoped>>;
     let previousNodeEnv: string | undefined;
+    let previousOverlayDir: string | undefined;
     const repoRoot = process.cwd();
+    // This file is the only writer of module email-template overlays.
+    // Under vitest's `pool: 'forks'` its writes into the SHARED
+    // src/modules/email/templates/ dir poisoned concurrent readers in
+    // other forks (hub email-preview saw "Custom welcome" instead of the
+    // core "Welcome to nest-server"). Redirect every write to a private
+    // per-file temp dir via the EMAIL_MODULE_TEMPLATES_DIR override so
+    // nothing leaks into the canonical dir other forks read.
+    const overlayDir = resolve(tmpdir(), `nest-base-email-overlay-${randomUUID()}`);
     // Includes core slugs the override-delete tests recreate so a
     // leftover overlay never poisons later "fetch composition for core
     // template" expectations (the runtime resolver picks module > core
@@ -44,6 +56,11 @@ describe("Hub · /hub/email-builder", () => {
     beforeAll(async () => {
       previousNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = "development";
+      // Set BEFORE bootstrap so the controller resolves this dir on the
+      // first save. The resolver reads process.env per request, so this
+      // ordering is sufficient — no app restart needed.
+      previousOverlayDir = process.env[EMAIL_MODULE_TEMPLATES_DIR_ENV];
+      process.env[EMAIL_MODULE_TEMPLATES_DIR_ENV] = overlayDir;
       pinHubTestAuthEnv();
       app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
       hub = await hubReqScoped(app, TENANT);
@@ -53,13 +70,18 @@ describe("Hub · /hub/email-builder", () => {
       await app.close();
       if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
       else process.env.NODE_ENV = previousNodeEnv;
+      if (previousOverlayDir === undefined) delete process.env[EMAIL_MODULE_TEMPLATES_DIR_ENV];
+      else process.env[EMAIL_MODULE_TEMPLATES_DIR_ENV] = previousOverlayDir;
+      // Drop the whole isolated overlay dir.
+      if (existsSync(overlayDir)) rmSync(overlayDir, { recursive: true, force: true });
     });
 
     beforeEach(() => {
-      // Wipe any artefacts an earlier run may have left in
-      // src/modules/email/templates/ — keeps the suite hermetic.
+      // Wipe any artefacts an earlier test left in the isolated overlay
+      // dir — keeps the suite hermetic without touching the shared
+      // src/modules/email/templates/ that other forks read.
       for (const slug of cleanupSlugs) {
-        const path = resolve(repoRoot, `src/modules/email/templates/${slug}.tsx`);
+        const path = resolve(overlayDir, `${slug}.tsx`);
         if (existsSync(path)) rmSync(path);
       }
     });
@@ -162,7 +184,7 @@ describe("Hub · /hub/email-builder", () => {
       expect(res.status).toBe(400);
     });
 
-    it("POST /hub/email-builder/save writes a .tsx file under src/modules/email/templates/", async () => {
+    it("POST /hub/email-builder/save writes the .tsx into the isolated overlay dir", async () => {
       const slug = "e2e-builder-test";
       const composition = {
         layout: "Barebone",
@@ -175,14 +197,23 @@ describe("Hub · /hub/email-builder", () => {
       };
       const res = await hub.post("/hub/email-builder/save").send({ slug, composition });
       expect(res.status).toBe(200);
-      expect(res.body.relativePath).toBe(`src/modules/email/templates/${slug}.tsx`);
-      const target = resolve(repoRoot, res.body.relativePath);
+      // relativePath points at the overridden overlay dir, not the
+      // canonical src/modules path.
+      expect(res.body.relativePath.endsWith(`${slug}.tsx`)).toBe(true);
+      const target = resolve(overlayDir, `${slug}.tsx`);
       expect(existsSync(target)).toBe(true);
+      // The write must NOT have leaked into the shared canonical dir
+      // that concurrent forks read — that leak is the bug being fixed.
+      expect(existsSync(resolve(repoRoot, `src/modules/email/templates/${slug}.tsx`))).toBe(false);
       const { readFileSync } = await import("node:fs");
       const source = readFileSync(target, "utf8");
       expect(source).toContain("AUTO-GENERATED");
       expect(source).toContain("export default function E2eBuilderTest");
       expect(source).toContain("Hello ");
+      // The generated overlay sits in a temp dir, so its core import must
+      // be an absolute path (not the canonical `../../../core/email`).
+      expect(source).toContain(resolve(repoRoot, "src/core/email"));
+      expect(source).not.toContain('"../../../core/email');
       // Cleanup
       rmSync(target);
     });
@@ -278,7 +309,7 @@ describe("Hub · /hub/email-builder", () => {
 
     describe("DELETE /hub/email-builder/templates/:name/override", () => {
       const slug = "welcome";
-      const overrideAbs = resolve(repoRoot, `src/modules/email/templates/${slug}.tsx`);
+      const overrideAbs = resolve(overlayDir, `${slug}.tsx`);
 
       beforeEach(() => {
         if (existsSync(overrideAbs)) rmSync(overrideAbs);
@@ -327,7 +358,7 @@ describe("Hub · /hub/email-builder", () => {
     describe("GET /hub/email-builder/templates.json (Issue #49)", () => {
       it("flags core templates with overrides via overrideExists=true", async () => {
         const slug = "welcome";
-        const overrideAbs = resolve(repoRoot, `src/modules/email/templates/${slug}.tsx`);
+        const overrideAbs = resolve(overlayDir, `${slug}.tsx`);
         if (existsSync(overrideAbs)) rmSync(overrideAbs);
 
         const composition = {

--- a/tests/setup-files/clean-module-email-overlays.ts
+++ b/tests/setup-files/clean-module-email-overlays.ts
@@ -1,11 +1,15 @@
 /**
  * Vitest `setupFiles` entry: remove module email-template overlays
- * left on disk by other e2e files in parallel forks.
+ * left on disk in `src/modules/email/templates/`.
  *
- * `email-builder.e2e-spec.ts` writes `src/modules/email/templates/*.tsx`
- * during save/override tests. Under `pool: 'forks'` those files survive
- * after the writer fork exits and poison readers (e.g. hub email-preview
- * expecting the core welcome subject).
+ * Belt-and-suspenders. The actual fix for the cross-fork race is in
+ * `email-builder.e2e-spec.ts`, which now redirects every overlay write
+ * to a private temp dir via `EMAIL_MODULE_TEMPLATES_DIR` and never
+ * touches `src/modules/email/templates/`. This worker-start cleaner
+ * stays as a safety net for any stray overlay a future writer (or a
+ * developer running the save endpoint manually) might leave behind —
+ * it only runs at worker START, so it can never prevent a concurrent
+ * writer on its own.
  */
 import { existsSync, rmSync } from "node:fs";
 import { resolve } from "node:path";

--- a/tests/stories/email-templates-dir.story.test.ts
+++ b/tests/stories/email-templates-dir.story.test.ts
@@ -1,0 +1,75 @@
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  EMAIL_MODULE_TEMPLATES_DIR_ENV,
+  resolveModuleTemplateCoreImportPrefix,
+  resolveModuleTemplatesDir,
+} from "../../src/core/email/email-templates-dir.js";
+
+/**
+ * Story · module email-templates directory resolver.
+ *
+ * The reader (`ReactEmailTemplateRenderer` / `discoverReactEmailTemplates`)
+ * and the writer (`/hub/email-builder/save` + its path-traversal guard)
+ * must agree on ONE source of truth for the module-overlay directory.
+ *
+ * Default: `<root>/src/modules/email/templates`. Override via the
+ * `EMAIL_MODULE_TEMPLATES_DIR` env var so parallel test forks can
+ * isolate their writes to a private temp dir and stop poisoning
+ * concurrent readers (the cross-fork flake fixed here).
+ */
+describe("Story · module email-templates dir resolver", () => {
+  const projectRoot = "/repo";
+
+  describe("resolveModuleTemplatesDir", () => {
+    it("defaults to <root>/src/modules/email/templates when env is unset", () => {
+      const dir = resolveModuleTemplatesDir({ projectRoot, env: {} });
+      expect(dir).toBe(resolve(projectRoot, "src/modules/email/templates"));
+    });
+
+    it("defaults when the env var is set to an empty string", () => {
+      const dir = resolveModuleTemplatesDir({
+        projectRoot,
+        env: { [EMAIL_MODULE_TEMPLATES_DIR_ENV]: "" },
+      });
+      expect(dir).toBe(resolve(projectRoot, "src/modules/email/templates"));
+    });
+
+    it("returns the env-override dir (resolved to absolute) when set", () => {
+      const dir = resolveModuleTemplatesDir({
+        projectRoot,
+        env: { [EMAIL_MODULE_TEMPLATES_DIR_ENV]: "/tmp/iso-1234" },
+      });
+      expect(dir).toBe(resolve("/tmp/iso-1234"));
+    });
+
+    it("resolves a relative env-override against the current working dir", () => {
+      const dir = resolveModuleTemplatesDir({
+        projectRoot,
+        env: { [EMAIL_MODULE_TEMPLATES_DIR_ENV]: "tmp/iso" },
+      });
+      expect(dir).toBe(resolve("tmp/iso"));
+    });
+  });
+
+  describe("resolveModuleTemplateCoreImportPrefix", () => {
+    it("keeps the relative prefix when the dir is the default", () => {
+      const prefix = resolveModuleTemplateCoreImportPrefix({ projectRoot, env: {} });
+      // Generated `.tsx` lives at src/modules/email/templates/<slug>.tsx;
+      // `../../../core/email` reaches src/core/email from there.
+      expect(prefix).toBe("../../../core/email");
+    });
+
+    it("returns an absolute prefix to src/core/email when the dir is overridden", () => {
+      const prefix = resolveModuleTemplateCoreImportPrefix({
+        projectRoot,
+        env: { [EMAIL_MODULE_TEMPLATES_DIR_ENV]: "/tmp/iso-1234" },
+      });
+      // The overlay no longer sits at the canonical depth, so the
+      // generated file must import core via an absolute path.
+      expect(prefix).toBe(resolve(projectRoot, "src/core/email"));
+    });
+  });
+});


### PR DESCRIPTION
## Problem

CI `test-e2e` on `main` fails intermittently (reproduced 2/2 on recent runs):
```
tests/hub.e2e-spec.ts > GET /hub/email-preview.json returns structured catalog + rendered
AssertionError: expected 'Custom welcome' to be 'Welcome to nest-server'
```

Root cause: a cross-fork filesystem race. `tests/email-builder.e2e-spec.ts` exercises the real `POST /hub/email-builder/save` endpoint with `subject: "Custom welcome"`, which writes `src/modules/email/templates/welcome.tsx` to the SHARED on-disk overlay dir. Under vitest `pool: 'forks'`, a concurrent fork running `hub.e2e-spec.ts`'s email-preview reads that same dir and sees the custom subject. The existing `clean-module-email-overlays.ts` setup file only cleans at worker START, so it cannot prevent a concurrent writer.

## Fix — make the overlay dir a single configurable source of truth

- **New resolver** `src/core/email/email-templates-dir.ts` (pure planner): `resolveModuleTemplatesDir({projectRoot, env})` → `EMAIL_MODULE_TEMPLATES_DIR` (absolute) if set, else `<root>/src/modules/email/templates` (unchanged default). `resolveModuleTemplateCoreImportPrefix(...)` → relative `../../../core/email` by default, **absolute** `<root>/src/core/email` when the dir is overridden (so a relocated generated overlay still imports core correctly).
- **Reader + writer + security guards** all route through the resolver: `email-templates.react.ts` (discovery + renderer default `moduleDir`), `hub.controller.ts` save/delete (incl. the path-traversal `expectedPrefix` anchor — now `moduleDir + "/"`), `email-builder.ts` (`resolveEmailTemplateTarget` anchors on the configured dir).
- **Writer test** sets `EMAIL_MODULE_TEMPLATES_DIR` to a per-file temp dir before `bootstrap()`, so it never writes to the shared default dir. Asserts the overlay lands in the temp dir, does not leak into `src/modules/email/templates/`, and renders correctly via `@react-email/render`.
- Default behaviour and codegen output are byte-identical when the env is unset (production unaffected).

## Result
`hub.e2e-spec.ts` + `email-builder.e2e-spec.ts` pass reliably together; the cross-fork poisoning is eliminated at its root.

## Gates
All 7 pass: lint, **format** (oxfmt), test:unit, test:e2e, test:types, test:coverage (core ≥80%), build. RED-first (resolver story test committed before the source).

🤖 Generated with Claude Code