### PR TITLE
feat(hub): hide workstation-tier pages from the Dev-Portal SPA outside development

### DIFF
--- a/docs/hub/login.md
+++ b/docs/hub/login.md
@@ -14,7 +14,9 @@ There is **no** separate Hub operator password or `hub.session` cookie anymore.
 2. Sign in with email + password (`POST /api/auth/sign-in/email`, session cookie).
 3. The SPA calls `bootstrapHubOperatorSession()` (Better-Auth `set-active`
    for the operator's organization) when multi-tenancy is enabled.
-4. The SPA checks `GET /hub/portal-access.json` (`hub` + `tenantAdmin` flags).
+4. The SPA checks `GET /hub/portal-access.json` (`hub` + `tenantAdmin` flags, plus
+   `workstation` — `false` outside development, which hides workstation-tier nav
+   entries such as Files/Migrations/Coverage/Tests/ERD/Emails and the testers).
 5. On success you land on `/hub` (system admin) or `/admin/*` (tenant admin).
 
 **After setup** (`bun run setup` runs migrate + seed by default), demo accounts are

--- a/src/core/dx/clients/CLAUDE.md
+++ b/src/core/dx/clients/CLAUDE.md
@@ -119,7 +119,12 @@ clients/
 1. Add a route to `App.tsx` with `React.lazy`.
 2. Add the corresponding sidebar entry to `layout/nav.ts` (extend
    `NAV_SECTIONS` and add the path to `SPA_ROUTES` so the link uses
-   react-router and not a full reload).
+   react-router and not a full reload). If the page's data endpoints
+   are workstation-tier (dev-only, see `hub-surface-policy.ts`), tag
+   the entry `tier: "workstation"` AND add the path prefix to
+   `WORKSTATION_SPA_PATH_PREFIXES` in `../hub-nav-planner.ts` — that
+   hides it (nav, palette, quick links, deep links) on deployed
+   servers where `portal-access.json` reports `workstation: false`.
 3. Add a `*.json` endpoint in `hub.controller.ts` (for `/hub/*`)
    or `admin-spa.controller.ts` (for `/admin/*`) — the controller does
    the planning, returns JSON, the React page renders.

--- a/src/core/dx/clients/components/HubPortalGate.tsx
+++ b/src/core/dx/clients/components/HubPortalGate.tsx
@@ -9,11 +9,13 @@ import { PageError, PageLoading } from "./PageState.js";
 import { AdminFetchError, fetchJson, signOut } from "../lib/api.js";
 import {
   isSpaPathAllowedByNavSnapshot,
+  isSpaPathWorkstationOnly,
   LEGACY_HUB_NAV_FEATURES_FALLBACK,
 } from "../../hub-nav-planner.js";
 import {
   hasHubPortalAccess,
   hasTenantAdminPortalAccess,
+  hasWorkstationSurfaces,
   type HubPortalAccessPayload,
   type HubPortalNavFeatures,
 } from "../lib/hub-portal-access.js";
@@ -103,6 +105,32 @@ export function HubPortalGate(): ReactNode {
         >
           Sign out and sign in again
         </button>
+      </div>
+    );
+  }
+
+  // Deep links to workstation-tier pages on a deployed server: the nav
+  // hides them, but a bookmarked URL would render a page whose data
+  // endpoints all 404 — show the honest explanation instead.
+  if (
+    (onHub || onAdmin) &&
+    !hasWorkstationSurfaces(data) &&
+    isSpaPathWorkstationOnly(location.pathname)
+  ) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-bg p-8">
+        <PageError>
+          This page is development-workstation tooling and is not available on a deployed server.
+        </PageError>
+        {hasHubPortalAccess(data) ? (
+          <a href="/hub" className="text-sm text-accent underline-offset-2 hover:underline">
+            Back to the Hub
+          </a>
+        ) : hasTenantAdminPortalAccess(data) ? (
+          <a href="/admin/users" className="text-sm text-accent underline-offset-2 hover:underline">
+            Go to admin area
+          </a>
+        ) : null}
       </div>
     );
   }

--- a/src/core/dx/clients/layout/AdminPortalLayout.tsx
+++ b/src/core/dx/clients/layout/AdminPortalLayout.tsx
@@ -2,9 +2,10 @@
  * Persistent hub/admin chrome — sidebar + header survive route changes.
  */
 import { useEffect, useLayoutEffect, type ReactNode } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useOutletContext } from "react-router-dom";
 
 import { CommandPalette } from "../components/CommandPalette.js";
+import type { HubPortalAccess } from "../components/HubPortalGate.js";
 import { bootstrapHubOperatorSession } from "../lib/hub-session-bootstrap.js";
 import { AdminShellProvider, useAdminShellContext } from "./admin-shell-context.js";
 import { AdminSidebar, PORTAL_TOP_CHROME_ROW } from "./AdminShell.js";
