### PR TITLE
fix(core): gate tenant modules on multiTenancy flag + recognize @Public() in Hub route inventory

### DIFF
--- a/src/core/app/app.module.ts
+++ b/src/core/app/app.module.ts
@@ -168,8 +168,8 @@ const features = loadFeatures(process.env as Record<string, string | undefined>)
     EmailModule,
     // Admin surface for email-outbox operator actions (issue #91).
     EmailOutboxAdminModule,
-    TenantSelfServiceModule,
-    TenantAdminModule,
+    ...conditionalImport(features, "multiTenancy", TenantSelfServiceModule),
+    ...conditionalImport(features, "multiTenancy", TenantAdminModule),
     ApiKeyModule,
     SessionsAdminModule,
     UserAdminModule,

--- a/src/core/dx/route-inventory-runner.ts
+++ b/src/core/dx/route-inventory-runner.ts
@@ -4,6 +4,7 @@ import { PATH_METADATA, METHOD_METADATA } from "@nestjs/common/constants.js";
 import { RequestMethod } from "@nestjs/common";
 
 import { CAN_METADATA_KEY, type CanMetadata } from "../permissions/can.guard.js";
+import { PUBLIC_ROUTE_METADATA_KEY } from "../permissions/public.decorator.js";
 import { buildRouteInventory, type RouteInput, type RouteInventory } from "./route-inventory.js";
 
 /**
@@ -56,6 +57,11 @@ export class RouteInventoryService {
           const canMetadata = Reflect.getMetadata(CAN_METADATA_KEY, target) as
             | CanMetadata
             | undefined;
+          // @Public() can sit on the method OR on the controller class
+          // (e.g. AdminSpaController applies it at class level), so check both.
+          const publicMeta =
+            Reflect.getMetadata(PUBLIC_ROUTE_METADATA_KEY, target) ??
+            Reflect.getMetadata(PUBLIC_ROUTE_METADATA_KEY, ctor as object);
           routes.push({
             method: httpMethod,
             path: fullPath,
@@ -69,6 +75,7 @@ export class RouteInventoryService {
                   },
                 }
               : {}),
+            ...(publicMeta ? { isPublic: true } : {}),
           });
         }
       }

--- a/src/core/dx/route-inventory.ts
+++ b/src/core/dx/route-inventory.ts
@@ -26,6 +26,13 @@ export interface RouteInput {
   handler: string;
   /** Set when the handler carries a @Can() decorator. */
   canMetadata?: RouteCanMetadata;
+  /**
+   * Set when the handler (or its controller class) carries a @Public()
+   * decorator — explicit consent that the route serves anonymous traffic
+   * by design. Lower precedence than @Can() and the dev-only allowlist,
+   * higher than the `unguarded` fallback (see classifyGuards).
+   */
+  isPublic?: boolean;
 }
 
 export type RouteGuard =
@@ -120,12 +127,23 @@ function normaliseAllowlist(
 }
 
 function classifyGuards(route: RouteInput, allowlist: AllowlistEntry[]): RouteGuard[] {
+  // Precedence (most specific signal wins):
+  //   1. @Can() metadata          → an explicit permission gate.
+  //   2. allowlist prefix match   → subsystem-wide intent; keeps /admin and
+  //      /hub routes classified `dev-only` even when they carry a class-level
+  //      @Public() (the SPA-shell controllers do) — the allowlist must win so
+  //      those stay honestly labelled dev-only, not public.
+  //   3. @Public() decorator      → per-route consent for anonymous traffic.
+  //   4. nothing                  → `unguarded` (a genuine audit finding).
   if (route.canMetadata) {
     return [{ kind: "can", action: route.canMetadata.action, subject: route.canMetadata.subject }];
   }
   const match = allowlist.find((entry) => route.path.startsWith(entry.prefix));
   if (match) {
     return [{ kind: match.kind }];
+  }
+  if (route.isPublic) {
+    return [{ kind: "public" }];
   }
   return [{ kind: "unguarded" }];
 }

