### PR TITLE
fix(setup): probe real Postgres readiness in wait-postgres step

### DIFF
--- a/src/core/setup/setup-bootstrap-runner.ts
+++ b/src/core/setup/setup-bootstrap-runner.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { connect } from "node:net";
+
+import { Client } from "pg";
 
 import type { SetupBootstrapPlan, SetupBootstrapStep } from "./setup-bootstrap.js";
 
@@ -19,6 +20,24 @@ export interface ExecuteSetupBootstrapOptions {
 
 const DEFAULT_WAIT_MS = 60_000;
 const DEFAULT_PROBE_INTERVAL_MS = 500;
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000;
+
+export interface WaitForPostgresOptions {
+  /** Overall budget before giving up. */
+  timeoutMs?: number;
+  /** Delay between probe attempts. */
+  intervalMs?: number;
+  /**
+   * Single readiness attempt. Resolves `true` only when Postgres can
+   * actually serve a query. Injected in tests; defaults to a real
+   * connect + `SELECT 1` via `probePostgresReadyOnce`.
+   */
+  probe?: (databaseUrl: string) => Promise<boolean>;
+  /** Clock source (tests). */
+  now?: () => number;
+  /** Delay primitive (tests). */
+  sleep?: (ms: number) => Promise<void>;
+}
 
 export async function executeSetupBootstrap(
   options: ExecuteSetupBootstrapOptions,
@@ -40,7 +59,7 @@ export async function executeSetupBootstrap(
 
   const waitForPostgres =
     options.waitForPostgres ??
-    ((databaseUrl: string) => waitForPostgresTcp(databaseUrl, DEFAULT_WAIT_MS));
+    ((databaseUrl: string) => waitForPostgresReady(databaseUrl, { timeoutMs: DEFAULT_WAIT_MS }));
 
   for (const step of plan.steps) {
     logger.info(`${step.verb}: ${step.description}`);
@@ -68,27 +87,95 @@ export async function executeSetupBootstrap(
   return { ok: true };
 }
 
-function parseDatabaseUrlForProbe(url: string): { host: string; port: number } | null {
-  try {
-    const parsed = new URL(url);
-    const port = parsed.port ? Number(parsed.port) : 5432;
-    if (!Number.isFinite(port)) return null;
-    return { host: parsed.hostname, port };
-  } catch {
-    return null;
+/**
+ * Poll until Postgres can serve a query or the deadline passes.
+ *
+ * A bare TCP `connect()` is NOT enough: under docker-compose the port
+ * proxy accepts the TCP handshake the moment the container starts, long
+ * before PostgreSQL has finished initialising — so a TCP probe reports
+ * "ready" almost instantly and the next `migrate` step then fails with
+ * `P1001`. This probes at the query level instead, so "ready" means the
+ * server actually answered a `SELECT 1`.
+ */
+export async function waitForPostgresReady(
+  databaseUrl: string,
+  options: WaitForPostgresOptions = {},
+): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_WAIT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_PROBE_INTERVAL_MS;
+  const probe = options.probe ?? ((url: string) => probePostgresReadyOnce(url));
+  const now = options.now ?? Date.now;
+  const wait = options.sleep ?? sleep;
+
+  const deadline = now() + timeoutMs;
+  // Always try at least once; then keep polling until the deadline.
+  for (;;) {
+    if (await probe(databaseUrl)) return true;
+    if (now() >= deadline) return false;
+    await wait(intervalMs);
   }
 }
 
-async function waitForPostgresTcp(databaseUrl: string, timeoutMs: number): Promise<boolean> {
-  const target = parseDatabaseUrlForProbe(databaseUrl);
-  if (!target) return false;
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const ok = await probeTcpOnce(target.host, target.port);
-    if (ok) return true;
-    await sleep(DEFAULT_PROBE_INTERVAL_MS);
+/**
+ * One readiness attempt: open a real Postgres connection and run
+ * `SELECT 1`. Resolves `true` only if that round-trip succeeds; any
+ * failure (connection refused, socket accepted by a non-Postgres
+ * listener, server still starting up, auth/timeout) resolves `false`.
+ *
+ * Teardown is forced, not graceful: the exact case this probe defends
+ * against — a socket accepted by docker's port proxy while Postgres is
+ * still booting — leaves `pg`'s own timers and `end()` handshake with no
+ * responsive peer, so they can hang and leak the socket handle. A hard
+ * timeout bounds the attempt and the underlying stream is destroyed
+ * outright so a failed probe never keeps the loop (or the process) alive.
+ */
+export async function probePostgresReadyOnce(
+  databaseUrl: string,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  let client: Client | undefined;
+  try {
+    client = new Client({
+      connectionString: databaseUrl,
+      connectionTimeoutMillis: timeoutMs,
+      query_timeout: timeoutMs,
+    });
+    const activeClient = client;
+    const attempt = (async () => {
+      await activeClient.connect();
+      await activeClient.query("SELECT 1");
+    })();
+    // Avoid an unhandled rejection if the hard timeout wins the race.
+    attempt.catch(() => {});
+    await Promise.race([
+      attempt,
+      sleep(timeoutMs).then(() => {
+        throw new Error("postgres-readiness-probe-timeout");
+      }),
+    ]);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    forceCloseClient(client);
   }
-  return false;
+}
+
+/**
+ * Tear a probe client down without waiting on a graceful `end()`
+ * handshake (which needs a cooperative peer). Destroy the raw socket
+ * first, then fire `end()` and forget it.
+ */
+function forceCloseClient(client: Client | undefined): void {
+  if (!client) return;
+  const stream = (client as unknown as { connection?: { stream?: { destroy?: () => void } } })
+    .connection?.stream;
+  try {
+    stream?.destroy?.();
+  } catch {
+    /* already gone */
+  }
+  void client.end().catch(() => {});
 }
 
 function spawnCommand(command: string, args: string[], env: NodeJS.ProcessEnv): Promise<number> {
@@ -104,20 +191,4 @@ function spawnCommand(command: string, args: string[], env: NodeJS.ProcessEnv): 
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function probeTcpOnce(host: string, port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = connect({ host, port, timeout: 800 });
-    let settled = false;
-    const finish = (ok: boolean): void => {
-      if (settled) return;
-      settled = true;
-      socket.destroy();
-      resolve(ok);
-    };
-    socket.on("connect", () => finish(true));
-    socket.on("error", () => finish(false));
-    socket.on("timeout", () => finish(false));
-  });
 }

--- a/tests/stories/setup-wait-postgres-readiness.story.test.ts
+++ b/tests/stories/setup-wait-postgres-readiness.story.test.ts
@@ -1,6 +1,6 @@
-import { createServer, type Server } from "node:net";
+import { createServer, type Socket } from "node:net";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   probePostgresReadyOnce,
@@ -20,42 +20,60 @@ import {
  * The contract these tests pin: readiness means "Postgres can serve a
  * query", not "some process accepted a TCP connection".
  */
-describe("Story · setup wait-postgres readiness", () => {
-  let server: Server | undefined;
 
-  afterEach(async () => {
-    if (server) {
-      await new Promise<void>((resolve) => server!.close(() => resolve()));
-      server = undefined;
-    }
+/**
+ * Run `fn` against a TCP listener that accepts connections and then goes
+ * silent — exactly like docker's port proxy before Postgres is up. Server
+ * sockets are tracked and destroyed on teardown so `close()` can't block
+ * on the still-open probe connection.
+ */
+async function withSilentTcpListener<T>(fn: (port: number) => Promise<T>): Promise<T> {
+  const sockets = new Set<Socket>();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
   });
+  const port = await new Promise<number>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve(typeof address === "object" && address ? address.port : 0);
+    });
+  });
+  try {
+    return await fn(port);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
 
+describe("Story · setup wait-postgres readiness", () => {
   it("does NOT report ready for a raw TCP listener that never speaks Postgres", async () => {
     // Mirrors the docker-compose port proxy: accepts the TCP connection
     // and holds it open, but is not a Postgres server. A TCP-accept probe
     // would (wrongly) call this ready; the query-level probe must not.
-    server = createServer((socket) => {
-      // Hold the socket open, send nothing — exactly the failure mode.
-      socket.on("error", () => {});
-    });
-    const port = await new Promise<number>((resolve) => {
-      server!.listen(0, "127.0.0.1", () => {
-        const address = server!.address();
-        resolve(typeof address === "object" && address ? address.port : 0);
-      });
-    });
-
-    const url = `postgresql://probe:probe@127.0.0.1:${port}/probe`;
-    const ready = await probePostgresReadyOnce(url, 800);
+    const ready = await withSilentTcpListener((port) =>
+      probePostgresReadyOnce(`postgresql://probe:probe@127.0.0.1:${port}/probe`, 800),
+    );
     expect(ready).toBe(false);
-  }, 5000);
+  }, 10_000);
 
   it("reports not-ready for a refused connection (nothing listening)", async () => {
     // Port 1 on loopback: connection refused — the early-boot case before
     // the container's port is even mapped.
     const ready = await probePostgresReadyOnce("postgresql://u:p@127.0.0.1:1/db", 800);
     expect(ready).toBe(false);
-  }, 5000);
+  }, 10_000);
+
+  it("reports ready against a live Postgres that answers SELECT 1", async () => {
+    // global-setup boots a Postgres testcontainer and exposes its URL —
+    // the success path: a real query round-trip resolves `true`.
+    const url = process.env.DATABASE_URL;
+    if (!url) throw new Error("expected global-setup to provide DATABASE_URL");
+    const ready = await probePostgresReadyOnce(url, 5_000);
+    expect(ready).toBe(true);
+  }, 15_000);
 
   it("keeps retrying until the probe reports ready, not on the first not-ready", async () => {
     let calls = 0;

--- a/tests/stories/setup-wait-postgres-readiness.story.test.ts
+++ b/tests/stories/setup-wait-postgres-readiness.story.test.ts
@@ -1,0 +1,102 @@
+import { createServer, type Server } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  probePostgresReadyOnce,
+  waitForPostgresReady,
+} from "../../src/core/setup/setup-bootstrap-runner.js";
+
+/**
+ * Story · setup wait-postgres readiness
+ *
+ * Regression guard for the smoke-pipeline flake: the old `wait-postgres`
+ * step probed with a bare TCP `connect()`. Under docker-compose the port
+ * proxy accepts the TCP handshake the instant the container starts —
+ * long before PostgreSQL inside the postgis image has finished
+ * initialising — so the probe reported "ready" after ~11 ms and the
+ * next `migrate` step hit `P1001: Can't reach database server`.
+ *
+ * The contract these tests pin: readiness means "Postgres can serve a
+ * query", not "some process accepted a TCP connection".
+ */
+describe("Story · setup wait-postgres readiness", () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  it("does NOT report ready for a raw TCP listener that never speaks Postgres", async () => {
+    // Mirrors the docker-compose port proxy: accepts the TCP connection
+    // and holds it open, but is not a Postgres server. A TCP-accept probe
+    // would (wrongly) call this ready; the query-level probe must not.
+    server = createServer((socket) => {
+      // Hold the socket open, send nothing — exactly the failure mode.
+      socket.on("error", () => {});
+    });
+    const port = await new Promise<number>((resolve) => {
+      server!.listen(0, "127.0.0.1", () => {
+        const address = server!.address();
+        resolve(typeof address === "object" && address ? address.port : 0);
+      });
+    });
+
+    const url = `postgresql://probe:probe@127.0.0.1:${port}/probe`;
+    const ready = await probePostgresReadyOnce(url, 800);
+    expect(ready).toBe(false);
+  }, 5000);
+
+  it("reports not-ready for a refused connection (nothing listening)", async () => {
+    // Port 1 on loopback: connection refused — the early-boot case before
+    // the container's port is even mapped.
+    const ready = await probePostgresReadyOnce("postgresql://u:p@127.0.0.1:1/db", 800);
+    expect(ready).toBe(false);
+  }, 5000);
+
+  it("keeps retrying until the probe reports ready, not on the first not-ready", async () => {
+    let calls = 0;
+    const probe = async (): Promise<boolean> => {
+      calls += 1;
+      return calls >= 3; // not ready twice, then ready
+    };
+    let clock = 0;
+    const ready = await waitForPostgresReady("postgresql://u:p@127.0.0.1:5432/db", {
+      timeoutMs: 10_000,
+      intervalMs: 100,
+      probe,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+    });
+    expect(ready).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it("gives up and returns false once the deadline passes with no ready probe", async () => {
+    let calls = 0;
+    const probe = async (): Promise<boolean> => {
+      calls += 1;
+      return false; // never ready
+    };
+    let clock = 0;
+    const ready = await waitForPostgresReady("postgresql://u:p@127.0.0.1:5432/db", {
+      timeoutMs: 1_000,
+      intervalMs: 250,
+      probe,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+    });
+    expect(ready).toBe(false);
+    // At least one attempt, and it stopped at the deadline (not an
+    // infinite loop): 1000ms / 250ms interval → ~5 attempts.
+    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(calls).toBeLessThanOrEqual(6);
+  });
+});


### PR DESCRIPTION
## Problem

Der `Setup Smoke`-Job kippte nach dem Merge von #189 intermittierend (grün auf einem Lauf, rot auf dem nächsten — gleicher Commit). Ursache ist ein **vorbestehender Bug** im Bootstrap-Runner, nicht das Dependency-Update:

`wait-postgres` prüfte Readiness mit einem reinen TCP-`connect()` (`probeTcpOnce`). Unter docker-compose bindet der Port-Proxy den Host-Port aber **sofort** beim Container-Start — lange bevor PostgreSQL im postgis-Image fertig initialisiert ist. Der Probe meldete nach ~11 ms „ready", der folgende `migrate`-Schritt lief los und Prisma bekam `P1001: Can't reach database server`. Ob es klappte, hing reines Glück vom Init-Timing ab.

## Fix

TCP-Probe → **Query-Level-Readiness**:

- `probePostgresReadyOnce()` öffnet eine echte Verbindung und führt `SELECT 1` aus. „Ready" heißt jetzt: der Server kann tatsächlich Queries beantworten. Jeder Fehler (refused, Socket von Nicht-Postgres akzeptiert, Server im Startup, Auth/Timeout) → `false`.
- `waitForPostgresReady()` pollt den Probe bis ready oder Deadline.
- **Teardown ist erzwungen** (Hard-Timeout-Race + Socket-Destroy), damit ein Probe gegen einen akzeptierten-aber-stummen Socket — genau der Docker-Proxy-Fall — nicht hängt und kein Handle leakt.

## TDD

1. **RED** (`455ac21`): Story-Test nagelt den Vertrag fest — ein reiner TCP-Listener (wie der Docker-Proxy) darf **nicht** als ready gelten; die Retry-Schleife darf nicht beim ersten Nicht-Ready aufgeben.
2. **GREEN** (`0a46b25`): Implementierung + robuster Test (serverseitige Sockets werden getrackt & zerstört, damit `server.close()` deterministisch ist). 5 Tests decken beide Probe-Ausgänge (inkl. Live-DB-Erfolgspfad gegen den Testcontainer) und beide Loop-Ausgänge ab.

## Verifikation

- ✅ lint, format, test:types, test:unit (262), build
- ✅ neue Story-Tests: 5/5 grün, deterministisch (~0.8s)
- ✅ full test:e2e/coverage: alle relevanten Tests grün (ein fremder Outbox-Test flakte einmal unter lokaler Parallel-Last, isoliert grün — unabhängig von dieser Änderung)
- Diff berührt nur `src/core/setup/setup-bootstrap-runner.ts` + den Story-Test → OAS/SDK/RLS strukturell unberührt

Behebt die Flakiness des `Setup Smoke`-Workflows dauerhaft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)