### PR TITLE
fix(setup): sanitize scoped package name (compose project name + .env DB vars)

### DIFF
--- a/src/core/setup/compose-project-name.ts
+++ b/src/core/setup/compose-project-name.ts
@@ -36,11 +36,29 @@ export function computeComposeProjectName(input: ComposeProjectNameInput): strin
     throw new Error("computeComposeProjectName: workspacePath is required");
   }
 
+  // docker compose project names must be lowercase, contain only
+  // [a-z0-9_-], and start with a letter or number. A scoped workspace
+  // name like "@bpa/api" would otherwise produce an invalid
+  // "@bpa/api-<hash>" (the `@` and `/` are rejected). Strip the scope
+  // marker, replace illegal runs with a single hyphen, and trim.
+  const safeName = input.projectName
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^[^a-z0-9]+/, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (safeName.length === 0) {
+    throw new Error(
+      `computeComposeProjectName: projectName "${input.projectName}" has no docker-compatible characters`,
+    );
+  }
+
   // sha256 truncated to 6 hex chars. We deliberately do NOT normalise
   // the path (no realpath, no lower-casing) — same input → same hash
   // is exactly what we want, and any normalisation would couple this
   // function to a host filesystem's case-sensitivity rules.
   const hash = createHash("sha256").update(input.workspacePath).digest("hex").slice(0, HASH_LENGTH);
 
-  return `${input.projectName}-${hash}`;
+  return `${safeName}-${hash}`;
 }

--- a/src/core/setup/setup-wizard-runner.ts
+++ b/src/core/setup/setup-wizard-runner.ts
@@ -167,15 +167,26 @@ function rewriteComposeProjectName(text: string, name: string): string {
 }
 
 function rewriteProjectScopedVars(text: string, projectName: string): string {
+  // The substituted value lands in POSTGRES_USER / POSTGRES_DB /
+  // DATABASE_URL and the portless host (api.<name>.localhost), so it must
+  // be a valid Postgres identifier AND a valid hostname label. A scoped
+  // workspace name like "@bpa/api" would otherwise leak `@` and `/` into
+  // the DATABASE_URL (breaking the connection) and the host. Sanitize to a
+  // lowercase alnum/hyphen slug: "@bpa/api" → "bpa-api".
+  const slug = projectName
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
   // Replace every occurrence of the template name. POSTGRES_USER /
   // POSTGRES_DB / DATABASE_URL all carry it; nothing else in
   // .env.example does (comments don't, secrets don't).
-  let out = text.split(TEMPLATE_NAME).join(projectName);
+  let out = text.split(TEMPLATE_NAME).join(slug);
   // APP_BASE_URL: assume portless when a name is given. Local-only devs
   // edit this back to http://localhost:<port> after generation.
   out = out.replace(
     /^APP_BASE_URL=http:\/\/localhost:\d+$/m,
-    `APP_BASE_URL=https://api.${projectName}.localhost`,
+    `APP_BASE_URL=https://api.${slug}.localhost`,
   );
   return out;
 }

--- a/tests/stories/setup-wizard-compose-project-name.story.test.ts
+++ b/tests/stories/setup-wizard-compose-project-name.story.test.ts
@@ -55,6 +55,23 @@ describe("Story · Setup-Wizard compose-project-name planner", () => {
     expect(a).toBe(b);
   });
 