--- a/tests/hub.e2e-spec.ts
+++ b/tests/hub.e2e-spec.ts
@@ -274,6 +274,22 @@ describe("Hub · GET /hub", () => {
       );
       expect(devRoute).toBeDefined();
     });
+
+    it("classifies a method-level @Public() route outside the allowlist as `public`, not `unguarded`", async () => {
+      // Regression: the Hub route walker used to ignore the @Public()
+      // decorator, so GET /metrics (method-level @Public, no allowlist
+      // prefix) was falsely reported as `unguarded`. It must now be
+      // `public` and contribute 0 to summary.unguarded.
+      const res = await hub.get("/hub/routes.json");
+      expect(res.status).toBe(200);
+      const metrics = res.body.routes.find(
+        (r: { path: string; method: string }) => r.path === "/metrics" && r.method === "GET",
+      );
+      expect(metrics).toBeDefined();
+      expect(metrics.guards).toEqual([{ kind: "public" }]);
+      // The whole point of the fix: no genuinely-public route lingers as unguarded.
+      expect(res.body.summary.unguarded).toBe(0);
+    });
   });
 
   describe("outside development mode", () => {

--- a/tests/multi-tenancy-module-gating.e2e-spec.ts
+++ b/tests/multi-tenancy-module-gating.e2e-spec.ts
@@ -1,0 +1,131 @@
+import type { INestApplication, LoggerService } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const SILENT_LOGGER: LoggerService = {
+  log() {},
+  warn() {},
+  error() {},
+  debug() {},
+  verbose() {},
+};
+
+/**
+ * E2E · Multi-tenancy module gating (DISABLED).
+ *
+ * End-to-end proof for the regression fixed in `app.module.ts`: when
+ * `multiTenancy` is OFF, the tenant self-service routes
+ * (`GET /me/tenants`, `POST /tenants`) must NOT be registered — an
+ * authenticated request gets 404, not a live 200/201.
+ *
+ * Before the fix `TenantSelfServiceModule` + `TenantAdminModule` were
+ * imported unconditionally, so `POST /tenants` actually created a tenant
+ * even with the feature disabled — inconsistent with the Hub nav planner,
+ * which already hides `/admin/tenants` behind the same flag.
+ *
+ * The deterministic flag-state matrix (ENABLED / DISABLED / default) is
+ * covered without an app boot in
+ * `tests/unit/multi-tenancy-module-gating.spec.ts` (introspects the
+ * `@Module({ imports })` metadata). The ENABLED-path 200/201 behaviour is
+ * exercised by `tests/me-tenants-self-service.e2e-spec.ts` (boots
+ * default-ON). This file keeps a single DISABLED boot for the strongest
+ * proof — a real HTTP 404 — while minimising added load on the parallel
+ * worker pool.
+ *
+ * Why an AUTHENTICATED probe: the BetterAuth session middleware 401s
+ * anonymous callers BEFORE NestJS route resolution, so anonymous requests
+ * cannot distinguish "route absent" (404) from "route present, auth
+ * required" (401). With a valid session the request reaches the routing
+ * layer, where an absent route yields 404. `/me/tenants` + `/tenants` are
+ * tenant-exempt + `@Public`, so the session alone suffices.
+ *
+ * `app.module.ts` snapshots `loadFeatures(process.env)` at module-import
+ * time, so the suite resets the module registry (`vi.resetModules()`),
+ * pins the feature env OFF, then dynamically imports a FRESH `AppModule`.
+ */
+describe("E2E · Multi-tenancy module gating — DISABLED", () => {
+  let app: INestApplication;
+  // PrismaService is imported dynamically (post-reset) so the DI token
+  // matches the freshly re-imported module graph.
+  let prisma: { user: { deleteMany: (args: unknown) => Promise<unknown> } };
+  const createdEmails: string[] = [];
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+  const originalFlag = process.env.FEATURE_MULTI_TENANCY_ENABLED;
+
+  beforeAll(async () => {
+    process.env.BETTER_AUTH_SECRET =
+      "test-better-auth-secret-for-testing-purposes-only-1234567890abcd";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+    // multiTenancy is default-ON, so it must be pinned OFF explicitly.
+    process.env.FEATURE_MULTI_TENANCY_ENABLED = "false";
+
+    // AppModule reads `loadFeatures(process.env)` at module top-level;
+    // reset the registry so the fresh import sees the disabled flag.
+    vi.resetModules();
+    const { AppModule } = await import("../src/core/app/app.module.js");
+    const { PrismaService } = await import("../src/core/prisma/prisma.service.js");
+    const { Test } = await import("@nestjs/testing");
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: SILENT_LOGGER });
+    // Mirror bootstrap.ts: `/me/*` + `/tenants` get the global `/api`
+    // prefix; `/admin/*` + health stay at root.
+    app.setGlobalPrefix("api", {
+      exclude: ["/", "health", "health/(.*)", "admin", "admin/(.*)"],
+    });
+    await app.init();
+    prisma = app.get(PrismaService);
+  });
+
+  afterAll(async () => {
+    try {
+      if (createdEmails.length) {
+        await prisma.user.deleteMany({ where: { email: { in: createdEmails } } });
+      }
+    } catch {
+      // ignore — testcontainer is tossed by global-setup anyway
+    }
+    await app.close();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+    if (originalFlag === undefined) delete process.env.FEATURE_MULTI_TENANCY_ENABLED;
+    else process.env.FEATURE_MULTI_TENANCY_ENABLED = originalFlag;
+  });
+
+  /** Sign up a fresh user; returns an agent with the session cookie + the email. */
+  async function authedAgent(): Promise<{
+    agent: ReturnType<typeof request.agent>;
+    email: string;
+  }> {
+    const email = `mt-gating-${Date.now()}-${Math.random().toString(16).slice(2)}@example.com`;
+    const password = "password-12345";
+    const agent = request.agent(app.getHttpServer());
+    const signUp = await agent
+      .post("/api/auth/sign-up/email")
+      .set("content-type", "application/json")
+      .send({ email, password, name: "MT Gating User" });
+    if (signUp.status !== 200) {
+      throw new Error(`sign-up failed (${signUp.status}): ${JSON.stringify(signUp.body)}`);
+    }
+    return { agent, email };
+  }
+
+  it("GET /api/me/tenants is 404 for an authenticated user (route not registered)", async () => {
+    const { agent, email } = await authedAgent();
+    createdEmails.push(email);
+    const res = await agent.get("/api/me/tenants");
+    expect(res.status, JSON.stringify(res.body)).toBe(404);
+  });
+
+  it("POST /api/tenants is 404 for an authenticated user (route not registered)", async () => {
+    const { agent, email } = await authedAgent();
+    createdEmails.push(email);
+    const res = await agent
+      .post("/api/tenants")
+      .set("content-type", "application/json")
+      .send({ name: "Should Not Exist Inc." });
+    expect(res.status, JSON.stringify(res.body)).toBe(404);
+  });
+});

