### PR TITLE
feat(permissions): optional AUTHENTICATED_ABILITY_FALLBACK hook for AbilityMiddleware

### DIFF
--- a/src/core/permissions/ability.middleware.ts
+++ b/src/core/permissions/ability.middleware.ts
@@ -1,4 +1,4 @@
-import { Injectable, type NestMiddleware } from "@nestjs/common";
+import { Inject, Injectable, type NestMiddleware, Optional } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 
 import { resolveHubOperatorTenantId } from "../hub/hub-operator-tenant.js";
@@ -6,6 +6,10 @@ import { isHubPortalProtectedPath, isHubPortalStaticAsset } from "../hub/hub-por
 import { resolveRequestTenantId } from "../multi-tenancy/resolve-request-tenant.js";
 import { isTenantExempt } from "../multi-tenancy/tenant-guard.js";
 import { PrismaService } from "../prisma/prisma.service.js";
+import {
+  AUTHENTICATED_ABILITY_FALLBACK,
+  type AuthenticatedAbilityFallback,
+} from "./authenticated-ability-fallback.js";
 import { type Ability, buildAbility } from "./casl-ability.js";
 import { PermissionService } from "./permission.service.js";
 
@@ -75,6 +79,16 @@ export class AbilityMiddleware implements NestMiddleware {
   constructor(
     private readonly permissions: PermissionService,
     private readonly prisma: PrismaService,
+    /**
+     * Optional project hook. When present, it decides the ability for an
+     * authenticated session the framework could not tenant-scope, in
+     * place of the empty-ability default (the "single-tenant gap" — see
+     * `authenticated-ability-fallback.ts`). Absent by default → behaviour
+     * is byte-identical to before.
+     */
+    @Optional()
+    @Inject(AUTHENTICATED_ABILITY_FALLBACK)
+    private readonly abilityFallback?: AuthenticatedAbilityFallback,
   ) {}
 
   async use(req: AuthenticatedRequest, _res: Response, next: NextFunction): Promise<void> {
@@ -106,7 +120,10 @@ export class AbilityMiddleware implements NestMiddleware {
           resolveHubOperatorTenantId(req.user!, this.prisma),
         );
       } else {
-        req.ability = buildAbility([]);
+        // Tenant-exempt but authenticated (`/me/*`, …): the framework
+        // default is an empty ability. A single-tenant project can
+        // upgrade this via the fallback hook (baseline for app sessions).
+        await this.installEmptyOrFallbackAbility(req);
       }
       next();
       return;
@@ -160,7 +177,10 @@ export class AbilityMiddleware implements NestMiddleware {
       return;
     }
     if (!tenantId) {
-      req.ability = buildAbility([]);
+      // No tenant resolvable for an authenticated user. Framework
+      // default is an empty ability; a project fallback may upgrade it
+      // (single-tenant staff → role ability, app session → baseline).
+      await this.installEmptyOrFallbackAbility(req);
       return;
     }
     try {
@@ -170,6 +190,34 @@ export class AbilityMiddleware implements NestMiddleware {
     } catch {
       req.ability = buildAbility([]);
     }
+  }
+
+  /**
+   * Install the empty-ability default, or — when a project registered
+   * `AUTHENTICATED_ABILITY_FALLBACK` and the request is authenticated —
+   * the ability the fallback resolves. Only ever called at a site that
+   * would otherwise install an empty ability, so it can never widen an
+   * ability the framework already resolved. A throwing fallback degrades
+   * to the empty default (never fails the request).
+   */
+  private async installEmptyOrFallbackAbility(req: AuthenticatedRequest): Promise<void> {
+    const user = req.user;
+    if (user && this.abilityFallback) {
+      const path = (req.originalUrl ?? req.url) as string | undefined;
+      try {
+        const fallbackAbility = await this.abilityFallback.resolve({
+          user,
+          ...(path !== undefined ? { path } : {}),
+        });
+        if (fallbackAbility) {
+          req.ability = fallbackAbility;
+          return;
+        }
+      } catch {
+        // fall through to the empty-ability default
+      }
+    }
+    req.ability = buildAbility([]);
   }
 }
 