+  it("sanitizes a scoped package name into a docker-compose-valid project name", () => {
+    // Regression: a monorepo workspace named `@bpa/api` flowed straight into
+    // COMPOSE_PROJECT_NAME as `@bpa/api-<hash>`, which `docker compose`
+    // rejects ("must consist only of lowercase alphanumeric characters,
+    // hyphens, and underscores ... start with a letter or number"). The
+    // scope marker `@` and the `/` separator must be stripped/replaced.
+    const name = computeComposeProjectName({
+      projectName: "@bpa/api",
+      workspacePath: "/srv/bpa/projects/api",
+    });
+    expect(name).toBe(`bpa-api-${name.slice("bpa-api-".length)}`);
+    expect(name).toMatch(/^bpa-api-[0-9a-f]{6}$/);
+    // docker-compose validity: starts with alnum, only [a-z0-9_-] thereafter.
+    expect(name).toMatch(/^[a-z0-9][a-z0-9_-]*$/);
+    expect(name).not.toMatch(/[@/]/);
+  });
+
   it("rejects an empty project name (programmer error)", () => {
     expect(() => computeComposeProjectName({ projectName: "", workspacePath: "/x" })).toThrow(
       /projectName/,

--- a/tests/stories/setup-wizard-runner.story.test.ts
+++ b/tests/stories/setup-wizard-runner.story.test.ts
@@ -162,6 +162,32 @@ describe("Story · setup-wizard runner planner", () => {
       expect(url).not.toContain("change-me-strong-pass");
     });
 
+    it("sanitizes a scoped package name into a valid identifier + host slug (@bpa/api -> bpa-api)", () => {
+      // Regression: a scoped monorepo workspace name leaked `@` and `/`
+      // straight into POSTGRES_USER/POSTGRES_DB/DATABASE_URL (an unparseable
+      // connection string → the server never booted) and the portless host.
+      // The substituted value must be a lowercase alnum/hyphen slug that is
+      // valid both as a Postgres identifier and a hostname label.
+      const example = [
+        "POSTGRES_USER=nest-base",
+        "POSTGRES_DB=nest-base",
+        "POSTGRES_PASSWORD=change-me-strong-pass",
+        "DATABASE_URL=postgresql://nest-base:change-me-strong-pass@localhost:5432/nest-base",
+        "APP_BASE_URL=http://localhost:3000",
+      ].join("\n");
+      const out = planEnvFromExample(example, {
+        randomBytes: deterministicRng(),
+        projectName: "@bpa/api",
+      });
+      expect(out).toMatch(/^POSTGRES_USER=bpa-api$/m);
+      expect(out).toMatch(/^POSTGRES_DB=bpa-api$/m);
+      expect(out).toMatch(/^APP_BASE_URL=https:\/\/api\.bpa-api\.localhost$/m);
+      const url = out.match(/^DATABASE_URL=(.*)$/m)?.[1];
+      expect(url).toMatch(/^postgresql:\/\/bpa-api:.+@localhost:5432\/bpa-api$/);
+      expect(url).not.toContain("@bpa/api");
+      expect(url).not.toContain("bpa/api");
+    });
+
     it("leaves the file untouched when projectName equals the template name (no churn)", () => {
       const example = "APP_BASE_URL=http://localhost:3000\nPOSTGRES_USER=nest-base\n";
       const out = planEnvFromExample(example, {


### PR DESCRIPTION
## Summary

A **scoped** workspace name (`@scope/name`) leaked the `@` scope marker and `/` separator into two derived values, breaking docker and the DB connection. Both are now sanitized to a lowercase alnum/hyphen slug (`@bpa/api` → `bpa-api`):

1. **`src/core/setup/compose-project-name.ts`** — `computeComposeProjectName` produced `@bpa/api-<hash>`, which `docker compose` rejects (project names must be lowercase `[a-z0-9_-]` and start with a letter or number). The scope marker and illegal chars are now stripped/collapsed before appending the hash, with a guard that throws if nothing docker-compatible remains.
2. **`src/core/setup/setup-wizard-runner.ts`** — `rewriteProjectScopedVars` substituted the raw name into `POSTGRES_USER` / `POSTGRES_DB` / `DATABASE_URL` and the portless host (`api.<name>.localhost`), yielding an unparseable connection string `postgresql://@bpa/api:pw@host/@bpa/api` (server never booted) and an invalid hostname label. It now slugs the name first, so the value is valid both as a Postgres identifier and a hostname label.

Each fix ships with a regression test (`tests/stories/setup-wizard-compose-project-name.story.test.ts`, `tests/stories/setup-wizard-runner.story.test.ts`).

## Origin

Found in a downstream consumer with a **scoped** package name (`@bpa/api`). nest-base's own name (`nest-base`) is unscoped, so it never triggers either bug — but any scoped consumer does. The sanitization is a **no-op for unscoped names** (`nest-base` → `nest-base`), so existing consumers are unaffected.

## Test plan

- [x] `bun install --frozen-lockfile` — clean
- [x] `bun run prisma:generate` — Prisma Client v7.8.0 generated
- [x] `bun run lint` — 0 errors (3 pre-existing warnings)
- [x] `bun run format` — all files correctly formatted
- [x] `bun run test:types` — passed
- [x] `bun run test:unit` — 245 passed (25 files)
- [x] `bun run test:e2e` — 4542 passed, 4 skipped (incl. `heap-delta-by-features`, passed)
- [x] `bun run test:coverage` — passed (statements 85.93%)
- [x] `bun run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)