--- a/tests/stories/route-inventory.story.test.ts
+++ b/tests/stories/route-inventory.story.test.ts
@@ -231,4 +231,88 @@ describe("Story · buildRouteInventory", () => {
       expect(inventory.routes[0]?.guards).toEqual([{ kind: "public" }]);
     });
   });
+
+  describe("@Public() decorator signal (isPublic)", () => {
+    // Why: the Hub route walker reads the `@Public()` decorator and forwards
+    // it as `isPublic: true`. A `@Public()` route outside the allowlist
+    // prefixes used to be reported as `unguarded` (a false positive in the
+    // Hub developer dashboard) — these tests lock in that it's now `public`.
+    it("classifies an isPublic route (no Can, no allowlist match) as `public`", () => {
+      const stack = [
+        {
+          method: "GET",
+          path: "/metrics",
+          controller: "MetricsController",
+          handler: "expose",
+          isPublic: true,
+        },
+      ];
+      const inventory = buildRouteInventory({ routes: stack });
+      expect(inventory.routes[0]?.guards).toEqual([{ kind: "public" }]);
+    });
+
+    it("counts isPublic routes under summary.public and keeps summary.unguarded at 0", () => {
+      const stack = [
+        { method: "GET", path: "/metrics", controller: "M", handler: "expose", isPublic: true },
+        { method: "GET", path: "/", controller: "Root", handler: "root", isPublic: true },
+      ];
+      const inventory = buildRouteInventory({ routes: stack });
+      expect(inventory.summary).toEqual({
+        total: 2,
+        guarded: 0,
+        public: 2,
+        devOnly: 0,
+        unguarded: 0,
+      });
+    });
+
+    it("lets the dev-only allowlist win over isPublic (class-@Public admin/hub SPA shells stay dev-only)", () => {
+      const stack = [
+        {
+          method: "GET",
+          path: "/admin/audit",
+          controller: "AdminSpaController",
+          handler: "audit",
+          isPublic: true,
+        },
+        {
+          method: "GET",
+          path: "/hub/x",
+          controller: "HubController",
+          handler: "x",
+          isPublic: true,
+        },
+      ];
+      const inventory = buildRouteInventory({
+        routes: stack,
+        publicAllowlist: [
+          { prefix: "/admin", kind: "dev-only" },
+          { prefix: "/hub", kind: "dev-only" },
+        ],
+      });
+      expect(inventory.routes.find((r) => r.path === "/admin/audit")?.guards).toEqual([
+        { kind: "dev-only" },
+      ]);
+      expect(inventory.routes.find((r) => r.path === "/hub/x")?.guards).toEqual([
+        { kind: "dev-only" },
+      ]);
+    });
+
+    it("lets canMetadata win over isPublic (an explicitly gated route stays `can`)", () => {
+      const stack = [
+        {
+          method: "GET",
+          path: "/projects",
+          controller: "P",
+          handler: "list",
+          canMetadata: { action: "read", subject: "Project" },
+          isPublic: true,
+        },
+      ];
+      const inventory = buildRouteInventory({ routes: stack });
+      expect(inventory.routes[0]?.guards).toEqual([
+        { kind: "can", action: "read", subject: "Project" },
+      ]);
+    });
+  });
 });