@@ -19,6 +20,10 @@ function getBrandName(): string {
 function AdminPortalLayoutInner(): ReactNode {
   const { state } = useAdminShellContext();
   const { title, subtitle, currentNav, toolbar } = state;
+  // Re-provide the HubPortalGate outlet context through this layout's
+  // own <Outlet> — otherwise pages below would read `undefined` and
+  // could not see the portal-access snapshot (workstation flag etc.).
+  const portalAccess = useOutletContext<HubPortalAccess | undefined>();
 
   useLayoutEffect(() => {
     if (typeof document !== "undefined") {
@@ -47,7 +52,7 @@ function AdminPortalLayoutInner(): ReactNode {
           </div>
         </header>
         <section className="flex-1 px-8 py-6">
-          <Outlet />
+          <Outlet context={portalAccess} />
         </section>
       </main>
     </div>

--- a/src/core/dx/clients/layout/AdminShell.tsx
+++ b/src/core/dx/clients/layout/AdminShell.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 
 import type { HubPortalAccess } from "../components/HubPortalGate.js";
 import { signOut } from "../lib/api.js";
+import { hasWorkstationSurfaces } from "../lib/hub-portal-access.js";
 import { cn } from "../lib/utils.js";
 
 import { pushRecentItem } from "../components/CommandPalette.js";
@@ -65,6 +66,7 @@ export function AdminSidebar({ currentNav }: AdminSidebarProps): ReactNode {
     hub: portalAccess?.hub ?? false,
     tenantAdmin: portalAccess?.tenantAdmin ?? false,
     navFeatures: portalAccess?.features ?? LEGACY_HUB_NAV_FEATURES_FALLBACK,
+    workstation: hasWorkstationSurfaces(portalAccess),
   });
 
   async function onSignOut(): Promise<void> {

--- a/src/core/dx/clients/layout/nav.ts
+++ b/src/core/dx/clients/layout/nav.ts
@@ -20,6 +20,13 @@ export interface AdminNavItem {
   href: string;
   /** key into `ICONS` from `./icons.tsx`. */
   icon: string;
+  /**
+   * `"workstation"` — the page's data lives on the developer's
+   * workstation (checkout files, .env, localhost tools), so its data
+   * endpoints are dev-only forever (see `hub-surface-policy.ts`).
+   * Hidden when `portal-access.json` reports `workstation: false`.
+   */
+  tier?: "workstation";
 }
 
 export interface AdminNavSection {
@@ -38,8 +45,14 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "diagnostics", label: "Diagnostics", href: "/hub/diagnostics", icon: "activity" },
       { id: "features", label: "Features", href: "/hub/features", icon: "toggle" },
       { id: "brand", label: "Brand", href: "/hub/brand", icon: "palette" },
-      { id: "coverage", label: "Coverage", href: "/hub/coverage", icon: "chart" },
-      { id: "tests", label: "Tests", href: "/hub/tests", icon: "check" },
+      {
+        id: "coverage",
+        label: "Coverage",
+        href: "/hub/coverage",
+        icon: "chart",
+        tier: "workstation",
+      },
+      { id: "tests", label: "Tests", href: "/hub/tests", icon: "check", tier: "workstation" },
     ],
   },
   {
@@ -48,7 +61,13 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "logs", label: "Logs", href: "/hub/logs", icon: "terminal" },
       { id: "traces", label: "Traces", href: "/hub/traces", icon: "pulse" },
       { id: "queries", label: "Queries", href: "/hub/queries", icon: "database" },
-      { id: "migrations", label: "Migrations", href: "/hub/migrations", icon: "table" },
+      {
+        id: "migrations",
+        label: "Migrations",
+        href: "/hub/migrations",
+        icon: "table",
+        tier: "workstation",
+      },
       { id: "jobs", label: "Jobs", href: "/hub/jobs", icon: "layers" },
       { id: "cron", label: "Cron", href: "/hub/cron", icon: "clock" },
       { id: "email-outbox", label: "Email Outbox", href: "/hub/email-outbox", icon: "inbox" },
@@ -61,13 +80,16 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
       { id: "openapi", label: "OpenAPI Spec", href: "/openapi", icon: "file" },
       { id: "routes", label: "Routes", href: "/hub/routes", icon: "route" },
       { id: "errors", label: "Error Codes", href: "/errors", icon: "bug" },
-      { id: "erd", label: "ERD", href: "/hub/erd", icon: "network" },
-      { id: "emails", label: "Emails", href: "/hub/emails", icon: "mail" },
+      { id: "erd", label: "ERD", href: "/hub/erd", icon: "network", tier: "workstation" },
+      { id: "emails", label: "Emails", href: "/hub/emails", icon: "mail", tier: "workstation" },
       {
         id: "prisma-studio",
         label: "Prisma Studio",
+        // The dev-runner's Prisma Studio on the developer's own machine —
+        // a dead link from any deployed portal, hence workstation tier.
         href: "http://localhost:5555",
         icon: "external-link",
+        tier: "workstation",
       },
     ],
   },
@@ -85,13 +107,20 @@ export const NAV_SECTIONS: readonly AdminNavSection[] = [
         label: "Permission Tester",
         href: "/admin/permissions/test",
         icon: "clipboard",
+        tier: "workstation",
       },
       { id: "rate-limits", label: "Rate Limits", href: "/admin/rate-limits", icon: "gauge" },
       { id: "webhooks", label: "Webhook Inspector", href: "/admin/webhooks", icon: "webhook" },
       { id: "realtime", label: "Realtime Inspector", href: "/admin/realtime", icon: "radio" },
       { id: "audit", label: "Audit Browser", href: "/admin/audit", icon: "list" },
-      { id: "search", label: "Search Tester", href: "/admin/search", icon: "search" },
-      { id: "files", label: "File Manager", href: "/hub/files", icon: "file" },
+      {
+        id: "search",
+        label: "Search Tester",
+        href: "/admin/search",
+        icon: "search",
+        tier: "workstation",
+      },
+      { id: "files", label: "File Manager", href: "/hub/files", icon: "file", tier: "workstation" },
     ],
   },
 ];
@@ -140,6 +169,8 @@ export interface PortalNavAccessInput {
   hub: boolean;
   tenantAdmin: boolean;
   navFeatures: HubPortalNavFeatures;
+  /** `portal-access.json → workstation` — false hides workstation-tier entries. */
+  workstation: boolean;
 }
 
 /** Sidebar sections visible for the signed-in operator and active feature flags. */
@@ -154,7 +185,17 @@ export function navSectionsForPortalAccess(
   } else {
     sections = NAV_SECTIONS;
   }
-  return filterNavSectionsForSnapshot(sections, access.navFeatures);
+  const filtered = filterNavSectionsForSnapshot(sections, access.navFeatures);
+  if (access.workstation) {
+    // Development: byte-identical nav — the tier tags stay invisible.
+    return filtered;
+  }
+  return filtered
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => item.tier !== "workstation"),
+    }))
+    .filter((section) => section.items.length > 0);
 }
 
 export function isSpaRoute(href: string): boolean {

--- a/src/core/dx/clients/lib/hub-portal-access.ts
+++ b/src/core/dx/clients/lib/hub-portal-access.ts
@@ -17,6 +17,8 @@ export interface HubPortalAccessPayload {
   hub?: boolean;
   tenantAdmin?: boolean;
   features?: HubPortalNavFeatures;
+  /** Workstation-tier surfaces servable (true exactly in development). */
+  workstation?: boolean;
   /** @deprecated Pre-rename API field — remove after all clients refresh. */
   devHub?: boolean;
 }
@@ -28,6 +30,15 @@ export function hasHubPortalAccess(data: HubPortalAccessPayload | undefined): bo
 
 export function hasTenantAdminPortalAccess(data: HubPortalAccessPayload | undefined): boolean {
   return data?.tenantAdmin === true;
+}
+
+/**
+ * Workstation-tier surfaces servable? Only an explicit `false` hides
+ * them — an absent field (server predating the flag) keeps today's
+ * full nav, mirroring `LEGACY_HUB_NAV_FEATURES_FALLBACK` semantics.
+ */
+export function hasWorkstationSurfaces(data: HubPortalAccessPayload | undefined): boolean {
+  return data?.workstation !== false;
 }
 
 /** Post-login / session-restore navigation target from portal-access flags. */

--- a/src/core/dx/clients/pages/BrandPage.tsx
+++ b/src/core/dx/clients/pages/BrandPage.tsx
@@ -8,12 +8,15 @@
  */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ReactNode } from "react";
+import { useOutletContext } from "react-router-dom";
 
 import { Button } from "../components/ui/button.js";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import { PageError, PageLoading } from "../components/PageState.js";
+import type { HubPortalAccess } from "../components/HubPortalGate.js";
 import { AdminShell } from "../layout/AdminShell.js";
 import { fetchJson } from "../lib/api.js";