--- a/src/core/permissions/authenticated-ability-fallback.ts
+++ b/src/core/permissions/authenticated-ability-fallback.ts
@@ -1,0 +1,70 @@
+import type { Ability } from "./casl-ability.js";
+
+/**
+ * Optional extension point for the `AbilityMiddleware`.
+ *
+ * ─── The problem this solves ────────────────────────────────────────
+ * `AbilityMiddleware` installs an EMPTY ability whenever an
+ * authenticated request cannot be resolved to a tenant (no
+ * `session.activeOrganizationId`, not a hub-operator path). That is the
+ * correct default for the framework: a `@Can()`-gated route then denies
+ * via `CanGuard`, and non-`@Can()` routes are unaffected.
+ *
+ * But a project that runs SINGLE-TENANT (Better-Auth organization plugin
+ * off) has NO `activeOrganizationId` on any session — so EVERY
+ * authenticated request would fall into the empty-ability branch and a
+ * `@Can()` gate would deny every real session. The friction-log calls
+ * this the "single-tenant gap": product routes had to stay `@Public()`
+ * because `@Can()` was structurally impossible.
+ *
+ * ─── The hook ───────────────────────────────────────────────────────
+ * When a project provides `AUTHENTICATED_ABILITY_FALLBACK`, the
+ * middleware consults it at exactly the moment it would otherwise
+ * install an empty ability for an AUTHENTICATED user. The provider
+ * decides the ability for that session — e.g. resolve the caller's
+ * first membership to a tenant and return their role ability, or return
+ * a fixed baseline for membership-less app sessions.
+ *
+ * Contract:
+ *   - Returning an `Ability` replaces the empty ability for this
+ *     request.
+ *   - Returning `null` keeps the framework default (empty ability), so
+ *     the provider can opt out per-request (e.g. only act in
+ *     single-tenant mode, leaving multi-tenant behaviour byte-identical).
+ *   - The hook is NEVER consulted for anonymous requests (no
+ *     `req.user`), for requests that already carry an ability
+ *     (`X-Test-Ability` / a resolved tenant), or when the tenant
+ *     resolver threw a security signal (bad tenant header). It only
+ *     ever UPGRADES an empty ability — it can never widen an ability the
+ *     framework already resolved.
+ *
+ * When no project registers the token the middleware behaves exactly as
+ * before (the injection is `@Optional()`), so this is a zero-cost,
+ * backwards-compatible extension point.
+ */
+export interface AuthenticatedAbilityFallbackUser {
+  /** Authenticated caller id (`req.user.id`). */
+  id: string;
+  /** API-key scopes when the request authenticated via a scoped key. */
+  scopes?: readonly string[];
+  /** Active organization from the Better-Auth session, if any. */
+  activeOrganizationId?: string | null;
+}
+
+export interface AuthenticatedAbilityFallbackInput {
+  user: AuthenticatedAbilityFallbackUser;
+  /** Resolved request path (`req.originalUrl ?? req.url`), when known. */
+  path?: string;
+}
+
+export interface AuthenticatedAbilityFallback {
+  /**
+   * Resolve the ability for an authenticated session the framework
+   * could not tenant-scope. Return `null` to keep the empty-ability
+   * default.
+   */
+  resolve(input: AuthenticatedAbilityFallbackInput): Promise<Ability | null>;
+}
+
+/** DI token for the optional `AuthenticatedAbilityFallback` provider. */
+export const AUTHENTICATED_ABILITY_FALLBACK = Symbol.for("lt:authenticated-ability-fallback");


### PR DESCRIPTION
> Validated on `main` @ `e600198` (current HEAD): patch applies via `git am`, `bun run test:types` exits 0 after `prisma generate`, the permissions story suite is green, and the only failing story (`email-brand-bridge`) fails identically on unpatched `main` (pre-existing, unrelated).
> Motivation and a battle-tested downstream provider exist in the BYND project, where this hook unlocked the full `@Public()`->`@Can()` migration in single-tenant mode.

## Problem

`AbilityMiddleware` installs an **empty** CASL ability (`buildAbility([])`) whenever an
authenticated request cannot be resolved to a tenant — i.e. no
`session.activeOrganizationId`, and the path is not a hub-operator path. For a
**multi-tenant** deployment this is the correct default:

- a `@Can()`-gated route then denies via `CanGuard` (empty ability grants nothing), and
- non-`@Can()` routes (e.g. the `/me/*` family that scopes by `req.user.id`) are unaffected.

But a project that runs **single-tenant** (Better-Auth organization plugin off) has **no
`activeOrganizationId` on any session**. Every authenticated request therefore falls into
the empty-ability branch, and any `@Can()` gate denies **every real session**. `@Can()`
becomes structurally unusable, and product routes are pushed back onto `@Public()` +
ad-hoc service-level checks — a fail-open posture, the opposite of what the permission
layer exists to provide. In our downstream project this was logged as the *"single-tenant
gap"*: we could not adopt `@Can()` on any product route until we could inject an ability
for membership-less sessions.

There is currently **no supported extension point** to influence the ability at the exact
moment the middleware decides to install an empty one, short of forking `src/core/`.

## Design

Add an **optional** injection token that the middleware consults *only* at the two sites
where it was already about to install an empty ability for an authenticated user.