--- a/tests/unit/multi-tenancy-module-gating.spec.ts
+++ b/tests/unit/multi-tenancy-module-gating.spec.ts
@@ -1,0 +1,74 @@
+import "reflect-metadata";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Unit · Multi-tenancy module gating (regression guard).
+ *
+ * `app.module.ts` snapshots `loadFeatures(process.env)` at module-import
+ * time and decides — via `conditionalImport(features, "multiTenancy", …)`
+ * — whether `TenantSelfServiceModule` and `TenantAdminModule` land in the
+ * `@Module({ imports })` array.
+ *
+ * Before the fix the two modules were imported UNCONDITIONALLY, so the
+ * tenant routes (`/me/tenants`, `/tenants`, `/admin/tenants`) stayed
+ * registered even with `multiTenancy` disabled — inconsistent with the
+ * Hub nav planner, which already hides `/admin/tenants` behind the same
+ * flag.
+ *
+ * This guard introspects the `@Module()` decorator's `imports` metadata
+ * (the established pattern from `tests/unit/bug-fixes.spec.ts`) under
+ * both flag states. No NestJS app boot, no HTTP — deterministic and
+ * cheap, so it cannot destabilise the parallel e2e worker pool.
+ *
+ * `vi.resetModules()` forces a fresh `app.module.ts` evaluation per case
+ * so its top-level `loadFeatures(process.env)` re-reads the pinned env.
+ */
+describe("Unit · Multi-tenancy module gating", () => {
+  const originalSecret = process.env.BETTER_AUTH_SECRET;
+  const originalBaseUrl = process.env.APP_BASE_URL;
+  const originalFlag = process.env.FEATURE_MULTI_TENANCY_ENABLED;
+
+  beforeEach(() => {
+    process.env.BETTER_AUTH_SECRET =
+      "test-better-auth-secret-for-testing-purposes-only-1234567890abcd";
+    process.env.APP_BASE_URL = "http://localhost:3000";
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    if (originalSecret === undefined) delete process.env.BETTER_AUTH_SECRET;
+    else process.env.BETTER_AUTH_SECRET = originalSecret;
+    if (originalBaseUrl === undefined) delete process.env.APP_BASE_URL;
+    else process.env.APP_BASE_URL = originalBaseUrl;
+    if (originalFlag === undefined) delete process.env.FEATURE_MULTI_TENANCY_ENABLED;
+    else process.env.FEATURE_MULTI_TENANCY_ENABLED = originalFlag;
+  });
+
+  /** Names of the modules registered in AppModule's `imports` for the given flag. */
+  async function importedModuleNames(flag: string | undefined): Promise<string[]> {
+    if (flag === undefined) delete process.env.FEATURE_MULTI_TENANCY_ENABLED;
+    else process.env.FEATURE_MULTI_TENANCY_ENABLED = flag;
+    vi.resetModules();
+    const { AppModule } = await import("../../src/core/app/app.module.js");
+    const imports = (Reflect.getMetadata("imports", AppModule) as unknown[]) ?? [];
+    return imports.map((m) => (typeof m === "function" ? m.name : String(m)));
+  }
+
+  it("registers the tenant modules when multiTenancy is ENABLED", async () => {
+    const names = await importedModuleNames("true");
+    expect(names).toContain("TenantSelfServiceModule");
+    expect(names).toContain("TenantAdminModule");
+  });
+
+  it("OMITS the tenant modules when multiTenancy is DISABLED", async () => {
+    const names = await importedModuleNames("false");
+    expect(names).not.toContain("TenantSelfServiceModule");
+    expect(names).not.toContain("TenantAdminModule");
+  });
+
+  it("registers the tenant modules by DEFAULT (flag unset → schema default ON)", async () => {
+    const names = await importedModuleNames(undefined);
+    expect(names).toContain("TenantSelfServiceModule");
+    expect(names).toContain("TenantAdminModule");
+  });
+});


