### PR TITLE
feat(hub): opt-in operational hub/admin console outside development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,12 @@ POWERSYNC_TOKEN=
 # FEATURE_POWERSYNC_ENABLED=false
 # FEATURE_MCP_ENABLED=false
 # FEATURE_FIELD_ENCRYPTION_ENABLED=false
+#
+# Operational hub/admin console outside development (staging/production).
+# Requires an authenticated Better-Auth session whose CASL ability grants
+# `read Hub` (for /hub/*) resp. tenant-admin subjects (for /admin/*).
+# Workstation tools (file browser, migrations, .env toggles) stay dev-only.
+# FEATURE_HUB_ENABLED=false
 
 # Geo (PostGIS, geocoding)
 # FEATURE_GEO_ENABLED=false

--- a/src/core/dx/admin-spa.controller.ts
+++ b/src/core/dx/admin-spa.controller.ts
@@ -14,6 +14,7 @@ import {
 } from "@nestjs/common";
 
 import { type AuditBrowserPageInput, type AuditLogEntry } from "./audit-browser-types.js";
+import { assertHubSurfaceAvailable } from "../hub/hub-surface-guard.js";
 import { buildDevPortalShellInput, renderDevPortalShell } from "./dev-portal-shell.js";
 import {
   type ActiveSocketEntry,
@@ -48,7 +49,6 @@ import { requireTenantContext } from "../multi-tenancy/require-tenant-context.js
 import { PrismaService } from "../prisma/prisma.service.js";
 import { RealtimeGateway } from "../realtime/realtime.module.js";
 import { SearchService } from "../search/search.service.js";
-import { serverConfigFromEnv } from "../server/server-config.js";
 import {
   buildPermissionReport,
   type PermissionReport,
@@ -170,7 +170,7 @@ function parseIsoQuery(value: string | undefined): Date | null {
 }
 
 @Public(
-  "Dev-Hub admin SPA JSON sidecars — assertDev() guards production; no CASL login required in local development.",
+  "Dev-Hub admin SPA JSON sidecars — the hub surface guard gates availability; no CASL login required in local development.",
 )
 @ApiTags("Admin")
 @Controller("admin")
@@ -191,7 +191,8 @@ export class AdminSpaController {
   @Get("permissions/test")
   @Header("content-type", "text/html; charset=utf-8")
   permissionsTestPage(): string {
-    this.assertDev();
+    // Tier: WORKSTATION — companion page of the x-test-ability tooling.
+    this.assertWorkstation();
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Permission Tester", brand: "central" }),
     );
@@ -212,7 +213,9 @@ export class AdminSpaController {
     report: PermissionReport | null;
     submitted: { userId: string; tenantId: string };
   }> {
-    this.assertDev();
+    // Tier: WORKSTATION — evaluates arbitrary (userId, tenantId) pairs,
+    // a debugging shortcut that must not exist on a deployed surface.
+    this.assertWorkstation();
     const submitted = { userId: userId ?? "", tenantId: tenantId ?? "" };
     if (!userId || !tenantId) {
       return { report: null, submitted };
@@ -238,7 +241,7 @@ export class AdminSpaController {
   @Get("webhooks")
   @Header("content-type", "text/html; charset=utf-8")
   webhookInspectorPage(): string {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Webhook Inspector", brand: "central" }),
     );
@@ -255,7 +258,7 @@ export class AdminSpaController {
     @Query("cursor") cursor: string | undefined,
     @Query("limit") limitRaw: string | undefined,
   ): Promise<WebhookInspectorPageInput> {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const limit = clampLimit(limitRaw);
     const filterStatus = normaliseDeliveryStatus(status);
     const filter: InspectorListFilter = { status: filterStatus };
@@ -297,7 +300,7 @@ export class AdminSpaController {
 
   @Get("webhooks/aggregates.json")
   async webhookAggregatesJson(): Promise<WebhookAggregatesResponse> {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const now = Date.now();
     const tenantId = getCurrentTenantId() ?? undefined;
     const all = await loadInspectorDeliveriesFromDb(this.prisma, {
@@ -330,14 +333,14 @@ export class AdminSpaController {
    */
   @Get("webhooks/event-types.json")
   webhookEventTypesJson(): WebhookEventTypesResponse {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const registered = getRegisteredWebhookEvents();
     return { eventTypes: registered.map((m) => m.name) };
   }
 
   @Get("webhooks/:id.json")
   async webhookDeliveryDetailJson(@Param("id") id: string): Promise<WebhookDeliveryDetailResponse> {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const tenantId = getCurrentTenantId() ?? undefined;
     const row = await findInspectorDeliveryById(this.prisma, id, tenantId);
     if (!row) throw new NotFoundException();
@@ -392,7 +395,7 @@ export class AdminSpaController {
     @Param("id") id: string,
     @Body() body: { eventType?: string; payload?: unknown } | undefined,
   ): Promise<WebhookTestEventResponse> {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const eventType = body?.eventType?.trim();
     if (!eventType) {
       throw new BadRequestException("eventType is required");
@@ -461,7 +464,7 @@ export class AdminSpaController {
     @Param("id") id: string,
     @Body() body: { csrfToken?: string } | undefined,
   ): Promise<WebhookRedeliverResponse> {
-    this.assertDevFeature("webhooks");
+    this.assertOperationalFeature("webhooks");
     const token = body?.csrfToken?.trim();
     if (!token) {
       throw new ForbiddenException("missing CSRF token");
@@ -518,7 +521,7 @@ export class AdminSpaController {
   @Get("realtime")
   @Header("content-type", "text/html; charset=utf-8")
   realtimeInspectorPage(): string {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Realtime Inspector", brand: "central" }),
     );
@@ -526,7 +529,7 @@ export class AdminSpaController {
 
   @Get("realtime.json")
   realtimeInspectorJson(): RealtimeInspectorPageInput {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     const snapshot = this.realtime.inspectorSnapshot();
     const sockets: ActiveSocketEntry[] = snapshot.sockets.map((s) => ({
       id: s.id,
@@ -571,7 +574,7 @@ export class AdminSpaController {
 
   @Get("realtime/channels.json")
   realtimeChannelsJson(): RealtimeChannelsPageInput {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     const snapshot = this.realtime.inspectorSnapshot();
     const channels: RealtimeChannelEntry[] = snapshot.channels.map((c) => ({
       name: c.name,
@@ -586,7 +589,7 @@ export class AdminSpaController {
   @Post("realtime/sockets/:id/disconnect")
   @HttpCode(200)
   realtimeDisconnectSocket(@Param("id") id: string): { id: string } {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     const ok = this.realtime.disconnectSocket(id);
     if (!ok) throw new NotFoundException(`unknown socket "${id}"`);
     return { id };
@@ -598,7 +601,7 @@ export class AdminSpaController {
     @Param("id") id: string,
     @Body() body: Partial<RealtimeSendInput>,
   ): { delivered: true } {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     if (!body || typeof body.eventType !== "string" || !body.eventType) {
       throw new BadRequestException("eventType (non-empty string) is required");
     }
@@ -610,7 +613,7 @@ export class AdminSpaController {
   @Post("realtime/events/replay")
   @HttpCode(200)
   realtimeReplayEvent(@Body() body: Partial<RealtimeReplayInput>): { replayed: true } {
-    this.assertDevFeature("realtime");
+    this.assertOperationalFeature("realtime");
     if (
       !body ||
       typeof body.channel !== "string" ||
@@ -629,7 +632,7 @@ export class AdminSpaController {
   @Get("audit")
   @Header("content-type", "text/html; charset=utf-8")
   auditBrowserPage(): string {
-    this.assertDevFeature("audit");
+    this.assertOperationalFeature("audit");
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Audit Browser", brand: "central" }),
     );
@@ -643,7 +646,7 @@ export class AdminSpaController {
     @Query("from") from: string | undefined,
     @Query("to") to: string | undefined,
   ): Promise<AuditBrowserPageInput> {
-    this.assertDevFeature("audit");
+    this.assertOperationalFeature("audit");
     const filter: AuditBrowserPageInput["filter"] = {};
     if (action) filter.action = action;
     if (resource) filter.resource = resource;
@@ -692,7 +695,7 @@ export class AdminSpaController {
   @Get("jobs")
   @Header("content-type", "text/html; charset=utf-8")
   adminJobsPage(): string {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Jobs", brand: "central" }));
   }
 
@@ -701,7 +704,7 @@ export class AdminSpaController {
   @Get("search")
   @Header("content-type", "text/html; charset=utf-8")
   searchTesterPage(): string {
-    this.assertDevFeature("search");
+    this.assertOperationalFeature("search");
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Search Tester", brand: "central" }),
     );
@@ -709,7 +712,10 @@ export class AdminSpaController {
 
   @Get("search.json")
   async searchTesterJson(@Query("q") q: string | undefined): Promise<SearchTesterPageInput> {
-    this.assertDevFeature("search");
+    // Tier: WORKSTATION — the tester intentionally searches ACROSS all
+    // tenants (tenantId = "") to verify FTS config; on a deployed
+    // surface that would be a cross-tenant data leak.
+    this.assertWorkstationFeature("search");
     if (q === undefined) {
       return { hits: [] };
     }
@@ -723,8 +729,8 @@ export class AdminSpaController {
     // The search tester is a dev-only admin tool. It intentionally searches
     // across all tenants (tenantId = "" disables the member-EXISTS filter in
     // the Postgres executor) so developers can verify FTS configuration without
-    // needing a specific organization context. The caller already validated that
-    // `NODE_ENV === "development"` via `assertDev()`.
+    // needing a specific organization context. The workstation-tier guard
+    // above already pinned this to `NODE_ENV=development`.
     const rawHits = await this.searchService.search(q, {
       limit: SEARCH_TESTER_PAGE_SIZE,
       tenantId: "",
@@ -744,15 +750,33 @@ export class AdminSpaController {
 
   // ── helpers ─────────────────────────────────────────────────────
 
-  private assertDev(): void {
-    const cfg = serverConfigFromEnv(process.env);
-    if (cfg.env !== "development") {
-      throw new NotFoundException();
-    }
+  /**
+   * OPERATIONAL tier (see `hub-surface-policy.ts`): the admin SPA
+   * shells and their JSON sidecars (webhooks, realtime, audit, jobs)
+   * are operator-console surfaces — development-always, and outside
+   * development available when `FEATURE_HUB_ENABLED=true` behind the
+   * CASL wall in `HubPortalMiddleware`.
+   */
+  private assertOperational(): void {
+    assertHubSurfaceAvailable("operational");
   }
 
-  private assertDevFeature(key: ToggleableFeatureKey): void {
-    this.assertDev();
+  /**
+   * WORKSTATION tier: dev tools that would undercut the permission
+   * model outside a workstation (x-test-ability permission tester,
+   * cross-tenant search tester). Development-only forever.
+   */
+  private assertWorkstation(): void {
+    assertHubSurfaceAvailable("workstation");
+  }
+
+  private assertOperationalFeature(key: ToggleableFeatureKey): void {
+    this.assertOperational();
+    assertFeatureEnabledFromEnv(key);
+  }
+
+  private assertWorkstationFeature(key: ToggleableFeatureKey): void {
+    this.assertWorkstation();
     assertFeatureEnabledFromEnv(key);
   }
 }

--- a/src/core/dx/dev-files.controller.ts
+++ b/src/core/dx/dev-files.controller.ts
@@ -7,11 +7,16 @@
  *   - `/hub/files/list.json`        — files in the active folder (grid)
  *   - `/hub/files/breadcrumb.json`  — root-to-active path (header)
  *
- * Every endpoint 404s outside `NODE_ENV=development`, identical to
- * the rest of the Hub. The controller is mounted unconditionally
- * by `HubSpaModule` so route discovery (`/hub/routes`) sees it on the
- * inventory. The `assertDev()` short-circuit keeps the surface from
- * leaking in a production build.
+ * Tier: WORKSTATION (see `hub-surface-policy.ts`) — a dev debug view
+ * that lists tenant file/folder rows via `@Public` routes with only
+ * the tenant context as its gate (no per-subject `@Can("File")`
+ * check). Exposing that outside development would sidestep the CASL
+ * model of the product file API, so every endpoint 404s in deployed
+ * environments even when `FEATURE_HUB_ENABLED` opts the operational
+ * hub in. The controller is mounted unconditionally by `HubSpaModule`
+ * so route discovery (`/hub/routes`) sees it on the inventory; the
+ * workstation guard keeps the surface from leaking in a deployed
+ * build.
  *
  * Tenant scoping: session `set-active` (TenantInterceptor ALS). RLS is
  * the last-resort backstop; reads are explicitly scoped by tenant id.
@@ -20,7 +25,7 @@
  * splat-catchall on `HubController` — react-router takes over from
  * the SPA shell.
  */
-import { Controller, Get, Header, NotFoundException, Query } from "@nestjs/common";
+import { Controller, Get, Header, Query } from "@nestjs/common";
 
 import { ApiTags } from "@nestjs/swagger";
 
@@ -35,9 +40,9 @@ import {
 } from "../files/file-manager-breadcrumb.js";
 import { applyFileSearch, type FileSearchSortKey } from "../files/file-manager-search.js";
 import { buildFolderTree, type FolderTreeNode } from "../files/file-manager-tree.js";
+import { assertHubSurfaceAvailable } from "../hub/hub-surface-guard.js";
 import { requireTenantContext } from "../multi-tenancy/require-tenant-context.js";
 import { PrismaService } from "../prisma/prisma.service.js";
-import { serverConfigFromEnv } from "../server/server-config.js";
 
 interface FileListEntry {
   id: string;
@@ -78,7 +83,9 @@ export class DevFilesController {
    * explicitly here means route inventory shows `/hub/files` as a
    * first-class route instead of "covered by splat".
    */
-  @Public("Hub file browser — NODE_ENV=development only; assertDev() rejects production requests")
+  @Public(
+    "Hub file browser — workstation tier, development-only; the surface guard 404s deployed requests",
+  )
   @Get()
   @Header("content-type", "text/html; charset=utf-8")
   page(): string {
@@ -88,7 +95,9 @@ export class DevFilesController {
     );
   }
 
-  @Public("Hub file browser — NODE_ENV=development only; assertDev() rejects production requests")
+  @Public(
+    "Hub file browser — workstation tier, development-only; the surface guard 404s deployed requests",
+  )
   @Get("tree.json")
   async tree(): Promise<FileTreeResponse> {
     this.assertDevFiles();
@@ -101,7 +110,9 @@ export class DevFilesController {
     return { tree };
   }
 
-  @Public("Hub file browser — NODE_ENV=development only; assertDev() rejects production requests")
+  @Public(
+    "Hub file browser — workstation tier, development-only; the surface guard 404s deployed requests",
+  )
   @Get("list.json")
   async list(
     @Query("folderId") folderId: string | undefined,
@@ -182,7 +193,9 @@ export class DevFilesController {
     return { files, totalCount: rows.length };
   }
 
-  @Public("Hub file browser — NODE_ENV=development only; assertDev() rejects production requests")
+  @Public(
+    "Hub file browser — workstation tier, development-only; the surface guard 404s deployed requests",
+  )
   @Get("breadcrumb.json")
   async breadcrumb(@Query("folderId") folderId: string | undefined): Promise<BreadcrumbResponse> {
     this.assertDevFiles();
@@ -198,15 +211,15 @@ export class DevFilesController {
     return { segments: buildFolderBreadcrumb({ activeId, folders }) };
   }
 
-  private assertDev(): void {
-    const cfg = serverConfigFromEnv(process.env);
-    if (cfg.env !== "development") {
-      throw new NotFoundException();
-    }
-  }
-
+  /**
+   * Tier: WORKSTATION for the entire controller (see
+   * `hub-surface-policy.ts`) — `@Public` debug listings over tenant
+   * file rows without per-subject CASL would undercut the product
+   * file API's permission model in a deployed container.
+   * `FEATURE_HUB_ENABLED` does not open it.
+   */
   private assertDevFiles(): void {
-    this.assertDev();
+    assertHubSurfaceAvailable("workstation");
     assertFeatureEnabledFromEnv("files");
   }
 }

--- a/src/core/dx/hub-spa.module.ts
+++ b/src/core/dx/hub-spa.module.ts
@@ -12,9 +12,12 @@ import { RealtimeModule } from "../realtime/realtime.module.js";
 /**
  * HubSpaModule — registers the `/hub` and `/admin` SPA controllers.
  *
- * Loaded unconditionally; both controllers short-circuit to a 404
- * outside `NODE_ENV=development` so they can never leak tool URLs in
- * production.
+ * Loaded unconditionally; every route short-circuits through the
+ * tiered surface guard (`hub-surface-policy.ts`): outside
+ * `NODE_ENV=development` operational surfaces 404 unless
+ * `FEATURE_HUB_ENABLED=true` (plus the CASL wall in
+ * `HubPortalMiddleware`), and workstation surfaces 404 always — tool
+ * URLs can never leak from a deployment that didn't opt in.
  *
  * `DiscoveryModule` is imported so `RouteInventoryService` can walk
  * the registered controllers for `/hub/routes`. `MigrationsService` is

--- a/src/core/dx/hub.controller.ts
+++ b/src/core/dx/hub.controller.ts
@@ -122,6 +122,7 @@ import { ApiTags } from "@nestjs/swagger";
 import type { Ability } from "../permissions/casl-ability.js";
 import { buildHubPortalAccessSnapshot } from "../hub/hub-portal-access.js";
 import { resolveHubOperatorTenantId, type HubOperatorUser } from "../hub/hub-operator-tenant.js";
+import { assertHubSurfaceAvailable } from "../hub/hub-surface-guard.js";
 import { buildHubNavFeatureSnapshot, filterPalettePagesForNavSnapshot } from "./hub-nav-planner.js";
 import { Public } from "../permissions/public.decorator.js";
 import { assertFeatureEnabledFromEnv } from "../features/assert-feature-enabled.js";
@@ -152,7 +153,7 @@ export class HubController {
   @Get()
   @Header("content-type", "text/html; charset=utf-8")
   index(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Dev Portal", brand: "central" }),
     );
@@ -160,12 +161,14 @@ export class HubController {
 
   /**
    * `/hub/static/:filename` — serves the bundled SPA assets from
-   * `dist/dev-portal/`. `assertDev()` ensures the route 404s outside
-   * development (no production-leak risk for the source-mapped bundle).
+   * `dist/dev-portal/`. Operational tier: outside development the
+   * surface guard 404s the route unless `FEATURE_HUB_ENABLED=true`
+   * (the login page at `/` needs these assets once the hub is opted
+   * in; without the flag nothing leaks, same as before).
    */
   @Get("static/:filename")
   serveStatic(@Param("filename") filename: string, @Res() res: Response): void {
-    this.assertDev();
+    this.assertOperational();
     if (!isSafeStaticName(filename)) {
       throw new NotFoundException();
     }
@@ -225,7 +228,7 @@ export class HubController {
   portalAccessJson(
     @Req() req: { ability?: Ability },
   ): ReturnType<typeof buildHubPortalAccessSnapshot> {
-    this.assertDev();
+    this.assertOperational();
     const features = this.featuresOnly();
     return buildHubPortalAccessSnapshot(req.ability, buildHubNavFeatureSnapshot(features));
   }
@@ -239,7 +242,7 @@ export class HubController {
    * tenant: the operator's OWN membership org via `resolveHubOperatorTenantId`
    * (same resolver the single-tenant `HubOperatorTenantInterceptor` uses).
    *
-   * `@Public` + `assertDev()` mirror `portalAccessJson`: it must be reachable
+   * `@Public` + the operational surface guard mirror `portalAccessJson`: it must be reachable
    * WITHOUT a tenant context (it is what RESOLVES the tenant). The
    * `HubOperatorTenantInterceptor` passes tenant-less hub requests through, so
    * no interceptor 400 blocks this. Returns `{ tenantId: null }` for an
@@ -258,7 +261,7 @@ export class HubController {
   async operatorTenantJson(
     @Req() req: { user?: HubOperatorUser },
   ): Promise<{ tenantId: string | null }> {
-    this.assertDev();
+    this.assertOperational();
     if (!req.user) {
       return { tenantId: null };
     }
@@ -267,7 +270,7 @@ export class HubController {
 
   @Get("dashboard.json")
   async dashboardJson(): Promise<unknown> {
-    this.assertDev();
+    this.assertOperational();
     const features = this.featuresOnly();
     const cfg = serverConfigFromEnv(process.env);
     const effective = resolveEffectiveBaseUrl({
@@ -368,7 +371,7 @@ export class HubController {
    */
   @Get("tunnel.json")
   tunnelJson(): { active: false } | { active: true; url: string; startedAt: string } {
-    this.assertDev();
+    this.assertWorkstation(); // leaks the workstation tunnel URL
     const state = readTunnelState(process.cwd());
     if (state === null) return { active: false };
     return { active: true, url: state.url, startedAt: state.startedAt };
@@ -384,7 +387,7 @@ export class HubController {
    */
   @Get("brand.json")
   brandJson(): BrandConfig {
-    this.assertDev();
+    this.assertOperational();
     return loadBrandSync(process.cwd());
   }
 
@@ -396,7 +399,7 @@ export class HubController {
   @Get("brand")
   @Header("content-type", "text/html; charset=utf-8")
   brandPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Brand", brand: "central" }));
   }
 
@@ -414,7 +417,7 @@ export class HubController {
   @Post("brand")
   @HttpCode(200)
   async saveBrand(@Body() body: unknown): Promise<{ ok: true; brand: BrandConfig }> {
-    this.assertDev();
+    this.assertWorkstation(); // writes src/modules/branding/brand.json
     let parsed: BrandConfig;
     try {
       parsed = decodeBrand(body);
@@ -440,7 +443,7 @@ export class HubController {
   @Post("brand/reset")
   @HttpCode(200)
   async resetBrand(): Promise<{ ok: true; acted: boolean }> {
-    this.assertDev();
+    this.assertWorkstation(); // deletes the repo brand overlay file
     const paths = resolveBrandPaths(process.cwd());
     let acted = false;
     try {
@@ -457,7 +460,7 @@ export class HubController {
 
   @Get("status.json")
   async statusJson(): Promise<ServiceProbeResult[]> {
-    this.assertDev();
+    this.assertOperational();
     const features = this.featuresOnly();
     const cfg = serverConfigFromEnv(process.env);
     const effective = resolveEffectiveBaseUrl({
@@ -485,7 +488,7 @@ export class HubController {
   @Get("features")
   @Header("content-type", "text/html; charset=utf-8")
   features(): string {
-    this.assertDev();
+    this.assertOperational();
     // SPA shell — the React `/hub/features` page fetches
     // `/hub/feature-catalog.json` and renders the same DOM the
     // legacy `renderFeaturesPage` produced. The legacy renderer
@@ -496,7 +499,7 @@ export class HubController {
 
   @Get("features.json")
   featuresJson(): Features {
-    this.assertDev();
+    this.assertOperational();
     return this.featuresOnly();
   }
 
@@ -509,7 +512,7 @@ export class HubController {
    */
   @Get("feature-catalog.json")
   featureCatalogJson(): { catalog: typeof FEATURE_CATALOG; features: Features } {
-    this.assertDev();
+    this.assertOperational();
     return { catalog: FEATURE_CATALOG, features: this.featuresOnly() };
   }
 
@@ -525,7 +528,7 @@ export class HubController {
   scheduledJobsJson(): {
     jobs: Array<{ name: string; cron: string; source: string }>;
   } {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     const jobs = this.scheduledJobs.list().map((entry) => ({
       name: entry.name,
       cron: entry.cron,
@@ -546,7 +549,7 @@ export class HubController {
    */
   @Get("webhook-events.json")
   webhookEventsJson(): { events: readonly WebhookEventMetadata[] } {
-    this.assertDev();
+    this.assertOperational();
     return { events: getRegisteredWebhookEvents() };
   }
 
@@ -556,7 +559,7 @@ export class HubController {
     @Param("key") key: string,
     @Body() body: { enabled?: unknown },
   ): Promise<{ ok: true; key: string; enabled: boolean; envKey: string; restart: true }> {
-    this.assertDev();
+    this.assertWorkstation(); // writes the .env file on disk
     const meta = FEATURE_CATALOG.find((f) => f.key === key);
     if (!meta) {
       throw new BadRequestException("unknown feature key");
@@ -603,7 +606,7 @@ export class HubController {
     @Headers("accept") accept: string | undefined,
     @Res() res: Response,
   ): void {
-    this.assertDev();
+    this.assertOperational();
     const { format, ...filterQuery } = query;
     const parsed = parsePostgrestQuery(filterQuery);
     const data = { where: parsed, query: filterQuery };
@@ -629,27 +632,27 @@ export class HubController {
   @Get("coverage")
   @Header("content-type", "text/html; charset=utf-8")
   coverage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Coverage", brand: "central" }));
   }
 
   /** JSON sibling for the React `/hub/coverage` page. */
   @Get("coverage.json")
   async coverageJson(): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation(); // reads coverage artifacts from the checkout
     return this.readCoverageSummary(process.cwd());
   }
 
   @Get("logs")
   @Header("content-type", "text/html; charset=utf-8")
   logsPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Logs", brand: "central" }));
   }
 
   @Get("logs.json")
   logsJson(@Query("since") since: string | undefined): unknown[] {
-    this.assertDev();
+    this.assertOperational();
     const buffer = getLogBuffer();
     const sinceSeq = Number.parseInt(since ?? "0", 10) || 0;
     return [...buffer.since(sinceSeq)];
@@ -658,21 +661,21 @@ export class HubController {
   @Get("tests")
   @Header("content-type", "text/html; charset=utf-8")
   tests(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Tests", brand: "central" }));
   }
 
   /** JSON sibling for the React `/hub/tests` page. */
   @Get("tests.json")
   async testsJson(): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation(); // reads local test-run artifacts
     return this.readTestSummary(process.cwd());
   }
 
   @Get("diagnostics")
   @Header("content-type", "text/html; charset=utf-8")
   diagnostics(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Diagnostics", brand: "central" }),
     );
@@ -680,27 +683,27 @@ export class HubController {
 
   @Get("diagnostics.json")
   diagnosticsJson(): DiagnosticsReport {
-    this.assertDev();
+    this.assertOperational();
     return this.buildDiagnostics();
   }
 
   @Get("routes")
   @Header("content-type", "text/html; charset=utf-8")
   routesPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Routes", brand: "central" }));
   }
 
   @Get("routes.json")
   routesJson(): RouteInventory {
-    this.assertDev();
+    this.assertOperational();
     return this.routes.build();
   }
 
   @Get("erd")
   @Header("content-type", "text/html; charset=utf-8")
   erdPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "ERD", brand: "central" }));
   }
 
@@ -714,7 +717,7 @@ export class HubController {
   @Get("json")
   @Header("content-type", "text/html; charset=utf-8")
   jsonViewerPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "JSON Viewer", brand: "central" }),
     );
@@ -722,14 +725,14 @@ export class HubController {
 
   @Get("erd.json")
   erdJson(): { mermaid: string; modelCount: number; relationCount: number } {
-    this.assertDev();
+    this.assertWorkstation(); // reads prisma/ schema files from the checkout
     return buildErdForProject();
   }
 
   @Get("traces")
   @Header("content-type", "text/html; charset=utf-8")
   tracesPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Traces", brand: "central" }));
   }
 
@@ -741,7 +744,7 @@ export class HubController {
     traces: TraceRecord[];
     summary: TraceSummary;
   } {
-    this.assertDev();
+    this.assertOperational();
     const buffer = getTraceBuffer();
     const filter: { limit?: number; requestId?: string } = {};
     if (limit) {
@@ -755,7 +758,7 @@ export class HubController {
   @Get("queries")
   @Header("content-type", "text/html; charset=utf-8")
   queriesPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Queries", brand: "central" }));
   }
 
@@ -769,7 +772,7 @@ export class HubController {
     topTemplates: TemplateGroup[];
     summary: QuerySummary;
   } {
-    this.assertDev();
+    this.assertOperational();
     const buffer = getQueryBuffer();
     const filter: { limit?: number; requestId?: string } = {};
     if (limit) {
@@ -791,7 +794,7 @@ export class HubController {
     rendered: Record<string, EmailPreviewResult>;
     payloadSources: Record<string, EmailPreviewPayloadSource>;
   }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email"); // renders template sources + overrides from the checkout
     // PRD § Out of Scope bans EJS — `/hub/email-preview` runs the
     // ReactEmailTemplateRenderer (the same path production code uses
     // through `EmailService.sendTemplate`) so the preview reflects
@@ -824,7 +827,7 @@ export class HubController {
   @Get("emails")
   @Header("content-type", "text/html; charset=utf-8")
   emailsPage(): string {
-    this.assertDevFeature("email");
+    this.assertOperationalFeature("email");
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Emails" }));
   }
 
@@ -832,7 +835,7 @@ export class HubController {
   @Get("email-builder")
   @Header("content-type", "text/html; charset=utf-8")
   emailBuilderPage(): string {
-    this.assertDevFeature("email");
+    this.assertOperationalFeature("email");
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Emails" }));
   }
 
@@ -843,7 +846,7 @@ export class HubController {
   @Get(["emails/templates/:name/preview.html", "email-builder/templates/:name/preview.html"])
   @Header("content-type", "text/html; charset=utf-8")
   async emailTemplatePreviewHtml(@Param("name") name: string): Promise<string> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email");
     if (!isValidEmailTemplateSlug(name)) {
       throw new BadRequestException(`Invalid template name: ${name}`);
     }
@@ -888,7 +891,7 @@ export class HubController {
       overrideExists?: boolean;
     }>;
   }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email");
     const discovered = await discoverReactEmailTemplates();
     const brand = resolveBrandConfig();
     const renderer = new ReactEmailTemplateRenderer({ brand });
@@ -981,7 +984,7 @@ export class HubController {
     composition?: EmailComposition;
     reason?: string;
   }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email");
     if (!isValidEmailTemplateSlug(name)) {
       throw new BadRequestException(`invalid template name: ${name}`);
     }
@@ -1061,7 +1064,7 @@ export class HubController {
     @Param("name") name: string,
     @Query("locale") locale: string | undefined,
   ): Promise<{ ok: true; acted: true; relativePath: string }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email"); // deletes template override files
     if (!isValidEmailTemplateSlug(name)) {
       throw new BadRequestException(`invalid template name: ${name}`);
     }
@@ -1115,7 +1118,7 @@ export class HubController {
     }>;
     layouts: Array<{ name: string; description: string }>;
   } {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email");
     return {
       blocks: KNOWN_EMAIL_BLOCKS.map((type) => buildBlockDescriptor(type)),
       layouts: KNOWN_EMAIL_LAYOUTS.map((name) => ({
@@ -1138,7 +1141,7 @@ export class HubController {
     html: string;
     text: string;
   }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email");
     const composition = pickComposition(body);
     const validation = validateEmailComposition(composition);
     if (!validation.ok) throw new BadRequestException(validation.error);
@@ -1164,7 +1167,7 @@ export class HubController {
     relativePath: string;
     bytesWritten: number;
   }> {
-    this.assertDevFeature("email");
+    this.assertWorkstationFeature("email"); // writes template override files into src/
     const slug = pickSlug(body);
     const locale = pickLocale(body);
     const composition = pickComposition(body);
@@ -1239,27 +1242,33 @@ export class HubController {
 
   // -----------------------------------------------------------------
   // /hub/migrations · Issue #10 — Migration Handler
+  //
+  // Tier: WORKSTATION for every data/action route below. The runner
+  // reads prisma/migrations from the checkout and mutates the schema —
+  // never eligible outside development, regardless of the hub flag.
+  // Only the SPA shell stays operational chrome (identical to the
+  // `*splat` fallback shell, so it reveals nothing).
   // -----------------------------------------------------------------
 
   /** SPA shell for `/hub/migrations` — React decides which tab to show. */
   @Get("migrations")
   @Header("content-type", "text/html; charset=utf-8")
   migrationsPage(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Migrations" }));
   }
 
   /** JSON snapshot of applied + pending + failed migrations + drift signal. */
   @Get("migrations.json")
   async migrationsJson(): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     return this.migrations.getStatus();
   }
 
   /** Read-only SQL preview of a single migration folder. */
   @Get("migrations/preview/:name")
   migrationsPreview(@Param("name") name: string): { name: string; sql: string } {
-    this.assertDev();
+    this.assertWorkstation();
     try {
       return this.migrations.previewSql(name);
     } catch (err) {
@@ -1270,7 +1279,7 @@ export class HubController {
   /** Schema diff between live DB and `prisma/schema.prisma`. */
   @Get("migrations/diff")
   async migrationsDiff(): Promise<{ sql: string; success: boolean; stderr: string }> {
-    this.assertDev();
+    this.assertWorkstation();
     return this.migrations.getDiff();
   }
 
@@ -1278,7 +1287,7 @@ export class HubController {
   @Post("migrations/deploy")
   @HttpCode(200)
   async migrationsDeploy(): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const r = await this.migrations.deployPending();
     return this.unwrapLock(r);
   }
@@ -1287,7 +1296,7 @@ export class HubController {
   @Post("migrations/apply-one")
   @HttpCode(200)
   async migrationsApplyOne(@Body() body: { name?: unknown }): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const name = assertNonEmptyString(body?.name, "name");
     try {
       const r = await this.migrations.applyOne(name);
@@ -1302,7 +1311,7 @@ export class HubController {
   @Post("migrations/dry-run")
   @HttpCode(200)
   async migrationsDryRun(@Body() body: { name?: unknown }): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const name = assertNonEmptyString(body?.name, "name");
     try {
       const r = await this.migrations.dryRun(name);
@@ -1317,7 +1326,7 @@ export class HubController {
   @Post("migrations/retry")
   @HttpCode(200)
   async migrationsRetry(@Body() body: { name?: unknown }): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const name = assertNonEmptyString(body?.name, "name");
     try {
       const r = await this.migrations.retryFailed(name);
@@ -1332,7 +1341,7 @@ export class HubController {
   @Post("migrations/create")
   @HttpCode(200)
   async migrationsCreate(@Body() body: { name?: unknown }): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const name = assertNonEmptyString(body?.name, "name");
     try {
       const r = await this.migrations.createDraft(name);
@@ -1347,7 +1356,7 @@ export class HubController {
   @Post("migrations/apply-draft")
   @HttpCode(200)
   async migrationsApplyDraft(@Body() body: { name?: unknown }): Promise<unknown> {
-    this.assertDev();
+    this.assertWorkstation();
     const name = assertNonEmptyString(body?.name, "name");
     try {
       const r = await this.migrations.applyDraft(name);
@@ -1364,7 +1373,7 @@ export class HubController {
   async migrationsDiscardDraft(
     @Param("name") name: string,
   ): Promise<{ name: string; deleted: boolean }> {
-    this.assertDev();
+    this.assertWorkstation();
     try {
       return this.migrations.discardDraft(name);
     } catch (err) {
@@ -1390,7 +1399,7 @@ export class HubController {
   @Get("jobs")
   @Header("content-type", "text/html; charset=utf-8")
   jobsPage(): string {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Jobs" }));
   }
 
@@ -1402,7 +1411,7 @@ export class HubController {
    */
   @Get("jobs/queues.json")
   async jobsQueuesJson(): Promise<unknown> {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     return this.jobs.getAggregates();
   }
 
@@ -1418,7 +1427,7 @@ export class HubController {
     @Query("name") name: string | undefined,
     @Query("limit") limit: string | undefined,
   ): Promise<{ jobs: unknown[] }> {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     const options: ListJobsOptions = {};
     if (state) {
       if (!isJobState(state)) {
@@ -1452,7 +1461,7 @@ export class HubController {
    */
   @Get("jobs/jobs/:id.json")
   async jobDetailJson(@Param("id") id: string): Promise<unknown> {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     if (!isSafeJobId(id)) {
       throw new BadRequestException(`invalid job id`);
     }
@@ -1469,7 +1478,7 @@ export class HubController {
   @Post("jobs/jobs/:id/retry")
   @HttpCode(200)
   async retryJob(@Param("id") id: string): Promise<{ id: string }> {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     if (!isSafeJobId(id)) {
       throw new BadRequestException(`invalid job id`);
     }
@@ -1500,7 +1509,7 @@ export class HubController {
   @Get("email-outbox")
   @Header("content-type", "text/html; charset=utf-8")
   emailOutboxPage(): string {
-    this.assertDevFeature("email");
+    this.assertOperationalFeature("email");
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Email Outbox", brand: "central" }),
     );
@@ -1516,13 +1525,13 @@ export class HubController {
   @Get("cron")
   @Header("content-type", "text/html; charset=utf-8")
   cronPage(): string {
-    this.assertDevFeature("jobs");
+    this.assertOperationalFeature("jobs");
     return renderDevPortalShell(buildDevPortalShellInput({ title: "Cron", brand: "central" }));
   }
 
   @Get("outbox.json")
   async outboxJson() {
-    this.assertDevFeature("email");
+    this.assertOperationalFeature("email");
     if (!this.emailOutbox) {
       return {
         enabled: false,
@@ -1557,14 +1566,15 @@ export class HubController {
    * the Cmd+K command palette (Issue #90). Returns matching Hub pages
    * ranked by score (exact > prefix > substring > fuzzy). Marked
    * `@Public` because the dev-portal itself runs without auth and this
-   * endpoint is gated by `assertDev()` — it 404s in production.
+   * endpoint is gated by the operational surface guard — without the
+   * hub opt-in it 404s in production.
    */
   @Get("palette/search.json")
   @Public(
-    "Hub palette search — fuzzy page lookup for Cmd+K. Dev portal only; assertDev() guards production.",
+    "Hub palette search — fuzzy page lookup for Cmd+K. Hub surface guard gates availability outside development.",
   )
   paletteSearchJson(@Query("q") q: string | undefined): { pages: PaletteSearchResult[] } {
-    this.assertDev();
+    this.assertOperational();
     const query = typeof q === "string" ? q.trim() : "";
     const snapshot = buildHubNavFeatureSnapshot(this.featuresOnly());
     const pages = filterPalettePagesForNavSnapshot(buildHubPageCatalog(), snapshot);
@@ -1585,25 +1595,45 @@ export class HubController {
   @Get("*splat")
   @Header("content-type", "text/html; charset=utf-8")
   spaCatchAll(): string {
-    this.assertDev();
+    this.assertOperational();
     return renderDevPortalShell(
       buildDevPortalShellInput({ title: "Dev Portal", brand: "central" }),
     );
   }
 
-  private assertDev(): void {
-    const cfg = serverConfigFromEnv(process.env);
-    if (cfg.env !== "development") {
-      throw new NotFoundException();
-    }
+  /**
+   * OPERATIONAL tier (see `hub-surface-policy.ts`): cockpit pages,
+   * SPA shells/assets, diagnostics buffers (logs/traces/queries),
+   * feature READ views, jobs/outbox dashboards. Development-always;
+   * outside development requires `FEATURE_HUB_ENABLED=true` plus the
+   * CASL wall in `HubPortalMiddleware`.
+   */
+  private assertOperational(): void {
+    assertHubSurfaceAvailable("operational");
+  }
+
+  /**
+   * WORKSTATION tier: routes that read or write the developer's
+   * checkout / process env (migrations runner, `.env` feature toggle,
+   * brand file writes, coverage/test-run artifacts, prisma-schema ERD,
+   * tunnel state, email template builder). Development-only forever —
+   * the flag never opens these.
+   */
+  private assertWorkstation(): void {
+    assertHubSurfaceAvailable("workstation");
   }
 
   private featuresOnly(): Features {
     return loadFeatures(process.env as Record<string, string | undefined>);
   }
 
-  private assertDevFeature(key: ToggleableFeatureKey): void {
-    this.assertDev();
+  private assertOperationalFeature(key: ToggleableFeatureKey): void {
+    this.assertOperational();
+    assertFeatureEnabledFromEnv(key);
+  }
+
+  private assertWorkstationFeature(key: ToggleableFeatureKey): void {
+    this.assertWorkstation();
     assertFeatureEnabledFromEnv(key);
   }
 }

--- a/src/core/dx/migrations/migrations-runner.ts
+++ b/src/core/dx/migrations/migrations-runner.ts
@@ -6,8 +6,10 @@
  * the actual `prisma migrate` toolchain.
  *
  * Production-safety: every public function in this module is gated at
- * the controller layer behind `assertDev()` so the planner-runner pair
- * can never be invoked outside `NODE_ENV=development`.
+ * the controller layer behind the WORKSTATION-tier surface guard
+ * (`hub-surface-policy.ts`) so the planner-runner pair can never be
+ * invoked outside `NODE_ENV=development` — the hub opt-in flag does
+ * not open it.
  *
  * Concurrency: the controller acquires the advisory lock via
  * `withAdvisoryLock(...)`. Two concurrent deploy attempts on the same

--- a/src/core/dx/user-admin.module.ts
+++ b/src/core/dx/user-admin.module.ts
@@ -20,7 +20,7 @@ import { UserAdminController } from "./user-admin.controller.js";
     // ensures DI wires it when BA is configured, falls back gracefully
     // when it isn't (e.g., BETTER_AUTH_SECRET not set in test builds).
     BetterAuthModule,
-    // ConfigModule provides ConfigService so assertDev() and callBaAdmin()
+    // ConfigModule provides ConfigService so callBaAdmin()
     // can read server.env and server.baseUrl without re-parsing process.env
     // via Zod on every request (MIN-2 fix).
     ConfigModule.forRoot(),

--- a/src/core/features/features.ts
+++ b/src/core/features/features.ts
@@ -112,6 +112,15 @@ const JobsSchema = z.object({
 // authentication / data-mutation surfaces always need audit traces;
 // projects with strict storage budgets opt out via FEATURE_AUDIT_ENABLED=false.
 const Audit = togglableDefault(true);
+// `hub` — opt-in availability of the OPERATIONAL hub/admin operator
+// console outside development (`FEATURE_HUB_ENABLED=true`). Default-off
+// preserves today's behaviour exactly: available in development,
+// 404 in staging/production. The flag is only consulted OUTSIDE
+// development — locally the hub is always on, so flipping it can never
+// lock a developer out of their workstation tooling. Workstation-tier
+// surfaces (file browser, migrations runner, .env writes, …) ignore
+// the flag entirely; see `src/core/hub/hub-surface-policy.ts`.
+const Hub = togglableDefault(false);
 
 export const FeaturesSchema = z.object({
   authMethods: AuthMethodsSchema.default(() => AuthMethodsSchema.parse({})),
@@ -138,6 +147,7 @@ export const FeaturesSchema = z.object({
   audit: Audit.default(() => Audit.parse({})),
   passwordPolicy: PasswordPolicy.default(() => PasswordPolicy.parse({})),
   filesMimeStrict: FilesMimeStrict.default(() => FilesMimeStrict.parse({})),
+  hub: Hub.default(() => Hub.parse({})),
 });
 
 export type Features = z.infer<typeof FeaturesSchema>;
@@ -149,6 +159,11 @@ export type FeatureKey = keyof Features;
  *
  * `authMethods` is intentionally excluded — the auth module is always loaded;
  * only its sub-options (emailPassword, twoFactor, passkey, etc.) vary.
+ *
+ * `hub` is intentionally excluded too: the hub/admin modules must always
+ * load (development needs them without any flag), so the flag must never
+ * feed `conditionalImport()`. It widens RUNTIME availability outside
+ * development only — enforced per request by `hub-surface-policy.ts`.
  */
 export type ToggleableFeatureKey =
   | "multiTenancy"
@@ -233,6 +248,7 @@ const SECTION_KEYS = new Set([
   "PASSWORDPOLICY",
   "FILES_MIME_STRICT",
   "FILESMIMESTRICT",
+  "HUB",
 ]);
 
 const SECTION_TO_KEY: Record<string, FeatureKey> = {
@@ -269,6 +285,7 @@ const SECTION_TO_KEY: Record<string, FeatureKey> = {
   PASSWORDPOLICY: "passwordPolicy",
   FILES_MIME_STRICT: "filesMimeStrict",
   FILESMIMESTRICT: "filesMimeStrict",
+  HUB: "hub",
 };
 
 const FIELD_TO_PROP: Record<string, string> = {

--- a/src/core/hub/hub-portal.middleware.ts
+++ b/src/core/hub/hub-portal.middleware.ts
@@ -2,10 +2,12 @@ import {
   ForbiddenException,
   Injectable,
   type NestMiddleware,
+  NotFoundException,
   UnauthorizedException,
 } from "@nestjs/common";
 import type { NextFunction, Request, Response } from "express";
 
+import { loadFeatures } from "../features/features.js";
 import type { Ability } from "../permissions/casl-ability.js";
 import { serverConfigFromEnv } from "../server/server-config.js";
 import { canAccessHub, canAccessTenantAdmin } from "./hub-portal-access.js";
@@ -16,6 +18,7 @@ import {
   isTenantAdminPortalPath,
   prefersHubPortalLoginRedirect,
 } from "./hub-portal-paths.js";
+import { evaluateHubPortalRequestOutsideDev } from "./hub-surface-policy.js";
 
 interface HubPortalRequest extends Request {
   user?: { id: string };
@@ -28,6 +31,18 @@ interface HubPortalRequest extends Request {
  * `BetterAuthSessionMiddleware`; this layer denies authenticated users
  * without Hub (`read Hub` / `manage:all`) or tenant-admin subjects on
  * `/admin/*`.
+ *
+ * Outside development the decision comes from
+ * `evaluateHubPortalRequestOutsideDev()`:
+ *   - `FEATURE_HUB_ENABLED` unset/false → inert pass-through, the
+ *     controllers keep today's behaviour (dev-gated routes 404 via
+ *     `assertHubSurfaceAvailable`).
+ *   - flag on → an authenticated session whose ability passes
+ *     `canAccessHub` (for `/hub/*`) resp. `canAccessTenantAdmin` (for
+ *     `/admin/*`) is REQUIRED; every other request gets the same 404 a
+ *     disabled hub produces. Deliberately no dev-style redirect and no
+ *     403 — an unauthorized caller must not be able to distinguish an
+ *     opted-in deployment from one without the flag.
  */
 @Injectable()
 export class HubPortalMiddleware implements NestMiddleware {
@@ -38,16 +53,31 @@ export class HubPortalMiddleware implements NestMiddleware {
       return;
     }
 
-    // Let the SPA read `{ hub, tenantAdmin }` even when the operator lacks
-    // `read Hub` — the React gate renders the friendly denial screen.
-    if (isHubPortalAccessProbePath(path)) {
+    if (serverConfigFromEnv(process.env).env !== "development") {
+      const decision = evaluateHubPortalRequestOutsideDev({
+        hubEnabled: loadFeatures(process.env as Record<string, string | undefined>).hub.enabled,
+        authenticated: Boolean(req.user?.id),
+        isProbePath: isHubPortalAccessProbePath(path),
+        isCockpitPath: isHubCockpitPath(path),
+        isTenantAdminPath: isTenantAdminPortalPath(path),
+        hubAllowed: canAccessHub(req.ability),
+        tenantAdminAllowed: canAccessTenantAdmin(req.ability),
+      });
+      if (decision === "not-found") {
+        throw new NotFoundException();
+      }
+      // "allow" and "pass-through" both continue: the surface guard in
+      // the controllers decides availability (tier + flag), this layer
+      // only decided authentication/authorization.
       next();
       return;
     }
 
-    // Dev-only surfaces (`assertDev()`). In production/staging the controllers
-    // 404 themselves — do not 401 here or specs that assert production 404s fail.
-    if (serverConfigFromEnv(process.env).env !== "development") {
+    // Development from here on — unchanged semantics.
+
+    // Let the SPA read `{ hub, tenantAdmin }` even when the operator lacks
+    // `read Hub` — the React gate renders the friendly denial screen.
+    if (isHubPortalAccessProbePath(path)) {
       next();
       return;
     }

--- a/src/core/hub/hub-surface-guard.ts
+++ b/src/core/hub/hub-surface-guard.ts
@@ -1,0 +1,29 @@
+import { NotFoundException } from "@nestjs/common";
+
+import { loadFeatures } from "../features/features.js";
+import { serverConfigFromEnv } from "../server/server-config.js";
+import { type HubSurfaceTier, isHubSurfaceAvailable } from "./hub-surface-policy.js";
+
+/**
+ * Thin runner for `isHubSurfaceAvailable()` — the successor of the
+ * scattered per-controller `assertDev()` helpers.
+ *
+ * Reads the env at REQUEST time (not boot time) on purpose: this is the
+ * convention `hub.controller.ts` always used, it is what the
+ * NODE_ENV-flipping production e2e specs rely on, and it means a real
+ * deployment (env set before process start) and the test harness agree.
+ *
+ * Throws the same bare `NotFoundException` the old asserts threw, so an
+ * unavailable surface stays indistinguishable from a route that does
+ * not exist.
+ */
+export function assertHubSurfaceAvailable(
+  tier: HubSurfaceTier,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): void {
+  const serverEnv = serverConfigFromEnv(env).env;
+  const hubEnabled = loadFeatures(env).hub.enabled;
+  if (!isHubSurfaceAvailable({ env: serverEnv, hubEnabled, tier })) {
+    throw new NotFoundException();
+  }
+}

--- a/src/core/hub/hub-surface-policy.ts
+++ b/src/core/hub/hub-surface-policy.ts
@@ -1,0 +1,98 @@
+import type { AppEnv } from "../http/cookie-cors-config.js";
+
+/**
+ * Pure policy for hub/admin surface availability across environments.
+ *
+ * Single source of truth consumed by two thin enforcement points:
+ *   - `hub-surface-guard.ts` → controller-level availability asserts
+ *     (the `assertDev()` successor)
+ *   - `hub-portal.middleware.ts` → session + CASL enforcement for the
+ *     non-development opt-in path
+ *
+ * Two-tier model:
+ *   - `operational` — the operator console: cockpit, diagnostics,
+ *     feature READ views, user/tenant/role/policy admin, rate-limit
+ *     admin, audit browser, admin SPA shells + JSON sidecars. Eligible
+ *     outside development when `FEATURE_HUB_ENABLED=true` AND the
+ *     request carries an authorized Better-Auth session (middleware).
+ *   - `workstation` — tools that read or write the developer's
+ *     workstation: source-tree file browser, migrations runner, `.env`
+ *     feature toggles, coverage/test-run artifacts, ERD (reads
+ *     prisma/ from disk), brand file writes, the x-test-ability
+ *     tester, the cross-tenant search tester, the local tunnel state.
+ *     These stay development-only FOREVER — no flag, no ability, no
+ *     exception. In a deployed container they would leak repo
+ *     internals or mutate process/env state, so the conservative
+ *     default for any ambiguous surface is this tier.
+ */
+export type HubSurfaceTier = "operational" | "workstation";
+
+export interface HubSurfaceAvailabilityInput {
+  env: AppEnv;
+  /** `features.hub.enabled` — the `FEATURE_HUB_ENABLED` opt-in. */
+  hubEnabled: boolean;
+  tier: HubSurfaceTier;
+}
+
+/**
+ * Availability of a hub/admin surface for the current environment.
+ *
+ * development → always available (both tiers; the flag is ignored so
+ *               the local workflow can never regress).
+ * otherwise   → workstation: never. operational: only when opted in.
+ */
+export function isHubSurfaceAvailable(input: HubSurfaceAvailabilityInput): boolean {
+  if (input.env === "development") return true;
+  if (input.tier === "workstation") return false;
+  return input.hubEnabled;
+}
+
+export interface HubPortalOutsideDevInput {
+  /** `features.hub.enabled` — the `FEATURE_HUB_ENABLED` opt-in. */
+  hubEnabled: boolean;
+  /** True when the session middleware resolved a Better-Auth user. */
+  authenticated: boolean;
+  /** `/hub/portal-access.json` — the SPA's access probe. */
+  isProbePath: boolean;
+  /** `/hub/*` pages + JSON (excluding static assets and the probe). */
+  isCockpitPath: boolean;
+  /** `/admin/*` pages + JSON. */
+  isTenantAdminPath: boolean;
+  /** `canAccessHub(req.ability)` result. */
+  hubAllowed: boolean;
+  /** `canAccessTenantAdmin(req.ability)` result. */
+  tenantAdminAllowed: boolean;
+}
+
+export type HubPortalOutsideDevDecision = "pass-through" | "allow" | "not-found";
+
+/**
+ * Middleware decision for hub/admin requests when `env !== development`.
+ *
+ * - Flag off → `pass-through`: the middleware stays inert and the
+ *   controllers keep today's behaviour byte-for-byte (dev-gated routes
+ *   404 via the surface guard; the pre-existing @Can-gated admin
+ *   surfaces keep their own gates).
+ * - Flag on → authentication + CASL become MANDATORY. Anything that is
+ *   not an authorized request answers `not-found` — the same 404 a
+ *   disabled hub produces, so an unauthorized caller cannot distinguish
+ *   an opted-in deployment from one without the flag (no dev-style
+ *   redirect, no 403). The probe stays reachable for ANY signed-in
+ *   user so the SPA can render its friendly denial screen instead of a
+ *   blind 404 (mirrors the probe's development semantics).
+ *
+ * Anonymous requests normally never reach this decision — the session
+ * middleware already 401s/redirects them on protected paths — but a
+ * deployment without Better-Auth configured would, so `authenticated`
+ * is checked first and masks with `not-found`.
+ */
+export function evaluateHubPortalRequestOutsideDev(
+  input: HubPortalOutsideDevInput,
+): HubPortalOutsideDevDecision {
+  if (!input.hubEnabled) return "pass-through";
+  if (!input.authenticated) return "not-found";
+  if (input.isProbePath) return "allow";
+  if (input.isCockpitPath && input.hubAllowed) return "allow";
+  if (input.isTenantAdminPath && input.tenantAdminAllowed) return "allow";
+  return "not-found";
+}

--- a/src/core/multi-tenancy/tenant-admin.module.ts
+++ b/src/core/multi-tenancy/tenant-admin.module.ts
@@ -19,7 +19,7 @@ import { TenantAdminController } from "./tenant-admin.controller.js";
     // ensures DI wires it when BA is configured, falls back gracefully
     // when it isn't (e.g., BETTER_AUTH_SECRET not set in test builds).
     BetterAuthModule,
-    // ConfigModule provides ConfigService so assertDev() and callBaOrgAdmin()
+    // ConfigModule provides ConfigService so callBaOrgAdmin()
     // can read server.env and server.baseUrl without re-parsing process.env
     // via Zod on every request (MIN-2 fix).
     ConfigModule.forRoot(),

--- a/src/core/permissions/admin-crud.module.ts
+++ b/src/core/permissions/admin-crud.module.ts
@@ -19,8 +19,8 @@ import type { Response } from "express";
 
 import { buildDevPortalShellInput, renderDevPortalShell } from "../dx/dev-portal-shell.js";
 import { ConfigModule } from "../config/config.module.js";
-import { ConfigService } from "../config/config.service.js";
 
+import { assertHubSurfaceAvailable } from "../hub/hub-surface-guard.js";
 import { requireTenantContext } from "../multi-tenancy/require-tenant-context.js";
 import { PrismaService } from "../prisma/prisma.service.js";
 import { Public } from "./public.decorator.js";
@@ -349,26 +349,35 @@ class PermissionAdminService {
 
 // Iter-202 reviewer feedback: bare non-empty check let `not-a-uuid`
 const DEV_ADMIN_CRUD_PUBLIC_REASON =
-  "Dev-Hub permission CRUD operator API — assertDev() guards production; no CASL login required in local development.";
+  "Dev-Hub permission CRUD operator API — the hub surface guard gates availability; no CASL login required in local development.";
 
-function assertDevPortalOnly(config: ConfigService): void {
-  if (config.server.env !== "development") {
-    throw new NotFoundException();
-  }
+/**
+ * Tier: OPERATIONAL (see `hub-surface-policy.ts`) — role/policy/
+ * permission CRUD is core operator-console functionality. Development-
+ * always; outside development it requires `FEATURE_HUB_ENABLED=true`
+ * AND the tenant-admin CASL wall in `HubPortalMiddleware`.
+ *
+ * Env is read at REQUEST time via the shared guard (the hub controller
+ * convention) instead of the boot-frozen `ConfigService` snapshot the
+ * old `assertDevPortalOnly` used — the snapshot missed runtime
+ * NODE_ENV flips, so these routes stayed open in the production-mode
+ * e2e boots that pin NODE_ENV after module import.
+ */
+function assertOperationalAdminSurface(): void {
+  assertHubSurfaceAvailable("operational");
 }
 
 @Controller("admin/roles")
 class RoleAdminController {
   constructor(
     private readonly service: RoleAdminService,
-    private readonly config: ConfigService,
     @Optional() @Inject(PermissionService) private readonly permissions?: PermissionService,
   ) {}
 
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get()
   async list(@Headers("accept") accept: string | undefined, @Res() res: Response): Promise<void> {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     if (wantsHtml(accept)) {
       res.setHeader("content-type", "text/html; charset=utf-8");
       res.send(
@@ -383,7 +392,7 @@ class RoleAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Post()
   async create(@Body() body: RoleCreateBody) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     const created = await this.service.create(body, tenantId);
     this.permissions?.invalidateAll();
@@ -392,7 +401,7 @@ class RoleAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get(":id")
   async get(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     const record = await this.service.get(id, tenantId);
     if (!record) throw new NotFoundException("role not found");
@@ -401,7 +410,7 @@ class RoleAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Delete(":id")
   async remove(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     try {
       await this.service.delete(id, tenantId);
@@ -415,7 +424,7 @@ class RoleAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Patch(":id")
   async update(@Param("id") id: string, @Body() body: RolePatchBody) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     const updated = await this.service.update(id, tenantId, body);
     this.permissions?.invalidateAll();
@@ -424,7 +433,7 @@ class RoleAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get(":id/policies")
   async listPolicies(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     // Verify the role belongs to the operator's tenant before exposing data.
     const role = await this.service.get(id, tenantId);
@@ -437,20 +446,19 @@ class RoleAdminController {
 class PolicyAdminController {
   constructor(
     private readonly service: PolicyAdminService,
-    private readonly config: ConfigService,
     @Optional() @Inject(PermissionService) private readonly permissions?: PermissionService,
   ) {}
 
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get()
   async list(@Headers("accept") accept: string | undefined, @Res() res: Response): Promise<void> {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     await negotiate(accept, res, "Policies", () => this.service.list());
   }
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Post()
   async create(@Body() body: PolicyCreateBody) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const created = await this.service.create(body);
     this.permissions?.invalidateAll();
     return created;
@@ -458,7 +466,7 @@ class PolicyAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get(":id")
   async get(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const record = await this.service.get(id);
     if (!record) throw new NotFoundException("policy not found");
     return record;
@@ -466,7 +474,7 @@ class PolicyAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Delete(":id")
   async remove(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     try {
       await this.service.delete(id);
     } catch {
@@ -478,7 +486,7 @@ class PolicyAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get(":id/roles")
   async listRoles(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const policy = await this.service.get(id);
     if (!policy) throw new NotFoundException("policy not found");
     return this.service.listRoles(id);
@@ -489,20 +497,19 @@ class PolicyAdminController {
 class PermissionAdminController {
   constructor(
     private readonly service: PermissionAdminService,
-    private readonly config: ConfigService,
     @Optional() @Inject(PermissionService) private readonly permissions?: PermissionService,
   ) {}
 
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get()
   async list(@Headers("accept") accept: string | undefined, @Res() res: Response): Promise<void> {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     await negotiate(accept, res, "Permissions", () => this.service.list());
   }
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Post()
   async create(@Body() body: PermissionCreateBody) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const created = await this.service.create(body);
     this.permissions?.invalidateAll();
     return created;
@@ -512,7 +519,7 @@ class PermissionAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get("matrix.json")
   async matrix() {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     return this.service.buildMatrix(tenantId);
   }
@@ -520,7 +527,7 @@ class PermissionAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Get(":id")
   async get(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const record = await this.service.get(id);
     if (!record) throw new NotFoundException("permission not found");
     return record;
@@ -528,7 +535,7 @@ class PermissionAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Delete(":id")
   async remove(@Param("id") id: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     try {
       await this.service.delete(id);
     } catch {
@@ -541,7 +548,7 @@ class PermissionAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Post("attach")
   async attach(@Body() body: RolePolicyAttachBody) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     const link = await this.service.attachToRole(body, tenantId);
     this.permissions?.invalidateAll();
@@ -551,7 +558,7 @@ class PermissionAdminController {
   @Public(DEV_ADMIN_CRUD_PUBLIC_REASON)
   @Delete("attach/:roleId/:policyId")
   async detach(@Param("roleId") roleId: string, @Param("policyId") policyId: string) {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     const tenantId = requireTenantContext();
     try {
       await this.service.detachFromRole(roleId, policyId, tenantId);
@@ -581,7 +588,7 @@ class PermissionAdminController {
     report: PermissionReport;
     can: boolean;
   }> {
-    assertDevPortalOnly(this.config);
+    assertOperationalAdminSurface();
     // Iter-202 reviewer-flagged: previously the handler resolved an
     // ability for any `body.tenantId` an operator supplied — they
     // could probe permissions for tenants outside their scope. Now

--- a/src/core/setup/setup-wizard.ts
+++ b/src/core/setup/setup-wizard.ts
@@ -283,6 +283,12 @@ function renderEnvExample(answers: WizardAnswers): string {
   lines.push("# FEATURE_POWERSYNC_ENABLED=false");
   lines.push("# FEATURE_MCP_ENABLED=false");
   lines.push("# FEATURE_FIELD_ENCRYPTION_ENABLED=false");
+  lines.push("#");
+  lines.push("# Operational hub/admin console outside development (staging/production).");
+  lines.push("# Requires an authenticated Better-Auth session whose CASL ability grants");
+  lines.push("# `read Hub` (for /hub/*) resp. tenant-admin subjects (for /admin/*).");
+  lines.push("# Workstation tools (file browser, migrations, .env toggles) stay dev-only.");
+  lines.push("# FEATURE_HUB_ENABLED=false");
   lines.push("");
   lines.push("# Geo (PostGIS, geocoding)");
   lines.push("# FEATURE_GEO_ENABLED=false");

--- a/src/core/throttler/rate-limit-admin.controller.ts
+++ b/src/core/throttler/rate-limit-admin.controller.ts
@@ -9,10 +9,12 @@
  *       The SPA shell is `@Public(...)` because the React bundle loads the
  *       page skeleton and the individual JSON fetches carry the gate.
  *
- * The controller is dev-portal-only; the `assertDev()` pattern from the hub
- * module is not wired here — the `/admin/` prefix is already in the public
- * allowlist of the route-audit planner and the jwt-middleware, and the CASL
- * `manage:RateLimitAdmin` gate blocks non-admin users.
+ * Tier: OPERATIONAL, without a surface guard — this controller was never
+ * dev-asserted: the CASL `manage:RateLimitAdmin` gate blocks non-admin
+ * users in every environment (pre-existing production behaviour, kept
+ * for backward compatibility). When `FEATURE_HUB_ENABLED=true`,
+ * `HubPortalMiddleware` additionally walls the whole `/admin/*` prefix
+ * behind `canAccessTenantAdmin`.
  */
 
 import {

--- a/tests/stories/admin-crud-controller.story.test.ts
+++ b/tests/stories/admin-crud-controller.story.test.ts
@@ -7,18 +7,20 @@ import { describe, expect, it } from "vitest";
  * Story · AdminCrudModule controllers (`/admin/roles`, `/admin/policies`,
  * `/admin/permissions`).
  *
- * Dev-Hub permission CRUD JSON must be `@Public()` + `assertDevPortalOnly()`
- * so local operators are not blocked by CanGuard without a CASL session.
+ * Dev-Hub permission CRUD JSON must be `@Public()` + the operational
+ * hub surface guard so local operators are not blocked by CanGuard
+ * without a CASL session. Outside development the surface is gated by
+ * FEATURE_HUB_ENABLED + the tenant-admin CASL wall in HubPortalMiddleware.
  */
 const ROOT = resolve(__dirname, "..", "..");
 
 describe("Story · AdminCrudModule dev gating", () => {
-  it("admin-crud controllers use @Public and assertDevPortalOnly on every handler", () => {
+  it("admin-crud controllers use @Public and the operational surface guard on every handler", () => {
     const src = readFileSync(resolve(ROOT, "src/core/permissions/admin-crud.module.ts"), "utf8");
     expect(src).toContain('@Controller("admin/roles")');
     expect(src).toContain('@Controller("admin/policies")');
     expect(src).toContain('@Controller("admin/permissions")');
-    expect(src).toContain("function assertDevPortalOnly");
+    expect(src).toContain("function assertOperationalAdminSurface");
     expect(src).toContain("DEV_ADMIN_CRUD_PUBLIC_REASON");
     const publicMatches = src.match(/@Public\(DEV_ADMIN_CRUD_PUBLIC_REASON\)/g) ?? [];
     expect(publicMatches.length).toBeGreaterThanOrEqual(19);

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -207,9 +207,10 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
       expect(ADMIN_SPA_CONTROLLER).toContain("requireTenantContext");
     });
 
-    it("AdminSpaController is @Public Hub surface with assertDev()", () => {
-      expect(ADMIN_SPA_CONTROLLER).toMatch(/@Public\([^)]*assertDev\(\)[^)]*local development/);
-      expect(ADMIN_SPA_CONTROLLER).toContain("private assertDev()");
+    it("AdminSpaController is @Public Hub surface behind the tiered surface guard", () => {
+      expect(ADMIN_SPA_CONTROLLER).toMatch(/@Public\([^)]*surface guard[^)]*local development/);
+      expect(ADMIN_SPA_CONTROLLER).toContain("private assertOperational()");
+      expect(ADMIN_SPA_CONTROLLER).toContain("private assertWorkstation()");
     });
   });
 

--- a/tests/stories/feature-flag-23-surface.story.test.ts
+++ b/tests/stories/feature-flag-23-surface.story.test.ts
@@ -51,6 +51,8 @@ describe("Story · Feature-flag surface contract (SC.BOOT.04)", () => {
     // Opt-in security hardening (H2 fix — routed through features.ts)
     "passwordPolicy",
     "filesMimeStrict",
+    // Operational hub/admin console outside development (opt-in)
+    "hub",
   ];
 
   it("loadFeatures({}) exposes every PRD-tracked toggleable subsystem", () => {
@@ -74,9 +76,10 @@ describe("Story · Feature-flag surface contract (SC.BOOT.04)", () => {
     const features = loadFeatures({});
     // PRD § Phase 1 — MVP scope pinned "23 feature-toggleable subsystems".
     // The schema has since grown: passwordPolicy and filesMimeStrict were
-    // added in the H2 fix (iter-216 review), bringing the total to 25.
+    // added in the H2 fix (iter-216 review), and `hub` (operational
+    // hub/admin console opt-in outside development) landed after that.
     // The meaningful contract is the named key set above, not the count.
-    expect(Object.keys(features).length).toBe(24);
+    expect(Object.keys(features).length).toBe(25);
   });
 
   it("counts auth-method sub-flags toward the broader feature breadth", () => {

--- a/tests/stories/hub-outside-dev-development.story.test.ts
+++ b/tests/stories/hub-outside-dev-development.story.test.ts
@@ -1,0 +1,84 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../../src/core/app/bootstrap.js";
+import { hubReqScoped, pinHubTestAuthEnv } from "../helpers/hub-request.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * Story · Hub outside development — development baseline is invariant.
+ *
+ * The `FEATURE_HUB_ENABLED` flag governs NON-development environments
+ * only. In development the hub keeps today's behaviour under EVERY flag
+ * value — here pinned with the strictest case, an explicit `false`:
+ *   - operational surfaces stay available
+ *   - workstation surfaces (file browser, migrations, ERD) stay available
+ *   - the anonymous browser redirect to the login page stays intact
+ *
+ * This is the local-DX guarantee: flipping the production opt-in can
+ * never lock a developer out of their own workstation tooling.
+ */
+describe("Story · Hub outside development (development boot, FEATURE_HUB_ENABLED=false)", () => {
+  let app: INestApplication;
+  let hub: Awaited<ReturnType<typeof hubReqScoped>>;
+  let previousHubFlag: string | undefined;
+
+  beforeAll(async () => {
+    pinHubTestAuthEnv();
+    previousHubFlag = process.env.FEATURE_HUB_ENABLED;
+    // Explicit false — the strongest form of "the flag must not matter here".
+    process.env.FEATURE_HUB_ENABLED = "false";
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    hub = await hubReqScoped(app);
+  }, 120_000);
+
+  afterAll(async () => {
+    await app.close();
+    if (previousHubFlag === undefined) delete process.env.FEATURE_HUB_ENABLED;
+    else process.env.FEATURE_HUB_ENABLED = previousHubFlag;
+  });
+
+  describe("operational surfaces stay available in development", () => {
+    it("hub SPA shell renders", async () => {
+      const res = await hub.get("/hub");
+      expect(res.status).toBe(200);
+    });
+
+    it("feature READ views respond 200", async () => {
+      const res = await hub.get("/hub/features.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("admin CRUD responds 200", async () => {
+      const res = await hub.get("/admin/roles").set("accept", "application/json");
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("workstation surfaces stay available in development", () => {
+    it("source-tree file browser responds 200", async () => {
+      const res = await hub.get("/hub/files/tree.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("migrations runner responds 200", async () => {
+      const res = await hub.get("/hub/migrations.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("ERD responds 200", async () => {
+      const res = await hub.get("/hub/erd.json");
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("development auth gate is unchanged", () => {
+    it("anonymous browser navigation still redirects to the login page", async () => {
+      const res = await request(app.getHttpServer()).get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/");
+    });
+  });
+});

--- a/tests/stories/hub-outside-dev-flag-off.story.test.ts
+++ b/tests/stories/hub-outside-dev-flag-off.story.test.ts
@@ -1,0 +1,169 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../../src/core/app/bootstrap.js";
+import { PrismaService } from "../../src/core/prisma/prisma.service.js";
+import { uuidV7 } from "../../src/core/uuid/uuid-v7.js";
+import {
+  type ApiTestSession,
+  createApiTestSession,
+  ensureOrganizationMember,
+  provisionApiTestTenant,
+} from "../helpers/api-request.js";
+import { pinHubTestAuthEnv } from "../helpers/hub-request.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * Story · Hub outside development — flag OFF (backward-compat baseline).
+ *
+ * `FEATURE_HUB_ENABLED` unset in a production boot must preserve today's
+ * behaviour byte-for-byte:
+ *   - every dev-asserted hub/admin route 404s — even for a session whose
+ *     DB grant WOULD authorize it (the flag gates, not the ability)
+ *   - anonymous requests hit the same session wall as before (401/302)
+ *   - the pre-existing @Can-gated admin surfaces that were ALREADY
+ *     reachable in production (user admin JSON, admin SPA shells) stay
+ *     reachable — this PR must not silently remove them
+ *
+ * One production boot per file (see hub-tunnel-production.e2e-spec.ts
+ * for the NODE_ENV-per-worker rationale).
+ */
+describe("Story · Hub outside development (production, FEATURE_HUB_ENABLED unset)", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let httpServer: Parameters<typeof request>[0];
+  let previousNodeEnv: string | undefined;
+  let previousHubFlag: string | undefined;
+
+  // Random v4 (not uuidV7): the helper's test-org slug derives from the
+  // first 8 chars, and v7 ids minted in the same millisecond share that
+  // prefix — colliding slugs would silently skip the org insert.
+  const OPERATOR_TENANT = crypto.randomUUID();
+  let operator: ApiTestSession;
+
+  const cleanupPolicyIds: string[] = [];
+  const cleanupRoleIds: string[] = [];
+
+  beforeAll(async () => {
+    pinHubTestAuthEnv();
+    previousNodeEnv = process.env.NODE_ENV;
+    previousHubFlag = process.env.FEATURE_HUB_ENABLED;
+    process.env.NODE_ENV = "production";
+    delete process.env.FEATURE_HUB_ENABLED;
+    process.env.SECRET_KEK_HEX ??= "0".repeat(64);
+    process.env.SECRET_HMAC_HEX ??= "0".repeat(64);
+
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    prisma = app.get(PrismaService);
+    httpServer = app.getHttpServer();
+
+    // A fully-granted operator (read Hub + CRUD User) — proves the 404s
+    // below come from the missing flag, not from a missing ability.
+    operator = await createApiTestSession(httpServer);
+    await ensureOrganizationMember(prisma, {
+      organizationId: OPERATOR_TENANT,
+      userId: operator.userId,
+    });
+    const roleId = uuidV7();
+    const policyId = uuidV7();
+    cleanupRoleIds.push(roleId);
+    cleanupPolicyIds.push(policyId);
+    await prisma.role.create({
+      data: { id: roleId, name: "owner", tenantId: OPERATOR_TENANT },
+    });
+    await prisma.policy.create({
+      data: { id: policyId, name: `hub-outside-dev-flag-off-${policyId}` },
+    });
+    await prisma.rolePolicy.create({ data: { roleId, policyId } });
+    await prisma.permission.createMany({
+      data: [
+        { policyId, resource: "Hub", action: "READ", fields: [] },
+        { policyId, resource: "User", action: "CREATE", fields: [] },
+        { policyId, resource: "User", action: "READ", fields: [] },
+        { policyId, resource: "User", action: "UPDATE", fields: [] },
+        { policyId, resource: "User", action: "DELETE", fields: [] },
+      ],
+    });
+    await provisionApiTestTenant(prisma, httpServer, operator, OPERATOR_TENANT);
+  }, 120_000);
+
+  afterAll(async () => {
+    try {
+      await prisma.permission.deleteMany({ where: { policyId: { in: cleanupPolicyIds } } });
+      await prisma.rolePolicy.deleteMany({ where: { policyId: { in: cleanupPolicyIds } } });
+      await prisma.policy.deleteMany({ where: { id: { in: cleanupPolicyIds } } });
+      await prisma.role.deleteMany({ where: { id: { in: cleanupRoleIds } } });
+    } catch {
+      // cleanup must never fail the suite
+    }
+    await app.close();
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+    if (previousHubFlag === undefined) delete process.env.FEATURE_HUB_ENABLED;
+    else process.env.FEATURE_HUB_ENABLED = previousHubFlag;
+    delete process.env.SECRET_KEK_HEX;
+    delete process.env.SECRET_HMAC_HEX;
+  });
+
+  describe("hub/admin surfaces stay 404 — even for a granted operator", () => {
+    it("hub SPA shell 404s", async () => {
+      const res = await operator.agent.get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(404);
+    });
+
+    it("operational cockpit JSON 404s", async () => {
+      const res = await operator.agent.get("/hub/dashboard.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("access probe 404s", async () => {
+      const res = await operator.agent.get("/hub/portal-access.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("admin CRUD 404s", async () => {
+      const res = await operator.agent.get("/admin/roles").set("accept", "application/json");
+      expect(res.status).toBe(404);
+    });
+
+    it("workstation surfaces 404 (unchanged)", async () => {
+      const files = await operator.agent.get("/hub/files/tree.json");
+      expect(files.status).toBe(404);
+      const migrations = await operator.agent.get("/hub/migrations.json");
+      expect(migrations.status).toBe(404);
+      const toggle = await operator.agent
+        .post("/hub/features/rateLimit/toggle")
+        .send({ enabled: true });
+      expect(toggle.status).toBe(404);
+    });
+  });
+
+  describe("anonymous surface is byte-identical to the flag-on boot", () => {
+    it("JSON without a session → 401 (session wall, not a hub-specific signal)", async () => {
+      const res = await request(httpServer).get("/hub/dashboard.json");
+      expect(res.status).toBe(401);
+    });
+
+    it("browser navigation without a session → 302 to /", async () => {
+      const res = await request(httpServer).get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/");
+    });
+  });
+
+  describe("pre-existing @Can-gated admin surfaces stay reachable (no silent removals)", () => {
+    it("user admin JSON stays 200 for a manage-User grant (today's production behaviour)", async () => {
+      const res = await operator.agent
+        .get("/admin/users/list.json")
+        .set("accept", "application/json");
+      expect(res.status).toBe(200);
+    });
+
+    it("admin SPA shells that never had a dev assert stay reachable (users shell)", async () => {
+      const res = await operator.agent.get("/admin/users").set("accept", "text/html");
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/tests/stories/hub-outside-dev.story.test.ts
+++ b/tests/stories/hub-outside-dev.story.test.ts
@@ -1,0 +1,290 @@
+import type { INestApplication } from "@nestjs/common";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { bootstrap } from "../../src/core/app/bootstrap.js";
+import { PrismaService } from "../../src/core/prisma/prisma.service.js";
+import { uuidV7 } from "../../src/core/uuid/uuid-v7.js";
+import {
+  type ApiTestSession,
+  createApiTestSession,
+  ensureOrganizationMember,
+  provisionApiTestTenant,
+} from "../helpers/api-request.js";
+import { pinHubTestAuthEnv } from "../helpers/hub-request.js";
+
+const SILENT_LOGGER = { log() {}, warn() {}, error() {}, debug() {}, verbose() {} };
+
+/**
+ * Story · Hub outside development — `FEATURE_HUB_ENABLED=true` in production.
+ *
+ * The Dev-Hub has evolved into an operator console (CASL-gated via
+ * `canAccessHub` / `canAccessTenantAdmin`). This story covers the opt-in
+ * path: a production boot with `FEATURE_HUB_ENABLED=true` exposes the
+ * OPERATIONAL tier to authenticated operators whose CASL ability grants
+ * access — resolved through the real Better-Auth session + DB-backed
+ * Role → RolePolicy → Policy → Permission chain. No `x-test-ability`
+ * shortcuts anywhere in this file: production must never honour them,
+ * and the positive cases must prove the real auth path.
+ *
+ * Tier contract under the flag:
+ *   - operational surfaces → 200 for authorized operators
+ *   - workstation surfaces → 404 for EVERYONE (dev-workstation-only)
+ *   - unauthorized/unknown → 404 (mask; the surface stays undiscoverable)
+ *   - anonymous            → same 401/302 the session wall produces today
+ *
+ * Lives in its own file so the worker boots ONE Nest app with
+ * `NODE_ENV=production` set before bootstrap (same isolation rationale
+ * as `hub-tunnel-production.e2e-spec.ts`).
+ */
+describe("Story · Hub outside development (production + FEATURE_HUB_ENABLED=true)", () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let httpServer: Parameters<typeof request>[0];
+  let previousNodeEnv: string | undefined;
+  let previousHubFlag: string | undefined;
+
+  // Fresh per-run tenants so parallel workers on the shared testcontainer
+  // never collide with the demo-seed tenant other specs use. Random v4
+  // (not uuidV7): the test-org slug derives from the first 8 chars, and
+  // v7 ids minted in the same millisecond share that prefix.
+  const OPERATOR_TENANT = crypto.randomUUID();
+  const MEMBER_TENANT = crypto.randomUUID();
+
+  let operator: ApiTestSession;
+  let plainMember: ApiTestSession;
+
+  const cleanupPolicyIds: string[] = [];
+  const cleanupRoleIds: string[] = [];
+
+  beforeAll(async () => {
+    pinHubTestAuthEnv();
+    previousNodeEnv = process.env.NODE_ENV;
+    previousHubFlag = process.env.FEATURE_HUB_ENABLED;
+    process.env.NODE_ENV = "production";
+    process.env.FEATURE_HUB_ENABLED = "true";
+    process.env.SECRET_KEK_HEX ??= "0".repeat(64);
+    process.env.SECRET_HMAC_HEX ??= "0".repeat(64);
+
+    app = await bootstrap({ listen: false, logger: SILENT_LOGGER });
+    prisma = app.get(PrismaService);
+    httpServer = app.getHttpServer();
+
+    // Operator: real sign-up/sign-in, org membership with role "owner",
+    // and an explicit DB grant `read Hub` + CRUD `User` behind that role
+    // name — the same chain a production deployment authors via seeds
+    // or the admin console.
+    operator = await createApiTestSession(httpServer);
+    await ensureOrganizationMember(prisma, {
+      organizationId: OPERATOR_TENANT,
+      userId: operator.userId,
+    });
+    const roleId = uuidV7();
+    const policyId = uuidV7();
+    cleanupRoleIds.push(roleId);
+    cleanupPolicyIds.push(policyId);
+    await prisma.role.create({
+      data: { id: roleId, name: "owner", tenantId: OPERATOR_TENANT },
+    });
+    await prisma.policy.create({
+      data: { id: policyId, name: `hub-outside-dev-operator-${policyId}` },
+    });
+    await prisma.rolePolicy.create({ data: { roleId, policyId } });
+    await prisma.permission.createMany({
+      data: [
+        { policyId, resource: "Hub", action: "READ", fields: [] },
+        { policyId, resource: "User", action: "CREATE", fields: [] },
+        { policyId, resource: "User", action: "READ", fields: [] },
+        { policyId, resource: "User", action: "UPDATE", fields: [] },
+        { policyId, resource: "User", action: "DELETE", fields: [] },
+      ],
+    });
+    await provisionApiTestTenant(prisma, httpServer, operator, OPERATOR_TENANT);
+
+    // Plain member: real session, org membership, but NO explicit role
+    // rows — only the synthesized Member rules (Example, File, …), which
+    // grant neither `read Hub` nor any tenant-admin subject.
+    plainMember = await createApiTestSession(httpServer);
+    await provisionApiTestTenant(prisma, httpServer, plainMember, MEMBER_TENANT);
+  }, 120_000);
+
+  afterAll(async () => {
+    // Best-effort cleanup so re-runs against a reused DB stay deterministic.
+    try {
+      await prisma.permission.deleteMany({ where: { policyId: { in: cleanupPolicyIds } } });
+      await prisma.rolePolicy.deleteMany({ where: { policyId: { in: cleanupPolicyIds } } });
+      await prisma.policy.deleteMany({ where: { id: { in: cleanupPolicyIds } } });
+      await prisma.role.deleteMany({ where: { id: { in: cleanupRoleIds } } });
+    } catch {
+      // cleanup must never fail the suite
+    }
+    await app.close();
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+    if (previousHubFlag === undefined) delete process.env.FEATURE_HUB_ENABLED;
+    else process.env.FEATURE_HUB_ENABLED = previousHubFlag;
+    delete process.env.SECRET_KEK_HEX;
+    delete process.env.SECRET_HMAC_HEX;
+  });
+
+  describe("anonymous requests (no session)", () => {
+    it("JSON request without a session stays behind the session wall (401, as today)", async () => {
+      const res = await request(httpServer).get("/hub/dashboard.json");
+      expect(res.status).toBe(401);
+    });
+
+    it("browser navigation without a session redirects to the login page (302 /, as today)", async () => {
+      const res = await request(httpServer).get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/");
+    });
+
+    it("admin JSON without a session stays behind the session wall (401, as today)", async () => {
+      const res = await request(httpServer).get("/admin/roles").set("accept", "application/json");
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("authenticated session WITHOUT hub ability", () => {
+    it("hub cockpit JSON responds 404 (masked — not 401/403)", async () => {
+      const res = await plainMember.agent.get("/hub/dashboard.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("hub cockpit HTML responds 404 (no dev-style redirect — stays undiscoverable)", async () => {
+      const res = await plainMember.agent.get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(404);
+    });
+
+    it("tenant-admin JSON responds 404 (masked)", async () => {
+      const res = await plainMember.agent
+        .get("/admin/users/list.json")
+        .set("accept", "application/json");
+      expect(res.status).toBe(404);
+    });
+
+    it("admin CRUD responds 404 (masked)", async () => {
+      const res = await plainMember.agent.get("/admin/roles").set("accept", "application/json");
+      expect(res.status).toBe(404);
+    });
+
+    it("previously shell-open admin pages are masked too (rate-limits shell)", async () => {
+      const res = await plainMember.agent.get("/admin/rate-limits").set("accept", "text/html");
+      expect(res.status).toBe(404);
+    });
+
+    it("the access probe stays reachable for any signed-in user and reports no access", async () => {
+      const res = await plainMember.agent.get("/hub/portal-access.json");
+      expect(res.status).toBe(200);
+      expect(res.body.hub).toBe(false);
+      expect(res.body.tenantAdmin).toBe(false);
+    });
+  });
+
+  describe("authenticated session WITH hub ability (real DB grant)", () => {
+    it("access probe reports hub + tenantAdmin", async () => {
+      const res = await operator.agent.get("/hub/portal-access.json");
+      expect(res.status).toBe(200);
+      expect(res.body.hub).toBe(true);
+      expect(res.body.tenantAdmin).toBe(true);
+    });
+
+    it("hub SPA shell renders (200)", async () => {
+      const res = await operator.agent.get("/hub").set("accept", "text/html");
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toContain("text/html");
+    });
+
+    it("operational cockpit JSON responds 200 (dashboard)", async () => {
+      const res = await operator.agent.get("/hub/dashboard.json");
+      expect(res.status).toBe(200);
+    });
+
+    it("operational feature READ views respond 200", async () => {
+      const features = await operator.agent.get("/hub/features.json");
+      expect(features.status).toBe(200);
+      const catalog = await operator.agent.get("/hub/feature-catalog.json");
+      expect(catalog.status).toBe(200);
+    });
+
+    it("operational diagnostics respond 200 (logs + routes)", async () => {
+      const logs = await operator.agent.get("/hub/logs.json");
+      expect(logs.status).toBe(200);
+      const routes = await operator.agent.get("/hub/routes.json");
+      expect(routes.status).toBe(200);
+    });
+
+    it("tenant-admin CRUD responds 200 (roles list)", async () => {
+      const res = await operator.agent.get("/admin/roles").set("accept", "application/json");
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+
+    it("user admin JSON responds 200 (manage User grant)", async () => {
+      const res = await operator.agent
+        .get("/admin/users/list.json")
+        .set("accept", "application/json");
+      expect(res.status).toBe(200);
+    });
+
+    it("admin SPA shells behind the CASL wall render (rate-limits shell)", async () => {
+      const res = await operator.agent.get("/admin/rate-limits").set("accept", "text/html");
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("workstation tier stays development-only — flag or not, ability or not", () => {
+    it("source-tree file browser responds 404", async () => {
+      const res = await operator.agent.get("/hub/files/tree.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("migrations runner responds 404", async () => {
+      const res = await operator.agent.get("/hub/migrations.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("feature toggle WRITE (.env file update) responds 404", async () => {
+      const res = await operator.agent
+        .post("/hub/features/rateLimit/toggle")
+        .send({ enabled: true });
+      expect(res.status).toBe(404);
+    });
+
+    it("x-test-ability tester responds 404", async () => {
+      const res = await operator.agent
+        .get("/admin/permissions/test.json")
+        .set("accept", "application/json");
+      expect(res.status).toBe(404);
+    });
+
+    it("workstation tunnel state responds 404", async () => {
+      const res = await operator.agent.get("/hub/tunnel.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("coverage / test-summary artifacts respond 404", async () => {
+      const coverage = await operator.agent.get("/hub/coverage.json");
+      expect(coverage.status).toBe(404);
+      const tests = await operator.agent.get("/hub/tests.json");
+      expect(tests.status).toBe(404);
+    });
+
+    it("ERD (reads prisma schema from the repo tree) responds 404", async () => {
+      const res = await operator.agent.get("/hub/erd.json");
+      expect(res.status).toBe(404);
+    });
+
+    it("brand WRITE (repo file) responds 404", async () => {
+      const res = await operator.agent.post("/hub/brand").send({});
+      expect(res.status).toBe(404);
+    });
+
+    it("cross-tenant search tester responds 404", async () => {
+      const res = await operator.agent
+        .get("/admin/search.json?q=probe")
+        .set("accept", "application/json");
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/tests/unit/hub-surface-policy.test.ts
+++ b/tests/unit/hub-surface-policy.test.ts
@@ -1,0 +1,163 @@
+import { NotFoundException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { assertHubSurfaceAvailable } from "../../src/core/hub/hub-surface-guard.js";
+import {
+  evaluateHubPortalRequestOutsideDev,
+  isHubSurfaceAvailable,
+} from "../../src/core/hub/hub-surface-policy.js";
+
+describe("hub-surface-policy · isHubSurfaceAvailable", () => {
+  it("development: both tiers available regardless of the flag", () => {
+    for (const hubEnabled of [true, false]) {
+      expect(isHubSurfaceAvailable({ env: "development", hubEnabled, tier: "operational" })).toBe(
+        true,
+      );
+      expect(isHubSurfaceAvailable({ env: "development", hubEnabled, tier: "workstation" })).toBe(
+        true,
+      );
+    }
+  });
+
+  it("production/staging: workstation tier is never available — flag or not", () => {
+    for (const env of ["production", "staging"] as const) {
+      for (const hubEnabled of [true, false]) {
+        expect(isHubSurfaceAvailable({ env, hubEnabled, tier: "workstation" })).toBe(false);
+      }
+    }
+  });
+
+  it("production/staging: operational tier follows the flag", () => {
+    for (const env of ["production", "staging"] as const) {
+      expect(isHubSurfaceAvailable({ env, hubEnabled: true, tier: "operational" })).toBe(true);
+      expect(isHubSurfaceAvailable({ env, hubEnabled: false, tier: "operational" })).toBe(false);
+    }
+  });
+});
+
+describe("hub-surface-policy · evaluateHubPortalRequestOutsideDev", () => {
+  const base = {
+    hubEnabled: true,
+    authenticated: true,
+    isProbePath: false,
+    isCockpitPath: false,
+    isTenantAdminPath: false,
+    hubAllowed: false,
+    tenantAdminAllowed: false,
+  };
+
+  it("flag off → pass-through (controllers keep today's behaviour untouched)", () => {
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        hubEnabled: false,
+        authenticated: false,
+      }),
+    ).toBe("pass-through");
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        hubEnabled: false,
+        isCockpitPath: true,
+        hubAllowed: true,
+      }),
+    ).toBe("pass-through");
+  });
+
+  it("flag on + anonymous → not-found (mask, e.g. deployments without Better-Auth)", () => {
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        authenticated: false,
+        isCockpitPath: true,
+        hubAllowed: true,
+      }),
+    ).toBe("not-found");
+  });
+
+  it("flag on + signed-in probe → allow (SPA renders the friendly denial)", () => {
+    expect(evaluateHubPortalRequestOutsideDev({ ...base, isProbePath: true })).toBe("allow");
+  });
+
+  it("flag on + cockpit path follows canAccessHub", () => {
+    expect(
+      evaluateHubPortalRequestOutsideDev({ ...base, isCockpitPath: true, hubAllowed: true }),
+    ).toBe("allow");
+    expect(
+      evaluateHubPortalRequestOutsideDev({ ...base, isCockpitPath: true, hubAllowed: false }),
+    ).toBe("not-found");
+  });
+
+  it("flag on + tenant-admin path follows canAccessTenantAdmin", () => {
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        isTenantAdminPath: true,
+        tenantAdminAllowed: true,
+      }),
+    ).toBe("allow");
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        isTenantAdminPath: true,
+        tenantAdminAllowed: false,
+      }),
+    ).toBe("not-found");
+  });
+
+  it("abilities do not cross surfaces (hub ability opens /hub only, admin ability /admin only)", () => {
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        isTenantAdminPath: true,
+        hubAllowed: true,
+      }),
+    ).toBe("not-found");
+    expect(
+      evaluateHubPortalRequestOutsideDev({
+        ...base,
+        isCockpitPath: true,
+        tenantAdminAllowed: true,
+      }),
+    ).toBe("not-found");
+  });
+});
+
+describe("hub-surface-guard · assertHubSurfaceAvailable", () => {
+  it("development env: passes for both tiers without any flag", () => {
+    expect(() =>
+      assertHubSurfaceAvailable("operational", { NODE_ENV: "development" }),
+    ).not.toThrow();
+    expect(() =>
+      assertHubSurfaceAvailable("workstation", { NODE_ENV: "development" }),
+    ).not.toThrow();
+  });
+
+  it("NODE_ENV=test maps to development (vitest workers keep full access)", () => {
+    expect(() => assertHubSurfaceAvailable("workstation", { NODE_ENV: "test" })).not.toThrow();
+  });
+
+  it("production without the flag: operational tier 404s (today's behaviour)", () => {
+    expect(() => assertHubSurfaceAvailable("operational", { NODE_ENV: "production" })).toThrow(
+      NotFoundException,
+    );
+  });
+
+  it("production with the flag: operational passes, workstation still 404s", () => {
+    const env = { NODE_ENV: "production", FEATURE_HUB_ENABLED: "true" };
+    expect(() => assertHubSurfaceAvailable("operational", env)).not.toThrow();
+    expect(() => assertHubSurfaceAvailable("workstation", env)).toThrow(NotFoundException);
+  });
+
+  it("staging behaves like production", () => {
+    expect(() => assertHubSurfaceAvailable("operational", { NODE_ENV: "staging" })).toThrow(
+      NotFoundException,
+    );
+    expect(() =>
+      assertHubSurfaceAvailable("operational", {
+        NODE_ENV: "staging",
+        FEATURE_HUB_ENABLED: "true",
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
# feat(hub): opt-in operational hub/admin console outside development

## Problem

The Dev-Hub started as a local dev portal, but it has evolved into an **operator console**: cockpit + health/diagnostics, feature views, role/policy/permission CRUD, user/tenant admin, rate-limit admin, audit browser, webhook/realtime inspectors. The CASL access layer for exactly this purpose already exists and is merged (`hub-portal-access.ts` → `canAccessHub()` / `canAccessTenantAdmin()`, wired via `grantsHubPortalAccess`; see #174 for the ability fallback hook and #175 for making the console work in single-tenant deployments — both extracted from the same consumer project as this PR, the bpa/BYND app).

What blocks real-world use is the environment gate: every `/hub/*` and `/admin/*` surface is hard-locked to `NODE_ENV=development` via scattered per-controller `assertDev()` copies. The console is unusable exactly where operators need it — staging and production. Consumers today either fork the gate or operate blind.

## Design

**One pure policy, two thin enforcement points** (planner/runner convention):

- **`FEATURE_HUB_ENABLED` (`features.hub`, default `false`)** — follows the `FeaturesSchema` convention (no raw `process.env` checks at call sites). Deliberately **not** a `ToggleableFeatureKey`: the hub modules always load; the flag only widens *runtime availability* outside development. **Development ignores the flag entirely** — flipping it can never lock a developer out of local tooling.
- **`src/core/hub/hub-surface-policy.ts`** (pure): `isHubSurfaceAvailable({env, hubEnabled, tier})` and `evaluateHubPortalRequestOutsideDev(...)` → `pass-through | allow | not-found`.
- **`src/core/hub/hub-surface-guard.ts`** (thin): `assertHubSurfaceAvailable(tier)` replaces every scattered `assertDev()`. Reads env at **request time** (the convention `hub.controller.ts` always used).
- **`HubPortalMiddleware`** — outside development:
  - flag **off** → inert pass-through; controllers behave byte-identically to today.
  - flag **on** → a Better-Auth session whose CASL ability passes `canAccessHub()` (for `/hub/*`) resp. `canAccessTenantAdmin()` (for `/admin/*`) is **mandatory**. Everything else answers the same bare **404** a disabled hub emits — deliberately no dev-style redirect and no 403, so an unauthorized caller cannot distinguish an opted-in deployment from one without the flag. The `portal-access.json` probe stays reachable for any *signed-in* user so the SPA renders its friendly denial screen (mirrors its development semantics).
  - Anonymous requests keep hitting the pre-existing session wall first (401 JSON / 302 → `/` for browsers) — indistinguishable from a flag-off deployment, and identical for *every* protected path, so nothing about the hub is probeable.

In development, behavior is unchanged under **every** flag value (locked by a dedicated story).

## Two-tier surface split

Blanket-unlocking everything would ship workstation tooling to production, so every dev-gated surface was classified. Tier rationale is commented at each call site.

### Operational — dev-always; outside dev: flag + session + CASL

| Surface | Routes |
|---|---|
| Hub SPA shell + assets + catch-all | `GET /hub`, `/hub/static/:file`, `/hub/*splat` |
| Access probes | `/hub/portal-access.json`, `/hub/operator-tenant.json` |
| Cockpit | `/hub/dashboard.json`, `/hub/status.json` |
| Feature READ views | `/hub/features` (page), `/hub/features.json`, `/hub/feature-catalog.json` |
| Diagnostics buffers | `/hub/diagnostics(.json)`, `/hub/logs(.json)`, `/hub/traces(.json)`, `/hub/queries(.json)` |
| Route inventory READ | `/hub/routes(.json)` |
| Registry reads | `/hub/scheduled-jobs.json`, `/hub/webhook-events.json` |
| Jobs dashboard (feature `jobs`) | `/hub/jobs`, `/hub/jobs/queues.json`, `/hub/jobs/jobs.json`, `/hub/jobs/jobs/:id.json`, `POST …/:id/retry`, `/hub/cron` |
| Email outbox views (feature `email`) | `/hub/email-outbox`, `/hub/outbox.json` |
| Brand READ | `/hub/brand.json`, `/hub/brand` (page shell) |
| PostgREST filter parser | `/hub/postgrest-parse` (pure parser, no state access) |
| Cmd+K palette | `/hub/palette/search.json` |
| Page shells whose data endpoints are workstation | `/hub/coverage`, `/hub/tests`, `/hub/erd`, `/hub/json`, `/hub/migrations`, `/hub/emails`, `/hub/email-builder` (chrome identical to the splat shell — reveals nothing) |
| Permission CRUD (admin-crud) | `/admin/roles*`, `/admin/policies*`, `/admin/permissions*` |
| Admin inspectors (admin-spa) | `/admin/webhooks*` (incl. test/redeliver), `/admin/realtime*` (incl. disconnect/send/replay), `/admin/audit*`, `/admin/jobs`, `/admin/search` (page shell only) |

**Unchanged pre-existing surfaces:** `/admin/users*`, `/admin/tenants*`, `/admin/sessions*`, `/admin/rate-limits*`, `/admin/email-outbox*` were never dev-asserted — their `@Can(...)` gates already work in every environment. This PR does not remove them (backward compat, locked by story); with the flag ON they are additionally walled behind `canAccessTenantAdmin` by the middleware.

### Workstation — development-only forever (flag and ability are irrelevant)

| Surface | Routes | Why |
|---|---|---|
| File manager sidecars (dev-files) | `/hub/files`, `/hub/files/tree.json`, `/hub/files/list.json`, `/hub/files/breadcrumb.json` | `@Public` listings over tenant file rows with only tenant context — would sidestep the product file API's per-subject CASL |
| Migrations runner | `/hub/migrations.json`, `preview/:name`, `diff`, `POST deploy/apply-one/dry-run/retry/create/apply-draft`, `DELETE draft/:name` | reads `prisma/migrations` from the checkout, mutates schema |
| Feature toggle WRITE | `POST /hub/features/:key/toggle` | writes the `.env` file, touches `src/main.ts` |
| Brand WRITE | `POST /hub/brand`, `POST /hub/brand/reset` | writes `src/modules/branding/brand.json` |
| Coverage / test artifacts | `/hub/coverage.json`, `/hub/tests.json` | read local test-run artifacts from the checkout |
| ERD | `/hub/erd.json` | reads `prisma/schema*.prisma` from the checkout |
| Tunnel state | `/hub/tunnel.json` | leaks the workstation's cloudflare tunnel URL |
| Email template builder (feature `email`) | `/hub/email-preview.json`, template `preview.html` / `templates.json` / payload GETs, `blocks.json`, `POST preview.json`, `POST save`, `DELETE …/override` | renders template sources + writes override files into `src/` |
| Permission tester | `/admin/permissions/test`, `/admin/permissions/test.json` | x-test-ability companion tooling |
| Search tester | `/admin/search.json` | intentionally searches **across all tenants** (`tenantId=""`) |

Non-route dev tooling (browser-open, dev-session lock, prisma-studio script, migrations runner internals) is untouched — already boot-time dev-gated.

## Backward-compat guarantee

- Flag unset/false: **every** environment behaves exactly as today. The flag-off story boots `NODE_ENV=production` with a fully-granted operator (`read Hub` + CRUD `User` in the DB) and proves the 404s persist — the flag gates, not the ability. Anonymous 401/302 semantics unchanged. The pre-existing `@Can` admin surfaces stay reachable.
- Development: a dedicated story boots with `FEATURE_HUB_ENABLED=false` (the strictest case) and proves both tiers stay fully available and the anonymous redirect is intact.
- One deliberate correction: `admin-crud`'s old `assertDevPortalOnly` read the **boot-frozen** `ConfigService` snapshot, so it missed runtime `NODE_ENV` flips — in production-mode e2e boots (env pinned after module import) `/admin/roles` stayed open. The shared guard reads env per request (the `hub.controller` convention). Real deployments (env set before process start) see no change.

## Test evidence (TDD, red-first)

Red commit first (`test(hub): red stories …`), then the implementation commit turns them green.

- `tests/stories/hub-outside-dev.story.test.ts` — production + flag on (26 cases): anonymous parity (401/302), authenticated-without-ability → 404 masks everywhere (including the previously shell-open `/admin/rate-limits`), probe reachability + `{hub, tenantAdmin}` truthfulness, authorized operator → 200 on operational surfaces, workstation tier → 404 for everyone. **Positive cases use the real auth path**: Better-Auth sign-up/sign-in + DB rows `Role → RolePolicy → Policy → Permission` (`read Hub`, CRUD `User`) + `organization/set-active` — no `x-test-ability` anywhere in the file.
- `tests/stories/hub-outside-dev-flag-off.story.test.ts` — production baseline lock (11 cases).
- `tests/stories/hub-outside-dev-development.story.test.ts` — development invariance lock (7 cases).
- `tests/unit/hub-surface-policy.test.ts` — full decision matrix for both pure functions + the guard (12 cases).
- Updated contract locks that intentionally moved: `feature-flag-23-surface` (new `hub` key), `admin-crud-controller` (guard rename), `dev-portal-pages` (tiered helpers).

Full gates green locally: `lint`, `format`, `check:rls`, `test:types`, `test:unit`, `test:e2e`, `test:coverage` (src/core ≥ 80 % lines), `build`, `dump:openapi --check` (no drift — no route surface changed), `sdk:check`.

## Notes for deployers (docs-worthy)

- Opting in requires the SPA bundle in the image: run `bun run build:dev-portal` in the build (the CI e2e/coverage jobs already do).
- Operators enter at `/` (login page), then navigate to `/hub` — there is intentionally no redirect flow on `/hub` for anonymous browsers beyond the existing session wall.
- Grant model: seeded admins pass via `manage all`; narrower operators need `read Hub` (cockpit) and/or CRUD on `User`/`TenantAdmin`/`Role`/`Policy`/`Permission` (admin surfaces).

## Open questions

1. **`canAccessTenantAdmin` scope:** it recognizes `User`/`TenantAdmin`/`Role`/`Policy`/`Permission` (or `manage all`) — not `RateLimitAdmin`, `EmailOutboxAdmin`, `Session`. With the flag ON, an operator holding only e.g. `manage RateLimitAdmin` is walled off `/admin/*` (they keep working with the flag OFF). Development has the same wall today, so this PR mirrors it — but should the subject list grow?
2. **Ambiguity calls:** `postgrest-parse` was kept operational (pure parser, no state); the dev-files file manager was parked workstation even though it is DB-backed (it bypasses per-subject CASL). Both easy to move if reviewers disagree — the tier is one word at the call site.
3. **SPA polish (follow-up):** outside development, workstation pages render their shells but their data endpoints 404 — the SPA shows its error/empty states. A follow-up could hide workstation nav entries via the `portal-access.json` snapshot.
4. Should an explicit `FEATURE_HUB_ENABLED=false` also disable the hub **in development**? Currently development is invariant by design (strongest local-DX guarantee).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