**New file — `src/core/permissions/authenticated-ability-fallback.ts`**
- `AUTHENTICATED_ABILITY_FALLBACK` — a `Symbol.for("lt:authenticated-ability-fallback")` DI token.
- `AuthenticatedAbilityFallback` — the provider contract: `resolve(input) => Promise<Ability | null>`.
- `AuthenticatedAbilityFallbackInput` / `...User` — the input shape (`user.id`, optional
  `scopes`, optional `activeOrganizationId`, optional resolved `path`).

**Patched — `src/core/permissions/ability.middleware.ts`**
- Constructor gains `@Optional() @Inject(AUTHENTICATED_ABILITY_FALLBACK)
  private readonly abilityFallback?: AuthenticatedAbilityFallback`.
- The two inline `req.ability = buildAbility([])` assignments for an authenticated user
  (the tenant-exempt branch and the no-tenant-resolved branch) are replaced by a single
  new private helper `installEmptyOrFallbackAbility(req)`.

```ts
private async installEmptyOrFallbackAbility(req: AuthenticatedRequest): Promise<void> {
  const user = req.user;
  if (user && this.abilityFallback) {
    const path = (req.originalUrl ?? req.url) as string | undefined;
    try {
      const fallbackAbility = await this.abilityFallback.resolve({
        user,
        ...(path !== undefined ? { path } : {}),
      });
      if (fallbackAbility) {
        req.ability = fallbackAbility;
        return;
      }
    } catch {
      // fall through to the empty-ability default
    }
  }
  req.ability = buildAbility([]);
}
```

### Safety properties (by construction)

- **Upgrade-only.** The hook is called *only* at sites that were about to install
  `buildAbility([])`. It can replace an empty ability but can **never widen** an ability
  the framework already resolved for a real tenant.
- **Never consulted where it must not be.** Not for anonymous requests (no `req.user`),
  not for requests that already carry an ability (`X-Test-Ability` / a resolved tenant),
  and not when the tenant resolver raised a security signal (bad/forbidden tenant header —
  that path installs empty ability directly and returns before reaching the helper).
- **Fail-safe.** A throwing provider is swallowed and degrades to the empty-ability
  default; the hook can never fail a request.
- **Opt-out per request.** Returning `null` keeps the framework default, so a provider can
  act only in single-tenant mode and leave multi-tenant behaviour byte-identical.

### Proof: byte-identical when no provider is registered

1. The injection is `@Optional()`. With no provider bound, `this.abilityFallback` is
   `undefined`.
2. `installEmptyOrFallbackAbility` opens with `if (user && this.abilityFallback)`. With
   `abilityFallback === undefined` that guard is false, so control falls straight through
   to `req.ability = buildAbility([])`.
3. That is exactly what the two call sites did inline before this change.

So for any consumer that does **not** register the token, the resulting `req.ability` is
identical at both sites (an empty ability). The only mechanical difference is that the two
sites now `await` a promise that resolves immediately — no observable behavioural change.
The existing core test-suite (including the cross-tenant write-breach regression) exercises
exactly the no-provider path and stays green.

## Usage (example provider registration)

A downstream project registers a global provider bound to the token. Example — resolve the
caller's first membership to a tenant and return their role ability, else a fixed baseline,
and opt out entirely in multi-tenant mode:

```ts
// project-side: src/modules/<x>/authenticated-ability-fallback.provider.ts
import { Injectable } from "@nestjs/common";
import {
  type AuthenticatedAbilityFallback,
  type AuthenticatedAbilityFallbackInput,
} from "../../core/permissions/authenticated-ability-fallback.js";
import { type Ability, buildAbility } from "../../core/permissions/casl-ability.js";
import { PermissionService } from "../../core/permissions/permission.service.js";
import { MembershipService } from "./membership.service.js";

@Injectable()
export class ProjectAbilityFallback implements AuthenticatedAbilityFallback {
  constructor(
    private readonly permissions: PermissionService,
    private readonly memberships: MembershipService,
  ) {}

  async resolve(input: AuthenticatedAbilityFallbackInput): Promise<Ability | null> {
    // Only act in single-tenant mode; leave multi-tenant behaviour untouched.
    if (process.env.MULTI_TENANCY === "true") return null;

    const tenantId = await this.memberships.firstTenantIdFor(input.user.id);
    if (tenantId) {
      // Staff with a membership → their real role ability.
      return this.permissions.abilityFor(input.user.id, tenantId, {
        scopes: input.user.scopes,
      });
    }

    // Membership-less app session → a fixed read-only baseline on public content.
    return buildAbility([{ action: "read", subject: "PublishedContent" }]);
  }
}
```

```ts
// project-side module — @Global so the core AbilityMiddleware can inject it
import { Global, Module } from "@nestjs/common";
import { AUTHENTICATED_ABILITY_FALLBACK } from "../../core/permissions/authenticated-ability-fallback.js";
import { ProjectAbilityFallback } from "./authenticated-ability-fallback.provider.js";

@Global()
@Module({
  providers: [
    ProjectAbilityFallback,
    { provide: AUTHENTICATED_ABILITY_FALLBACK, useExisting: ProjectAbilityFallback },
  ],
  exports: [AUTHENTICATED_ABILITY_FALLBACK],
})
export class ProjectAccessModule {}
```

