### PR TITLE
feat(auth): trust dev frontend origins (Expo web :8081) for CORS + Better-Auth

### DIFF
--- a/src/core/auth/better-auth.module.ts
+++ b/src/core/auth/better-auth.module.ts
@@ -13,6 +13,7 @@ import { EmailService } from "../email/email.service.js";
 import { type Features, loadFeatures } from "../features/features.js";
 import { GeoIpModule } from "../geoip/geoip.module.js";
 import { GeoIpService } from "../geoip/geoip.service.js";
+import { corsDefaults } from "../http/cookie-cors-config.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 import {
   PrismaVerificationStore,
@@ -112,6 +113,10 @@ import { isBetterAuthRateLimitEnabled } from "./rate-limit-flag.js";
         return buildBetterAuth({
           secret,
           baseUrl: cfg.baseUrl,
+          // Trust the configured CORS origins (dev allowlist incl. the Expo
+          // web port) so cross-origin sign-up/sign-in pass Better-Auth's
+          // origin guard. The baseURL is always trusted regardless.
+          trustedOrigins: corsDefaults(cfg.env).allowedOrigins,
           sessionExpiresInSeconds: 60 * 60 * 24 * 7,
           // Audit hook (issue #99): write a CREATE row to audit_log after
           // every user creation, regardless of the creation path. The hook

--- a/src/core/auth/better-auth.ts
+++ b/src/core/auth/better-auth.ts
@@ -86,6 +86,13 @@ export interface BuildBetterAuthInput {
   /** Optional override; defaults to /api/auth via `resolveBetterAuthMountPath()`. */
   basePath?: string;
   /**
+   * Origins Better-Auth trusts for state-changing requests (its CSRF /
+   * cross-origin guard, separate from CORS). The `baseURL` is always
+   * trusted; pass additional dev/prod frontends (e.g. the Expo web port)
+   * so cross-origin sign-up/sign-in don't fail with "Invalid origin".
+   */
+  trustedOrigins?: string[];
+  /**
    * Optional Prisma client. When supplied, Better-Auth persists
    * users / sessions / accounts / verifications via
    * `better-auth/adapters/prisma`. When omitted, the built-in
@@ -597,6 +604,9 @@ export function buildBetterAuth(input: BuildBetterAuthInput): ReturnType<typeof 
     secret: input.secret,
     baseURL: input.baseUrl,
     basePath,
+    ...(input.trustedOrigins && input.trustedOrigins.length > 0
+      ? { trustedOrigins: input.trustedOrigins }
+      : {}),
     emailAndPassword: emailAndPasswordOptions,
     ...(emailVerificationOptions ? { emailVerification: emailVerificationOptions } : {}),
     ...(databaseHooks ? { databaseHooks } : {}),

--- a/src/core/http/cookie-cors-config.ts
+++ b/src/core/http/cookie-cors-config.ts
@@ -70,6 +70,10 @@ export function corsDefaults(
         // to call its own API without a proxy workaround.
         "http://localhost:3001",
         "http://localhost:5173",
+        // Expo web / Metro dev server (React Native projects) — lets the
+        // Expo Web build call the dev API with credentials.
+        "http://localhost:8081",
+        "http://localhost:19006",
         "http://app.nst.localhost",
       ],
       credentials: true,

--- a/tests/cookies-cors-config.spec.ts
+++ b/tests/cookies-cors-config.spec.ts
@@ -109,6 +109,13 @@ describe("Cookie & CORS Config", () => {
       expect(cfg.allowedOrigins).toContain("http://localhost:3001");
     });
 
+    it('corsDefaults("development") includes the Expo web dev port :8081', () => {
+      // Expo Web / Metro serves the React Native app on :8081; the dev API
+      // must allow it so credentialed auth requests pass CORS preflight.
+      const cfg = corsDefaults("development");
+      expect(cfg.allowedOrigins).toContain("http://localhost:8081");
+    });
+
     it('corsDefaults("production") returns no origins (must be configured explicitly)', () => {
       const cfg = corsDefaults("production");
       expect(cfg.allowedOrigins).toEqual([]);


### PR DESCRIPTION
## Problem

A frontend dev server running on a port outside the dev CORS allowlist (e.g. **Expo Web / Metro on `:8081`**) cannot sign up or sign in cross-origin against the dev API. It fails twice over:

1. The dev CORS allowlist (`corsDefaults("development")`) only had `:3000`, `:3001`, `:5173`, `app.nst.localhost` → preflight blocked.
2. Even past CORS, **Better-Auth's own origin guard** (`trustedOrigins`, separate from CORS) rejected the request with `"Invalid origin"`.

## Fix

- `corsDefaults("development")`: add `http://localhost:8081` + `http://localhost:19006` (Expo web / Metro dev ports).
- `buildBetterAuth`: new optional `trustedOrigins`; `BetterAuthModule` feeds it `corsDefaults(env).allowedOrigins`, so CORS and Better-Auth's trusted-origin set share **one source of truth**. The `baseURL` stays implicitly trusted.

## Verification

`POST /api/auth/sign-up/email` with `Origin: http://localhost:8081` now returns `200` (previously `"Invalid origin"`). Extends `tests/cookies-cors-config.spec.ts` with a `:8081` assertion. Local gates green: lint (0 errors), cors spec (12/12), test:types.