### PR DESCRIPTION
## Summary

Two independent, generic core fixes that every nest-base consumer benefits from.

### 1. Tenant modules now feature-gated on `multiTenancy`

`TenantSelfServiceModule` and `TenantAdminModule` were imported unconditionally in `app.module.ts`, so tenant routes (`/me/tenants`, `/tenants`, `/admin/tenants`) stayed registered even when the `multiTenancy` feature flag was off — inconsistent with the Hub nav planner, which already gates `/admin/tenants` on that flag.

Both modules now use `conditionalImport(features, "multiTenancy", …)`. Adds a zero-boot unit regression guard plus a disabled-boot e2e proof (routes return 404 when the feature is off).

### 2. Hub route-inventory recognizes `@Public()`

The Hub route walker classified a route as `unguarded` unless it had `@Can()` metadata or matched a hardcoded path-prefix allowlist — it never read the `@Public()` decorator. As a result, `@Public` routes outside those prefixes (`GET /`, `GET /metrics`, `GET /files/share/:token`, the `/me/*` self-service routes) were falsely reported as unguarded on the dashboard.

The runner now reads `PUBLIC_ROUTE_METADATA_KEY` from both the handler and its controller class (class-level `@Public`, e.g. admin SPA shells). `classifyGuards` precedence is `@Can → allowlist → @Public → unguarded`, so `/admin` and `/hub` stay `dev-only`. Hub now reports 0 unguarded routes.

Both fixes carry regression tests; the authoritative static route-gating CI audit reports 0 genuinely-ungated routes.

## Origin

Developed and validated in a downstream consumer that vendors the nest-base `src/core/` template, then ported back upstream so all consumers benefit. The two changes are independent of the dashboard fixes in #155 and apply cleanly on top of current `main`.

## Test plan

- [x] `lint` — 0 errors
- [x] `format` — clean
- [x] `test:types` — passes (after `prisma:generate`)
- [x] `test:unit` — 245 tests pass (incl. new tenant-gating zero-boot guard)
- [x] `test:e2e` — 4540 pass / 4 skipped (incl. disabled-boot 404 proof + Hub 0-unguarded assertion)
- [x] `test:coverage` — 85.9% stmts / 78.64% branch / 87.77% lines
- [x] `build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)