+import { hasWorkstationSurfaces } from "../lib/hub-portal-access.js";
 
 interface BrandConfig {
   name: string;
@@ -35,6 +38,10 @@ interface BrandConfig {
 
 export function BrandPage(): ReactNode {
   const queryClient = useQueryClient();
+  const portalAccess = useOutletContext<HubPortalAccess | undefined>();
+  // Reset deletes a repo file — a workstation-tier write that 404s on a
+  // deployed server, so the whole card disappears with the tier.
+  const canWrite = hasWorkstationSurfaces(portalAccess);
   const { data, isLoading, isError } = useQuery<BrandConfig>({
     queryKey: ["brand"],
     queryFn: () => fetchJson<BrandConfig>("/hub/brand.json"),
@@ -73,37 +80,40 @@ export function BrandPage(): ReactNode {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Reset to default</CardTitle>
-            <p className="text-xs text-fg-muted">
-              Deletes <code className="font-mono text-accent">src/modules/branding/brand.json</code>{" "}
-              and falls back to{" "}
-              <code className="font-mono text-accent">src/core/branding/brand.default.json</code>.
-              The dev runner restarts the API automatically.
-            </p>
-          </CardHeader>
-          <CardContent>
-            <Button
-              variant="danger"
-              onClick={() => {
-                if (
-                  window.confirm("Delete src/modules/branding/brand.json and reset to default?")
-                ) {
-                  reset.mutate();
-                }
-              }}
-              disabled={reset.isPending}
-            >
-              {reset.isPending ? "Resetting…" : "Reset brand"}
-            </Button>
-            {reset.isSuccess ? (
-              <p className="mt-2 text-sm text-ok">
-                Brand reset. The dev runner is restarting the API.
+        {canWrite ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Reset to default</CardTitle>
+              <p className="text-xs text-fg-muted">
+                Deletes{" "}
+                <code className="font-mono text-accent">src/modules/branding/brand.json</code> and
+                falls back to{" "}
+                <code className="font-mono text-accent">src/core/branding/brand.default.json</code>.
+                The dev runner restarts the API automatically.
               </p>
-            ) : null}
-          </CardContent>
-        </Card>
+            </CardHeader>
+            <CardContent>
+              <Button
+                variant="danger"
+                onClick={() => {
+                  if (
+                    window.confirm("Delete src/modules/branding/brand.json and reset to default?")
+                  ) {
+                    reset.mutate();
+                  }
+                }}
+                disabled={reset.isPending}
+              >
+                {reset.isPending ? "Resetting…" : "Reset brand"}
+              </Button>
+              {reset.isSuccess ? (
+                <p className="mt-2 text-sm text-ok">
+                  Brand reset. The dev runner is restarting the API.
+                </p>
+              ) : null}
+            </CardContent>
+          </Card>
+        ) : null}
       </div>
     </AdminShell>
   );

--- a/src/core/dx/clients/pages/FeaturesPage.tsx
+++ b/src/core/dx/clients/pages/FeaturesPage.tsx
@@ -6,6 +6,7 @@
  */
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
+import { useOutletContext } from "react-router-dom";
 
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card.js";
 import {
@@ -17,8 +18,10 @@ import {
 } from "../components/ui/dialog.js";
 import { Switch } from "../components/ui/switch.js";
 import { PageError, PageLoading, StatTile } from "../components/PageState.js";
+import type { HubPortalAccess } from "../components/HubPortalGate.js";
 import { AdminShell } from "../layout/AdminShell.js";
 import { fetchJson } from "../lib/api.js";
+import { hasWorkstationSurfaces } from "../lib/hub-portal-access.js";
 import { cn } from "../lib/utils.js";
 
 interface FeatureMeta {
@@ -50,6 +53,10 @@ function isActive(features: FeatureCatalogResponse["features"], key: string): bo
 }
 
 export function FeaturesPage(): ReactNode {
+  const portalAccess = useOutletContext<HubPortalAccess | undefined>();
+  // Toggling writes the workstation's .env — outside development the
+  // POST 404s (workstation tier), so render the switches read-only.
+  const readOnly = !hasWorkstationSurfaces(portalAccess);
   const data = useQuery({
     queryKey: ["hub", "feature-catalog"],
     queryFn: () => fetchJson<FeatureCatalogResponse>("/hub/feature-catalog.json"),
@@ -62,7 +69,7 @@ export function FeaturesPage(): ReactNode {
   return (
     <AdminShell title="Features" subtitle={subtitle} currentNav="features">
       {data.data ? (
-        <FeaturesBody data={data.data} />
+        <FeaturesBody data={data.data} readOnly={readOnly} />
       ) : data.isError ? (
         <PageError>Failed to load feature catalog.</PageError>
       ) : (
@@ -72,7 +79,13 @@ export function FeaturesPage(): ReactNode {
   );
 }
 
-function FeaturesBody({ data }: { data: FeatureCatalogResponse }): ReactNode {
+function FeaturesBody({
+  data,
+  readOnly,
+}: {
+  data: FeatureCatalogResponse;
+  readOnly: boolean;
+}): ReactNode {
   const total = data.catalog.length;
   const active = data.catalog.filter((m) => isActive(data.features, m.key)).length;
   const available = total - active;
@@ -104,6 +117,7 @@ function FeaturesBody({ data }: { data: FeatureCatalogResponse }): ReactNode {
                   key={meta.key}
                   meta={meta}
                   active={isActive(data.features, meta.key)}
+                  readOnly={readOnly}
                 />
               ))}
             </div>
@@ -116,6 +130,13 @@ function FeaturesBody({ data }: { data: FeatureCatalogResponse }): ReactNode {
           <CardTitle>How toggling works</CardTitle>
         </CardHeader>
         <CardContent className="text-sm text-fg-muted">
+          {readOnly ? (
+            <p className="mb-3 text-warn">
+              Read-only view: toggling writes the development workstation&apos;s{" "}
+              <code className="font-mono text-accent">.env</code> and is not available on a deployed
+              server — change the environment variables of the deployment instead.
+            </p>
+          ) : null}
           Flipping a switch above writes the matching{" "}
           <code className="font-mono text-accent">FEATURE_*_ENABLED</code> line into{" "}
           <code className="font-mono text-accent">.env</code> and touches{" "}
@@ -134,9 +155,11 @@ function FeaturesBody({ data }: { data: FeatureCatalogResponse }): ReactNode {
 interface FeatureCardProps {
   meta: FeatureMeta;
   active: boolean;
+  /** Workstation surfaces unavailable — render the switch inert. */
+  readOnly: boolean;
 }
 
-function FeatureCard({ meta, active }: FeatureCardProps): ReactNode {
+function FeatureCard({ meta, active, readOnly }: FeatureCardProps): ReactNode {
   const [overlay, setOverlay] = useState<{ visible: boolean; message: string }>({
     visible: false,
     message: "Applying feature change. The page will reload when the API is back.",
@@ -208,7 +231,7 @@ function FeatureCard({ meta, active }: FeatureCardProps): ReactNode {
             data-toggle
             data-key={meta.key}
             checked={checked}
-            disabled={mutation.isPending}
+            disabled={mutation.isPending || readOnly}
             onCheckedChange={(value) => mutation.mutate(value)}
             aria-label={`Toggle ${meta.label}`}
           />

--- a/src/core/dx/clients/pages/HubLandingPage.tsx
+++ b/src/core/dx/clients/pages/HubLandingPage.tsx
@@ -9,7 +9,7 @@
  */
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, type ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { Link, useOutletContext } from "react-router-dom";
 
 import { Badge } from "../components/ui/badge.js";
 import { Button } from "../components/ui/button.js";
@@ -28,10 +28,16 @@ import {
   YAxis,
 } from "../components/ui/chart.js";
 import { PageError, PageLoading, PageEmpty } from "../components/PageState.js";
+import type { HubPortalAccess } from "../components/HubPortalGate.js";
 import { AdminShell } from "../layout/AdminShell.js";
-import { buildHubNavFeatureSnapshot, isHubQuickLinkVisible } from "../../hub-nav-planner.js";
+import {
+  buildHubNavFeatureSnapshot,
+  isHubQuickLinkVisible,
+  isSpaPathWorkstationOnly,
+} from "../../hub-nav-planner.js";
 import type { Features } from "../../../features/features.js";
 import { fetchJson, formatDuration, levelName, stripProto } from "../lib/api.js";
+import { hasWorkstationSurfaces } from "../lib/hub-portal-access.js";
 import { cn } from "../lib/utils.js";
 
 // ---------------------------------------------------------------------------
@@ -234,6 +240,8 @@ export function HubLandingPage(): ReactNode {
 // ---------------------------------------------------------------------------
 
 function DashboardBody({ data }: { data: DashboardJson }): ReactNode {
+  const portalAccess = useOutletContext<HubPortalAccess | undefined>();
+  const workstation = hasWorkstationSurfaces(portalAccess);
   const probesDown = data.probes.filter((p) => p.status === "down").length;
   const probesUp = data.probes.filter((p) => p.status === "up").length;
   const overall = computeOverallHealth(data, probesDown);
@@ -287,7 +295,7 @@ function DashboardBody({ data }: { data: DashboardJson }): ReactNode {
         <FeatureOverview features={data.features} catalog={data.catalog} />
       </div>
 
-      <QuickLinks features={data.features} />
+      <QuickLinks features={data.features} workstation={workstation} />
     </div>
   );
 }
@@ -971,7 +979,13 @@ function FeatureOverview({
   );
 }
 
-function QuickLinks({ features }: { features: DashboardJson["features"] }): ReactNode {
+function QuickLinks({
+  features,
+  workstation,
+}: {
+  features: DashboardJson["features"];
+  workstation: boolean;
+}): ReactNode {
   const navSnapshot = buildHubNavFeatureSnapshot(features as Features);
   const links = [
     { href: "/api/docs", label: "API Reference", hint: "Interactive OpenAPI 3.1 reference" },
@@ -1001,7 +1015,12 @@ function QuickLinks({ features }: { features: DashboardJson["features"] }): Reac
       hint: "Try the WHERE clause parser",
     },
     { href: "/hub/diagnostics", label: "Diagnostics", hint: "Memory, versions, runtime" },
-  ].filter((link) => isHubQuickLinkVisible(link.href, navSnapshot));
+  ].filter(
+    (link) =>
+      isHubQuickLinkVisible(link.href, navSnapshot) &&
+      // Workstation-tier targets vanish with the tier (deployed server).
+      (workstation || !isSpaPathWorkstationOnly(link.href.split("?")[0] ?? link.href)),
+  );
   return (
     <Card>
       <CardHeader>

--- a/src/core/dx/hub-nav-planner.ts
+++ b/src/core/dx/hub-nav-planner.ts
@@ -101,6 +101,34 @@ export function isSpaPathAllowedByFeatures(pathname: string, features: Features)
   return isSpaPathAllowedByNavSnapshot(pathname, buildHubNavFeatureSnapshot(features));
 }
 
+/**
+ * SPA paths whose DATA endpoints are workstation-tier (see
+ * `hub-surface-policy.ts` — dev-only forever). Outside development the
+ * server 404s their JSON, so nav, quick links, the palette, and the
+ * client route gate hide them when `portal-access.json` says
+ * `workstation: false`. Page-shell tiers do not matter here — this list
+ * classifies what the PAGE needs to function.
+ */
+export const WORKSTATION_SPA_PATH_PREFIXES: readonly string[] = [
+  "/hub/coverage",
+  "/hub/tests",
+  "/hub/migrations",
+  "/hub/erd",
+  "/hub/emails",
+  "/hub/email-preview",
+  "/hub/email-builder",
+  "/hub/files",
+  "/admin/permissions/test",
+  "/admin/search",
+];
+
+/** Prefix match, same semantics as `SPA_ROUTE_FEATURE_REQUIREMENTS`. */
+export function isSpaPathWorkstationOnly(pathname: string): boolean {
+  return WORKSTATION_SPA_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
 /** Hub landing quick-links: SPA paths respect flags; `/api/docs` and `/errors` stay visible. */
 export function isHubQuickLinkVisible(href: string, snapshot: HubPortalNavFeatures): boolean {
   const path = href.split("?")[0] ?? href;

--- a/src/core/dx/hub.controller.ts
+++ b/src/core/dx/hub.controller.ts
@@ -122,8 +122,15 @@ import { ApiTags } from "@nestjs/swagger";
 import type { Ability } from "../permissions/casl-ability.js";
 import { buildHubPortalAccessSnapshot } from "../hub/hub-portal-access.js";
 import { resolveHubOperatorTenantId, type HubOperatorUser } from "../hub/hub-operator-tenant.js";
-import { assertHubSurfaceAvailable } from "../hub/hub-surface-guard.js";
-import { buildHubNavFeatureSnapshot, filterPalettePagesForNavSnapshot } from "./hub-nav-planner.js";
+import {
+  assertHubSurfaceAvailable,
+  isHubSurfaceAvailableFromEnv,
+} from "../hub/hub-surface-guard.js";
+import {
+  buildHubNavFeatureSnapshot,
+  filterPalettePagesForNavSnapshot,
+  isSpaPathWorkstationOnly,
+} from "./hub-nav-planner.js";
 import { Public } from "../permissions/public.decorator.js";
 import { assertFeatureEnabledFromEnv } from "../features/assert-feature-enabled.js";
 import type { ToggleableFeatureKey } from "../features/features.js";
@@ -230,7 +237,13 @@ export class HubController {
   ): ReturnType<typeof buildHubPortalAccessSnapshot> {
     this.assertOperational();
     const features = this.featuresOnly();
-    return buildHubPortalAccessSnapshot(req.ability, buildHubNavFeatureSnapshot(features));
+    return buildHubPortalAccessSnapshot(
+      req.ability,
+      buildHubNavFeatureSnapshot(features),
+      // Same pure policy that 404s the workstation routes — so the SPA
+      // nav and the server gates can never drift apart.
+      isHubSurfaceAvailableFromEnv("workstation"),
+    );
   }
 
   /**
@@ -1577,7 +1590,12 @@ export class HubController {
     this.assertOperational();
     const query = typeof q === "string" ? q.trim() : "";
     const snapshot = buildHubNavFeatureSnapshot(this.featuresOnly());
-    const pages = filterPalettePagesForNavSnapshot(buildHubPageCatalog(), snapshot);
+    // Outside development the workstation pages 404 — keep Cmd+K in
+    // lock-step with the sidebar instead of offering dead entries.
+    const workstation = isHubSurfaceAvailableFromEnv("workstation");
+    const pages = filterPalettePagesForNavSnapshot(buildHubPageCatalog(), snapshot).filter(
+      (page) => workstation || !isSpaPathWorkstationOnly(page.href),
+    );
     const results = searchPalettePages({ query, pages, maxResults: 30 });
     return { pages: results };
   }

--- a/src/core/hub/hub-portal-access.ts
+++ b/src/core/hub/hub-portal-access.ts
@@ -39,15 +39,24 @@ export interface HubPortalAccessSnapshot {
   hub: boolean;
   tenantAdmin: boolean;
   features: HubPortalNavFeatures;
+  /**
+   * Workstation-tier surfaces servable? `true` exactly in development
+   * (`isHubSurfaceAvailable({tier: "workstation"})`). The SPA's only
+   * environment signal — deliberately a boolean, not the raw NODE_ENV,
+   * so the probe leaks nothing beyond what the 404s already prove.
+   */
+  workstation: boolean;
 }
 
 export function buildHubPortalAccessSnapshot(
   ability: Ability | undefined,
   features: HubPortalNavFeatures,
+  workstation: boolean,
 ): HubPortalAccessSnapshot {
   return {
     hub: canAccessHub(ability),
     tenantAdmin: canAccessTenantAdmin(ability),
     features,
+    workstation,
   };
 }

--- a/src/core/hub/hub-surface-guard.ts
+++ b/src/core/hub/hub-surface-guard.ts
@@ -21,9 +21,22 @@ export function assertHubSurfaceAvailable(
   tier: HubSurfaceTier,
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): void {
-  const serverEnv = serverConfigFromEnv(env).env;
-  const hubEnabled = loadFeatures(env).hub.enabled;
-  if (!isHubSurfaceAvailable({ env: serverEnv, hubEnabled, tier })) {
+  if (!isHubSurfaceAvailableFromEnv(tier, env)) {
     throw new NotFoundException();
   }
+}
+
+/**
+ * Boolean twin of `assertHubSurfaceAvailable` — same request-time env
+ * read, no throw. Feeds availability into payloads instead of gates:
+ * `portal-access.json → workstation` and the palette page filter, so
+ * the SPA hides surfaces the server would 404 anyway.
+ */
+export function isHubSurfaceAvailableFromEnv(
+  tier: HubSurfaceTier,
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): boolean {
+  const serverEnv = serverConfigFromEnv(env).env;
+  const hubEnabled = loadFeatures(env).hub.enabled;
+  return isHubSurfaceAvailable({ env: serverEnv, hubEnabled, tier });
 }

--- a/tests/stories/dev-portal-pages.story.test.ts
+++ b/tests/stories/dev-portal-pages.story.test.ts
@@ -43,6 +43,10 @@ const FEATURES_PAGE = read("src/core/dx/clients/pages/FeaturesPage.tsx");
 const AUDIT_BROWSER_PAGE = read("src/core/dx/clients/pages/AuditBrowserPage.tsx");
 const API_TS = read("src/core/dx/clients/lib/api.ts");
 const HUB_LOGIN_PAGE = read("src/core/dx/clients/pages/HubLoginPage.tsx");
+const HUB_PORTAL_GATE = read("src/core/dx/clients/components/HubPortalGate.tsx");
+const BRAND_PAGE = read("src/core/dx/clients/pages/BrandPage.tsx");
+const HUB_LANDING_PAGE = read("src/core/dx/clients/pages/HubLandingPage.tsx");
+const HUB_PORTAL_ACCESS_LIB = read("src/core/dx/clients/lib/hub-portal-access.ts");
 
 describe("Story · Dev-Portal SPA route + nav contract", () => {
   describe("admin fetch sends session cookies", () => {
@@ -475,6 +479,72 @@ describe("Story · Dev-Portal SPA route + nav contract", () => {
 
     it('nav.ts "permissions-crud" entry has href "/admin/permissions" (exact path)', () => {
       expect(NAV_TS).toMatch(/id: "permissions-crud"[^}]+href: "\/admin\/permissions"/s);
+    });
+  });
+
+  describe("Workstation-tier nav entries hidden outside development (#186 follow-up)", () => {
+    // Pages whose DATA endpoints are workstation-tier (dev-only forever)
+    // plus the Prisma-Studio localhost link. The sidebar model carries
+    // the tier tag; the SPA filters on `portal-access.json → workstation`.
+    const workstationNavIds = [
+      "coverage",
+      "tests",
+      "migrations",
+      "erd",
+      "emails",
+      "prisma-studio",
+      "permissions",
+      "search",
+      "files",
+    ];
+    for (const id of workstationNavIds) {
+      it(`nav.ts tags id="${id}" as workstation tier`, () => {
+        expect(NAV_TS).toMatch(new RegExp(`id: "${id}",[^}]*tier: "workstation"`, "s"));
+      });
+    }
+
+    const operationalNavIds = ["hub", "diagnostics", "features", "brand", "logs", "users"];
+    for (const id of operationalNavIds) {
+      it(`nav.ts keeps id="${id}" untagged (operational)`, () => {
+        expect(NAV_TS).not.toMatch(new RegExp(`id: "${id}",[^}]*tier: "workstation"`, "s"));
+      });
+    }
+
+    it("client portal-access mirror carries the workstation flag + resolver", () => {
+      expect(HUB_PORTAL_ACCESS_LIB).toContain("workstation?: boolean");
+      expect(HUB_PORTAL_ACCESS_LIB).toContain("hasWorkstationSurfaces");
+    });
+
+    it("AdminShell feeds the workstation flag into the nav filter", () => {
+      expect(ADMIN_SHELL).toContain("hasWorkstationSurfaces");
+      expect(ADMIN_SHELL).toMatch(/workstation:/);
+    });
+
+    it("AdminPortalLayout forwards the portal-access outlet context to pages", () => {
+      expect(ADMIN_PORTAL_LAYOUT).toMatch(/<Outlet context=/);
+    });
+
+    it("HubPortalGate blocks workstation SPA deep links outside development", () => {
+      expect(HUB_PORTAL_GATE).toContain("isSpaPathWorkstationOnly");
+      expect(HUB_PORTAL_GATE).toContain("hasWorkstationSurfaces");
+    });
+
+    it("FeaturesPage switches go read-only without workstation surfaces", () => {
+      expect(FEATURES_PAGE).toContain("hasWorkstationSurfaces");
+      expect(FEATURES_PAGE).toMatch(/disabled=\{mutation\.isPending \|\| readOnly\}/);
+    });
+
+    it("BrandPage hides the reset write control without workstation surfaces", () => {
+      expect(BRAND_PAGE).toContain("hasWorkstationSurfaces");
+    });
+
+    it("HubLandingPage quick links respect the workstation tier", () => {
+      expect(HUB_LANDING_PAGE).toContain("isSpaPathWorkstationOnly");
+    });
+
+    it("hub.controller filters palette pages by workstation availability", () => {
+      expect(CONTROLLER).toContain("isSpaPathWorkstationOnly");
+      expect(CONTROLLER).toContain('isHubSurfaceAvailableFromEnv("workstation")');
     });
   });
 });

--- a/tests/stories/hub-nav-filter.story.test.ts
+++ b/tests/stories/hub-nav-filter.story.test.ts
@@ -24,10 +24,33 @@ const _navFeaturesOff = buildHubNavFeatureSnapshot(
   loadFeatures({ FEATURE_MULTI_TENANCY_ENABLED: "false" }),
 );
 
+/**
+ * Nav entries whose DATA endpoints are workstation-tier (dev-only
+ * forever, see `hub-surface-policy.ts` and the #186 tier table) plus
+ * the Prisma-Studio link (points at the developer's own localhost).
+ * Outside development the sidebar must not offer them.
+ */
+const WORKSTATION_NAV_IDS = [
+  "coverage",
+  "tests",
+  "migrations",
+  "erd",
+  "emails",
+  "prisma-studio",
+  "permissions",
+  "search",
+  "files",
+];
+
 describe("Story · Hub nav filter", () => {
   it("shows every section for system admin (hub + tenant admin)", () => {
     expect(
-      navSectionsForPortalAccess({ hub: true, tenantAdmin: true, navFeatures: navFeaturesOn }),
+      navSectionsForPortalAccess({
+        hub: true,
+        tenantAdmin: true,
+        navFeatures: navFeaturesOn,
+        workstation: true,
+      }),
     ).toEqual(NAV_SECTIONS);
   });
 
@@ -36,6 +59,7 @@ describe("Story · Hub nav filter", () => {
       hub: true,
       tenantAdmin: false,
       navFeatures: navFeaturesOn,
+      workstation: true,
     });
     expect(sections.some((s) => s.title === ADMIN_NAV_SECTION_TITLE)).toBe(false);
     expect(sections.length).toBeGreaterThan(0);
@@ -46,8 +70,76 @@ describe("Story · Hub nav filter", () => {
       hub: false,
       tenantAdmin: true,
       navFeatures: navFeaturesOn,
+      workstation: true,
     });
     expect(sections).toHaveLength(1);
     expect(sections[0]?.title).toBe(ADMIN_NAV_SECTION_TITLE);
+  });
+
+  it("nav model tags exactly the workstation-tier entries (#186 tier table)", () => {
+    const tagged = NAV_SECTIONS.flatMap((s) => s.items)
+      .filter((i) => i.tier === "workstation")
+      .map((i) => i.id);
+    expect([...tagged].sort()).toEqual([...WORKSTATION_NAV_IDS].sort());
+  });
+
+  it("workstation:false hides every workstation entry and keeps the operational console", () => {
+    const sections = navSectionsForPortalAccess({
+      hub: true,
+      tenantAdmin: true,
+      navFeatures: navFeaturesOn,
+      workstation: false,
+    });
+    const ids = sections.flatMap((s) => s.items).map((i) => i.id);
+    for (const id of WORKSTATION_NAV_IDS) {
+      expect(ids, `nav must hide workstation entry "${id}"`).not.toContain(id);
+    }
+    for (const id of [
+      "hub",
+      "diagnostics",
+      "features",
+      "brand",
+      "logs",
+      "traces",
+      "queries",
+      "jobs",
+      "cron",
+      "email-outbox",
+      "scalar",
+      "openapi",
+      "routes",
+      "errors",
+      "users",
+      "tenants",
+      "sessions",
+      "roles",
+      "policies",
+      "permissions-crud",
+      "rate-limits",
+      "webhooks",
+      "realtime",
+      "audit",
+    ]) {
+      expect(ids, `nav must keep operational entry "${id}"`).toContain(id);
+    }
+    // No section collapses to an empty shell.
+    for (const section of sections) {
+      expect(section.items.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("tenant-admin-only nav outside development drops the workstation testers", () => {
+    const sections = navSectionsForPortalAccess({
+      hub: false,
+      tenantAdmin: true,
+      navFeatures: navFeaturesOn,
+      workstation: false,
+    });
+    expect(sections).toHaveLength(1);
+    const ids = sections[0]?.items.map((i) => i.id) ?? [];
+    expect(ids).not.toContain("permissions");
+    expect(ids).not.toContain("search");
+    expect(ids).not.toContain("files");
+    expect(ids).toContain("users");
   });
 });

--- a/tests/stories/hub-nav-planner.story.test.ts
+++ b/tests/stories/hub-nav-planner.story.test.ts
@@ -6,8 +6,10 @@ import {
   isHubQuickLinkVisible,
   isNavItemVisibleForNavSnapshot,
   isSpaPathAllowedByNavSnapshot,
+  isSpaPathWorkstationOnly,
   NAV_ITEM_FEATURE_REQUIREMENTS,
   SPA_ROUTE_FEATURE_REQUIREMENTS,
+  WORKSTATION_SPA_PATH_PREFIXES,
 } from "../../src/core/dx/hub-nav-planner.js";
 import { loadFeatures } from "../../src/core/features/features.js";
 import { NAV_SECTIONS, navSectionsForPortalAccess } from "../../src/core/dx/clients/layout/nav.js";
@@ -100,6 +102,7 @@ describe("Story · Hub nav planner (feature flags)", () => {
       hub: true,
       tenantAdmin: true,
       navFeatures: snapshotWith({ multiTenancy: false }),
+      workstation: true,
     });
     const admin = sections.find((s) => s.title === "Admin");
     expect(admin?.items.some((i) => i.id === "tenants")).toBe(false);
@@ -112,6 +115,7 @@ describe("Story · Hub nav planner (feature flags)", () => {
         hub: true,
         tenantAdmin: true,
         navFeatures: allOn,
+        workstation: true,
       }),
     ).toEqual(NAV_SECTIONS);
   });
@@ -143,6 +147,81 @@ describe("Story · Hub nav planner (feature flags)", () => {
     for (const [itemId, feature] of Object.entries(NAV_ITEM_FEATURE_REQUIREMENTS)) {
       const route = SPA_ROUTE_FEATURE_REQUIREMENTS.find((r) => r.feature === feature);
       expect(route, `nav item "${itemId}" feature "${feature}"`).toBeTruthy();
+    }
+  });
+});
+
+describe("Story · Hub nav planner (workstation tier)", () => {
+  // Pages whose DATA endpoints assert the workstation surface tier
+  // (dev-only forever) — mirrors the #186 tier table.
+  const workstationPaths = [
+    "/hub/coverage",
+    "/hub/tests",
+    "/hub/migrations",
+    "/hub/erd",
+    "/hub/emails",
+    "/hub/emails/templates",
+    "/hub/email-preview",
+    "/hub/email-builder",
+    "/hub/files",
+    "/hub/files/nested/dir",
+    "/admin/permissions/test",
+    "/admin/search",
+    "/admin/search/anything",
+  ];
+
+  // Operator-console pages: their data endpoints are operational tier
+  // and must stay reachable on an opted-in deployment.
+  const operationalPaths = [
+    "/hub",
+    "/hub/diagnostics",
+    "/hub/features",
+    "/hub/brand",
+    "/hub/logs",
+    "/hub/traces",
+    "/hub/queries",
+    "/hub/jobs",
+    "/hub/cron",
+    "/hub/email-outbox",
+    "/hub/routes",
+    "/hub/json",
+    "/hub/postgrest-parse",
+    "/admin/users",
+    "/admin/permissions",
+    "/admin/rate-limits",
+  ];
+
+  it.each(workstationPaths.map((path) => ({ path })))(
+    "$path is a workstation-only SPA path",
+    ({ path }) => {
+      expect(isSpaPathWorkstationOnly(path)).toBe(true);
+    },
+  );
+
+  it.each(operationalPaths.map((path) => ({ path })))(
+    "$path stays an operational SPA path",
+    ({ path }) => {
+      expect(isSpaPathWorkstationOnly(path)).toBe(false);
+    },
+  );
+
+  it("every workstation path prefix is covered by the exported list", () => {
+    expect(WORKSTATION_SPA_PATH_PREFIXES.length).toBeGreaterThan(0);
+    for (const prefix of WORKSTATION_SPA_PATH_PREFIXES) {
+      expect(isSpaPathWorkstationOnly(prefix), prefix).toBe(true);
+    }
+  });
+
+  it("nav tier tags agree with the path classification (cross-lock)", () => {
+    for (const item of NAV_SECTIONS.flatMap((s) => s.items)) {
+      if (item.href.startsWith("http")) {
+        // External links (Prisma Studio → the developer's localhost)
+        // are tagged by hand — the path classifier cannot see them.
+        continue;
+      }
+      expect(isSpaPathWorkstationOnly(item.href), `nav item "${item.id}"`).toBe(
+        item.tier === "workstation",
+      );
     }
   });
 });

--- a/tests/stories/hub-outside-dev-development.story.test.ts
+++ b/tests/stories/hub-outside-dev-development.story.test.ts
@@ -46,6 +46,22 @@ describe("Story · Hub outside development (development boot, FEATURE_HUB_ENABLE
       expect(res.status).toBe(200);
     });
 
+    it("the access probe reports workstation:true (flag value irrelevant in dev)", async () => {
+      // Development invariance for the SPA nav: with the flag pinned to
+      // FALSE the probe must still say workstation:true, so the sidebar
+      // renders exactly as today on every developer workstation.
+      const res = await hub.get("/hub/portal-access.json");
+      expect(res.status).toBe(200);
+      expect(res.body.workstation).toBe(true);
+    });
+
+    it("palette search keeps workstation pages in development", async () => {
+      const res = await hub.get("/hub/palette/search.json?q=migrations");
+      expect(res.status).toBe(200);
+      const hrefs = (res.body.pages as Array<{ href: string }>).map((p) => p.href);
+      expect(hrefs).toContain("/hub/migrations");
+    });
+
     it("feature READ views respond 200", async () => {
       const res = await hub.get("/hub/features.json");
       expect(res.status).toBe(200);

--- a/tests/stories/hub-outside-dev.story.test.ts
+++ b/tests/stories/hub-outside-dev.story.test.ts
@@ -204,9 +204,7 @@ describe("Story · Hub outside development (production + FEATURE_HUB_ENABLED=tru
     it("palette search omits workstation-tier pages (nav parity)", async () => {
       const migrations = await operator.agent.get("/hub/palette/search.json?q=migrations");
       expect(migrations.status).toBe(200);
-      const migrationHrefs = (migrations.body.pages as Array<{ href: string }>).map(
-        (p) => p.href,
-      );
+      const migrationHrefs = (migrations.body.pages as Array<{ href: string }>).map((p) => p.href);
       expect(migrationHrefs).not.toContain("/hub/migrations");
       const logs = await operator.agent.get("/hub/palette/search.json?q=logs");
       expect(logs.status).toBe(200);

--- a/tests/stories/hub-outside-dev.story.test.ts
+++ b/tests/stories/hub-outside-dev.story.test.ts
@@ -178,6 +178,9 @@ describe("Story · Hub outside development (production + FEATURE_HUB_ENABLED=tru
       expect(res.status).toBe(200);
       expect(res.body.hub).toBe(false);
       expect(res.body.tenantAdmin).toBe(false);
+      // Even a no-access probe reports the tier signal, so the SPA never
+      // has to guess the environment.
+      expect(res.body.workstation).toBe(false);
     });
   });
 
@@ -187,6 +190,28 @@ describe("Story · Hub outside development (production + FEATURE_HUB_ENABLED=tru
       expect(res.status).toBe(200);
       expect(res.body.hub).toBe(true);
       expect(res.body.tenantAdmin).toBe(true);
+    });
+
+    it("access probe reports workstation:false so the SPA hides dev-only nav", async () => {
+      // The one signal the SPA was missing: outside development the
+      // workstation tier is never servable, so the sidebar must not
+      // offer Files/Migrations/Coverage/… — their data endpoints 404.
+      const res = await operator.agent.get("/hub/portal-access.json");
+      expect(res.status).toBe(200);
+      expect(res.body.workstation).toBe(false);
+    });
+
+    it("palette search omits workstation-tier pages (nav parity)", async () => {
+      const migrations = await operator.agent.get("/hub/palette/search.json?q=migrations");
+      expect(migrations.status).toBe(200);
+      const migrationHrefs = (migrations.body.pages as Array<{ href: string }>).map(
+        (p) => p.href,
+      );
+      expect(migrationHrefs).not.toContain("/hub/migrations");
+      const logs = await operator.agent.get("/hub/palette/search.json?q=logs");
+      expect(logs.status).toBe(200);
+      const logHrefs = (logs.body.pages as Array<{ href: string }>).map((p) => p.href);
+      expect(logHrefs).toContain("/hub/logs");
     });
 
     it("hub SPA shell renders (200)", async () => {

--- a/tests/stories/hub-portal-access.story.test.ts
+++ b/tests/stories/hub-portal-access.story.test.ts
@@ -24,10 +24,23 @@ describe("Story · Hub portal CASL access", () => {
     const ability = buildAbility([{ action: "manage", subject: "all" }]);
     expect(canAccessHub(ability)).toBe(true);
     expect(canAccessTenantAdmin(ability)).toBe(true);
-    expect(buildHubPortalAccessSnapshot(ability, navFeatures)).toEqual({
+    expect(buildHubPortalAccessSnapshot(ability, navFeatures, true)).toEqual({
       hub: true,
       tenantAdmin: true,
       features: navFeatures,
+      workstation: true,
+    });
+  });
+
+  it("workstation availability flows through the snapshot verbatim (deployed = false)", () => {
+    // Ability grants everything — yet outside development the snapshot
+    // must still say workstation:false so the SPA can hide dev-only nav.
+    const ability = buildAbility([{ action: "manage", subject: "all" }]);
+    expect(buildHubPortalAccessSnapshot(ability, navFeatures, false)).toEqual({
+      hub: true,
+      tenantAdmin: true,
+      features: navFeatures,
+      workstation: false,
     });
   });
 
@@ -46,10 +59,11 @@ describe("Story · Hub portal CASL access", () => {
     const ability = buildAbility([{ action: "manage", subject: "User" }]);
     expect(canAccessTenantAdmin(ability)).toBe(true);
     expect(canAccessHub(ability)).toBe(false);
-    expect(buildHubPortalAccessSnapshot(ability, navFeatures)).toEqual({
+    expect(buildHubPortalAccessSnapshot(ability, navFeatures, true)).toEqual({
       hub: false,
       tenantAdmin: true,
       features: navFeatures,
+      workstation: true,
     });
   });
 
@@ -62,10 +76,11 @@ describe("Story · Hub portal CASL access", () => {
       { action: "read", subject: "Hub" },
     ]);
     expect(canAccessTenantAdmin(ability)).toBe(true);
-    expect(buildHubPortalAccessSnapshot(ability, navFeatures)).toEqual({
+    expect(buildHubPortalAccessSnapshot(ability, navFeatures, true)).toEqual({
       hub: true,
       tenantAdmin: true,
       features: navFeatures,
+      workstation: true,
     });
   });
 
@@ -76,10 +91,11 @@ describe("Story · Hub portal CASL access", () => {
       { action: "update", subject: "all" },
       { action: "delete", subject: "all" },
     ]);
-    expect(buildHubPortalAccessSnapshot(ability, navFeatures)).toEqual({
+    expect(buildHubPortalAccessSnapshot(ability, navFeatures, true)).toEqual({
       hub: true,
       tenantAdmin: true,
       features: navFeatures,
+      workstation: true,
     });
   });
 });

--- a/tests/unit/hub-surface-policy.test.ts
+++ b/tests/unit/hub-surface-policy.test.ts
@@ -1,7 +1,10 @@
 import { NotFoundException } from "@nestjs/common";
 import { describe, expect, it } from "vitest";
 
-import { assertHubSurfaceAvailable } from "../../src/core/hub/hub-surface-guard.js";
+import {
+  assertHubSurfaceAvailable,
+  isHubSurfaceAvailableFromEnv,
+} from "../../src/core/hub/hub-surface-guard.js";
 import {
   evaluateHubPortalRequestOutsideDev,
   isHubSurfaceAvailable,
@@ -159,5 +162,32 @@ describe("hub-surface-guard · assertHubSurfaceAvailable", () => {
         FEATURE_HUB_ENABLED: "true",
       }),
     ).not.toThrow();
+  });
+});
+
+describe("hub-surface-guard · isHubSurfaceAvailableFromEnv", () => {
+  it("development: workstation surfaces available regardless of the flag", () => {
+    expect(isHubSurfaceAvailableFromEnv("workstation", { NODE_ENV: "development" })).toBe(true);
+    expect(
+      isHubSurfaceAvailableFromEnv("workstation", {
+        NODE_ENV: "development",
+        FEATURE_HUB_ENABLED: "false",
+      }),
+    ).toBe(true);
+  });
+
+  it("production + flag: operational true, workstation false — the probe's `workstation` source", () => {
+    const env = { NODE_ENV: "production", FEATURE_HUB_ENABLED: "true" };
+    expect(isHubSurfaceAvailableFromEnv("operational", env)).toBe(true);
+    expect(isHubSurfaceAvailableFromEnv("workstation", env)).toBe(false);
+  });
+
+  it("staging behaves like production for the workstation tier", () => {
+    expect(
+      isHubSurfaceAvailableFromEnv("workstation", {
+        NODE_ENV: "staging",
+        FEATURE_HUB_ENABLED: "true",
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
# feat(hub): hide workstation-tier pages from the Dev-Portal SPA outside development

Follow-up to #186 (opt-in hub outside development, squash `3c5bdd6`) — completes **open question 3**.

## Problem (verified on a live opted-in deployment)

With `FEATURE_HUB_ENABLED=true` in production the server gating from #186 is correct: every workstation-tier data endpoint 404s. But `GET /hub/portal-access.json` returned only `{hub, tenantAdmin, features}` — **no environment/tier signal** — so the SPA sidebar rendered ALL entries, including the workstation pages (Files, Migrations, Coverage, Tests, ERD, Emails, testers). Clicking them produced error/empty states; `/hub/files` 404s entirely. The SPA simply could not know.

## Approach — one policy, one signal, four consumers

### Snapshot extension (additive)

`buildHubPortalAccessSnapshot(...)` and `/hub/portal-access.json` gain

```jsonc
{ "hub": true, "tenantAdmin": true, "features": { … }, "workstation": false }
```

`workstation` is computed from the **same pure policy that gates the routes** — `isHubSurfaceAvailable({env, hubEnabled, tier: "workstation"})` via a new boolean twin of the surface guard, `isHubSurfaceAvailableFromEnv(tier)` (same request-time env read as `assertHubSurfaceAvailable`, so the SPA and the 404s can never drift apart). `true` exactly when workstation surfaces are servable, i.e. in development. Deliberately a **boolean, not the raw `NODE_ENV`** — it leaks nothing beyond what the 404s already prove.

**Backward compat:** the field is additive. The client treats an *absent* field as `true` (mirrors the `LEGACY_HUB_NAV_FEATURES_FALLBACK` pattern), so a new SPA bundle against an old server keeps today's behaviour, and old clients ignore the new field. `/hub/portal-access.json` has no response schema in the OpenAPI document → **no OpenAPI/SDK drift** (`dump:openapi --check` and `sdk:check` pass unchanged, see gates).

### Path classification in the shared planner

`hub-nav-planner.ts` (already the single source shared by client + server) gains `WORKSTATION_SPA_PATH_PREFIXES` + `isSpaPathWorkstationOnly(path)` — classifying pages by their **data** endpoints (the #186 tier table), not their page shells. Consumed by:

1. **Sidebar nav** — `AdminNavItem` gains `tier?: "workstation"`; `navSectionsForPortalAccess` drops tagged entries when the snapshot says `workstation: false` (and drops sections that would become empty; with all features on, none do).
2. **`HubPortalGate` deep links** — a bookmarked `/hub/migrations` on a deployed server now renders an honest "development-workstation tooling" screen (with a link back to `/hub` / `/admin/users`) instead of a page whose queries all 404.
3. **Landing-page quick links** — Permission Tester / Search Tester links vanish with the tier.
4. **Cmd+K palette** (server-side) — `/hub/palette/search.json` filters workstation pages with the same helper, so search can't resurrect hidden entries.

### Nav entries tagged `tier: "workstation"`

| Nav entry | Data endpoint(s) | #186 tier rationale |
|---|---|---|
| Coverage (`/hub/coverage`) | `coverage.json` | local test-run artifacts from the checkout |
| Tests (`/hub/tests`) | `tests.json` | local test-run artifacts from the checkout |
| Migrations (`/hub/migrations`) | `migrations.json` + writes | reads `prisma/migrations`, mutates schema |
| ERD (`/hub/erd`) | `erd.json` | reads `prisma/schema*.prisma` from the checkout |
| Emails (`/hub/emails`, incl. `/hub/email-builder`, `/hub/email-preview` routes) | `templates.json`, `blocks.json`, `preview.*`, … | renders template sources + writes overrides into `src/` |
| File Manager (`/hub/files`) | dev-files sidecars | `@Public` listings that sidestep per-subject CASL |
| Permission Tester (`/admin/permissions/test`) | `permissions/test.json` | x-test-ability companion tooling |
| Search Tester (`/admin/search`) | `search.json` | intentionally searches across ALL tenants |
| Prisma Studio (external link) | — | judgment call: `http://localhost:5555` is the developer's **own machine** — a dead link from any deployed portal. Tagged by hand (it has no SPA path); easy to untag if you disagree. |

Kept operational (unchanged): dashboard, Diagnostics, Features (READ), Brand (READ), Logs/Traces/Queries, Jobs/Cron, Email Outbox, API Reference, OpenAPI Spec, Routes, Error Codes, and all admin CRUD/inspector pages.

**Deliberate non-moves** (consistent with the #186 server classification): `/hub/json` (pure client-side paste-viewer, no data endpoint) and `/hub/postgrest-parse` (operational pure parser) stay visible — both are fully functional on a deployed server. The dashboard `TunnelCard` needs no gating: it only renders when the dev-runner reports an active tunnel, and `tunnel.json` is already workstation-gated server-side.

### Page-internal write controls (kept minimal per scope)

- **Features page**: the toggle switches render `disabled` when `workstation: false`, plus a short read-only note (the POST writes the workstation's `.env` — on a deployment you change the env vars instead). READ view untouched.
- **Brand page**: the "Reset to default" card is hidden entirely (it deletes a repo file — meaningless on a deployed server). READ view untouched.
- Plumbing: `AdminPortalLayout` now re-provides the gate's outlet context through its own `<Outlet>` — previously pages below it read `undefined`, so no page could see the snapshot.

That is the full write-control set that was trivially reachable via the snapshot; everything else stays nav-/gate-level as agreed.

## Development invariance (the #186 guarantee holds)

In development the snapshot says `workstation: true` **under every flag value** (locked with `FEATURE_HUB_ENABLED=false`, the strictest case), `navSectionsForPortalAccess` returns `NAV_SECTIONS` untouched, and the palette keeps all pages. Nothing about the local workflow changes.

## Test evidence (TDD, red-first)

Red commit first (`test(hub): red stories …`), implementation turns them green.

- `tests/stories/hub-outside-dev.story.test.ts` — production + flag on: probe reports `workstation:false` for the authorized operator **and** for the no-ability member (real Better-Auth path, no `x-test-ability`); palette omits `/hub/migrations`, keeps `/hub/logs`.
- `tests/stories/hub-outside-dev-development.story.test.ts` — development boot with the flag pinned `false`: probe reports `workstation:true`; palette keeps workstation pages.
- `tests/stories/hub-portal-access.story.test.ts` — pure snapshot builder carries the flag verbatim (both values).
- `tests/stories/hub-nav-filter.story.test.ts` — the tagged set equals the #186 workstation table exactly; `workstation:false` hides every tagged entry, keeps 24 operational entries, leaves no empty section; `workstation:true` ≡ `NAV_SECTIONS`.
- `tests/stories/hub-nav-planner.story.test.ts` — `isSpaPathWorkstationOnly` matrix (13 workstation / 16 operational paths) + cross-lock: nav tier tags ⇔ path classification (external links exempt).
- `tests/stories/dev-portal-pages.story.test.ts` — source-shape locks: tier tags in `nav.ts`, gate deep-link block, AdminShell wiring, outlet-context forwarding, FeaturesPage read-only switch, BrandPage reset hiding, quick-link + palette filters, client payload mirror. (The repo has no DOM test rig for the SPA — these locks follow the file's existing convention.)
- `tests/unit/hub-surface-policy.test.ts` — `isHubSurfaceAvailableFromEnv` matrix (dev/prod/staging × tiers).

## Gates

<!-- GATES-TO-FILL -->

## Docs

- `docs/hub/login.md` — probe step now names the `workstation` flag.
- `src/core/dx/clients/CLAUDE.md` — "Adding a new page" recipe covers when/how to tag a workstation page.

## Open questions

1. **Prisma Studio tag** — see table above; one line to revert.
2. `STATUS_HREF` chips on the landing dashboard still link `database → /hub/migrations`; outside development that now lands on the friendly gate screen. If preferred, the chip could point to `/hub/queries` on deployed servers — left out to keep this PR signal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