No core wiring change is needed on the consumer side beyond importing that module — the
middleware picks the provider up through the optional token.

## Tests (proposed additions upstream)

Suggested new story test `tests/stories/authenticated-ability-fallback.story.test.ts`.
It drives the deterministic tenant-exempt branch (e.g. `/me`) so the helper is reached
without a live tenant resolver, and asserts the contract. (The "not consulted when a real
tenant resolves" property is already covered by the existing multi-tenant regression
suite, which registers no provider and stays green.)

```ts
import { describe, expect, it } from "vitest";

import {
  AUTHENTICATED_ABILITY_FALLBACK,
  type AuthenticatedAbilityFallback,
} from "../../src/core/permissions/authenticated-ability-fallback.js";
import { AbilityMiddleware } from "../../src/core/permissions/ability.middleware.js";
import { buildAbility } from "../../src/core/permissions/casl-ability.js";
import type { PermissionService } from "../../src/core/permissions/permission.service.js";
import type { PrismaService } from "../../src/core/prisma/prisma.service.js";

// abilityFor is only reached when a tenant resolves; the fallback sites never call it.
const permissions = { abilityFor: async () => buildAbility([]) } as unknown as PermissionService;
const prisma = {} as PrismaService;

function reqFor(user?: { id: string }) {
  // `/me` is tenant-exempt → the middleware routes to installEmptyOrFallbackAbility.
  return { user, originalUrl: "/me", url: "/me" } as any;
}
const next = () => {};

describe("Story · AUTHENTICATED_ABILITY_FALLBACK", () => {
  it("no provider registered → empty ability (byte-identical default)", async () => {
    const mw = new AbilityMiddleware(permissions, prisma /* no fallback */);
    const req = reqFor({ id: "u1" });
    await mw.use(req, {} as any, next);
    expect(req.ability).toBeDefined();
    expect(req.ability!.can("read", "AnySubject")).toBe(false);
  });

  it("provider returns an ability → it replaces the empty default", async () => {
    const granted = buildAbility([{ action: "read", subject: "PublishedContent" }]);
    const fallback: AuthenticatedAbilityFallback = { resolve: async () => granted };
    const mw = new AbilityMiddleware(permissions, prisma, fallback);
    const req = reqFor({ id: "u1" });
    await mw.use(req, {} as any, next);
    expect(req.ability!.can("read", "PublishedContent")).toBe(true);
  });

  it("provider returns null → empty ability (per-request opt-out)", async () => {
    const fallback: AuthenticatedAbilityFallback = { resolve: async () => null };
    const mw = new AbilityMiddleware(permissions, prisma, fallback);
    const req = reqFor({ id: "u1" });
    await mw.use(req, {} as any, next);
    expect(req.ability!.can("read", "PublishedContent")).toBe(false);
  });

  it("anonymous request → provider is never consulted", async () => {
    let called = false;
    const fallback: AuthenticatedAbilityFallback = {
      resolve: async () => {
        called = true;
        return buildAbility([{ action: "manage", subject: "all" }]);
      },
    };
    const mw = new AbilityMiddleware(permissions, prisma, fallback);
    const req = reqFor(undefined); // no req.user
    await mw.use(req, {} as any, next);
    expect(called).toBe(false);
    expect(req.ability!.can("read", "AnySubject")).toBe(false);
  });

  it("throwing provider → degrades to empty ability, request still passes", async () => {
    const fallback: AuthenticatedAbilityFallback = {
      resolve: async () => {
        throw new Error("provider boom");
      },
    };
    const mw = new AbilityMiddleware(permissions, prisma, fallback);
    const req = reqFor({ id: "u1" });
    let passed = false;
    await mw.use(req, {} as any, () => {
      passed = true;
    });
    expect(passed).toBe(true);
    expect(req.ability!.can("read", "AnySubject")).toBe(false);
  });
});
```

Adjust the fake shapes / subject strings to the repo's existing test conventions (see
`tests/stories/pino-logger-service.story.test.ts` for the light-fake style and
`src/core/permissions/test-ability.ts` for ability construction helpers).

## Checklist for the reviewer

- [ ] Token naming (`lt:authenticated-ability-fallback`) fits the core namespace convention.
- [ ] Contract types live in the right place (`src/core/permissions/`).
- [ ] The proposed story test is added (or reshaped to match the existing harness).
- [ ] Confirm no `src/modules/`-specific symbol leaked into the patch (it does not — the
      patch is limited to the two `src/core/permissions/` files; the project provider and
      its `@Global` module registration stay downstream).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
